### PR TITLE
fix: use max_completion_tokens for gpt-5 model family

### DIFF
--- a/app.py
+++ b/app.py
@@ -814,7 +814,7 @@ Return JSON with: {"type": "<type>", "confidence": <0.0-1.0>}"""
             if CLASSIFICATION_MODEL.startswith("o"):  # o-series (o1, o3, etc.)
                 token_param = {"max_completion_tokens": 50}
             elif CLASSIFICATION_MODEL.startswith("gpt-5"):  # gpt-5 family
-                token_param = {"max_output_tokens": 50}
+                token_param = {"max_completion_tokens": 50}
             else:  # gpt-4o-mini, gpt-4, etc.
                 token_param = {"max_tokens": 50}
             response = state.openai_client.chat.completions.create(

--- a/automem/utils/text.py
+++ b/automem/utils/text.py
@@ -151,7 +151,7 @@ def summarize_content(
         if model.startswith("o"):  # o-series (o1, o3, etc.)
             token_param = {"max_completion_tokens": token_limit}
         elif model.startswith("gpt-5"):  # gpt-5 family
-            token_param = {"max_output_tokens": token_limit}
+            token_param = {"max_completion_tokens": token_limit}
         else:  # gpt-4o-mini, gpt-4, etc.
             token_param = {"max_tokens": token_limit}
 


### PR DESCRIPTION
## Summary
- Fixes `LLM classification failed: Completions.create() got an unexpected keyword argument 'max_output_tokens'` errors in production
- `max_output_tokens` is an Anthropic parameter — OpenAI's SDK uses `max_completion_tokens` for gpt-5 models (same as o-series)
- Affects both `app.py` (classification) and `automem/utils/text.py` (summarization)

## Test plan
- [x] `pytest tests/test_app.py` — 15/15 passing
- [x] Deploy and verify classification works with `gpt-5-nano`