### PR TITLE
ci: add push trigger to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,8 @@
 name: Release Please
 
 on:
-    # Keep releases opt-in. This avoids surprise "release PR" churn on every push to main.
+    push:
+        branches: [main]
     workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
## Summary
- Adds `push` trigger to release-please workflow so it auto-updates on every merge to main
- Previously only ran on `workflow_dispatch`, causing PR #52 to go stale since Jan 21

## Context
PR #52 (release 0.10.0) has been stuck because release-please wasn't picking up new commits (2 feats, 1 fix since Jan 21).