### PR TITLE
ci: use PAT for release-please to trigger CI on its PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,5 +40,4 @@ jobs:
               id: release
               with:
                   release-type: python
-                  # Optional: specify package name if different from repo
-                  # package-name: automem
+                  token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
## Summary
- PRs created by the default `GITHUB_TOKEN` don't trigger other workflows (GitHub's infinite loop prevention)
- This is why release-please PRs always show "Waiting for status to be reported" and CI never runs
- Using the org-wide `RELEASE_PLEASE_TOKEN` PAT so release-please PRs trigger CI automatically

## Test plan
- [ ] Merge a fix PR to main, verify the release-please PR gets CI checks triggered automatically