### PR TITLE
ci: run node tests for SSE bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,28 @@ jobs:
             - name: Run pre-commit
               uses: pre-commit/action@v3.0.1
 
+    node-test:
+        runs-on: ubuntu-latest
+        needs: pre-commit
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "20"
+                  cache: "npm"
+                  cache-dependency-path: mcp-sse-server/package-lock.json
+
+            - name: Install dependencies
+              working-directory: mcp-sse-server
+              run: npm ci
+
+            - name: Run tests
+              working-directory: mcp-sse-server
+              run: npm test
+
     test:
         runs-on: ubuntu-latest
         needs: pre-commit


### PR DESCRIPTION
Adds a dedicated GitHub Actions job that runs `npm ci && npm test` in `mcp-sse-server/`.\n\nNotes:\n- I also tightened the "Protect Main" ruleset to require this new `node-test` check and to require branches to be up-to-date with main before merging.