### PR TITLE
chore(ci): make release-please manual

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,9 +21,8 @@
 name: Release Please
 
 on:
-    push:
-        branches:
-            - main
+    # Keep releases opt-in. This avoids surprise "release PR" churn on every push to main.
+    workflow_dispatch: {}
 
 permissions:
     contents: write


### PR DESCRIPTION
Stop running release-please on every push to main; keep it available via workflow_dispatch.