### PR TITLE
chore(release): prepare v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to AutoMem will be documented in this file.
 
+## [0.9.3] - 2025-12-10
+
+### Fixed
+- **Critical**: Fixed missing `RECALL_EXPANSION_LIMIT` import that caused crashes when using expansion features
+
+### CI/CD
+- Added GitHub Actions CI workflow with tests on Python 3.10, 3.11, 3.12
+- Added pre-commit hooks for code quality enforcement
+  - Black formatting (100 char line length)
+  - isort import sorting
+  - Flake8 syntax checking
+  - Conventional commit validation
+  - Secret detection
+- Added release-please for automated versioning and releases
+
+### Style
+- Applied consistent formatting across entire codebase with Black and isort
+
 ## [0.9.2] - 2025-12-10
 
 ### Added


### PR DESCRIPTION
This pull request introduces several important improvements and fixes for the 0.9.3 release of AutoMem. The update addresses a critical bug, enhances the CI/CD pipeline, and enforces consistent code style throughout the codebase.

Bug fix:

* Fixed a critical issue by importing the missing `RECALL_EXPANSION_LIMIT`, which previously caused crashes when using expansion features.

CI/CD enhancements:

* Added a GitHub Actions CI workflow to test against Python 3.10, 3.11, and 3.12.
* Introduced pre-commit hooks for code quality, including Black formatting (100 char line length), isort import sorting, Flake8 syntax checking, conventional commit validation, and secret detection.
* Integrated release-please for automated versioning and releases.

Code style:

* Applied consistent formatting across the entire codebase using Black and isort.