### PR TITLE
feat: enhanced recall — BM25 search, LLM reranking, query expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tests/benchmarks/locomo/
 node_modules/
 # Experiment results (promote notable runs to tests/benchmarks/results/)
 /tests/benchmarks/experiments/results_*/
+data/

--- a/app.py
+++ b/app.py
@@ -3100,6 +3100,7 @@ def recall_memories() -> Any:
         allowed_relations=ALLOWED_RELATIONS,
         relation_limit=RECALL_RELATION_LIMIT,
         expansion_limit_default=RECALL_EXPANSION_LIMIT,
+        get_openai_client=get_openai_client,
     )
 
     # Emit SSE event for real-time monitoring

--- a/app.py
+++ b/app.py
@@ -37,7 +37,12 @@ except ImportError:  # Allow tests to import without full qdrant client installe
     UnexpectedResponse = Exception  # type: ignore[misc,assignment]
 
 try:  # Allow tests to import without full qdrant client installed
-    from qdrant_client.models import Distance, PayloadSchemaType, PointStruct, VectorParams
+    from qdrant_client.models import (
+        Distance,
+        PayloadSchemaType,
+        PointStruct,
+        VectorParams,
+    )
 except Exception:  # pragma: no cover - degraded import path
     try:
         from qdrant_client.http import models as _qmodels
@@ -187,11 +192,16 @@ from automem.utils.time import (
     _parse_time_expression,
     utc_now,
 )
-from automem.utils.validation import get_effective_vector_size, validate_vector_dimensions
+from automem.utils.validation import (
+    get_effective_vector_size,
+    validate_vector_dimensions,
+)
 
 # Embedding batching configuration
 EMBEDDING_BATCH_SIZE = int(os.getenv("EMBEDDING_BATCH_SIZE", "20"))
-EMBEDDING_BATCH_TIMEOUT_SECONDS = float(os.getenv("EMBEDDING_BATCH_TIMEOUT_SECONDS", "2.0"))
+EMBEDDING_BATCH_TIMEOUT_SECONDS = float(
+    os.getenv("EMBEDDING_BATCH_TIMEOUT_SECONDS", "2.0")
+)
 
 """Note: default types/relations/weights are imported from automem.config"""
 
@@ -283,10 +293,14 @@ def _result_passes_filters(
                 if not tag_set:
                     return False
                 if normalized_mode == "all":
-                    if not all(filter_tag in tag_set for filter_tag in normalized_filters):
+                    if not all(
+                        filter_tag in tag_set for filter_tag in normalized_filters
+                    ):
                         return False
                 else:
-                    if not any(filter_tag in tag_set for filter_tag in normalized_filters):
+                    if not any(
+                        filter_tag in tag_set for filter_tag in normalized_filters
+                    ):
                         return False
             else:
                 prefixes = memory.get("tag_prefixes") or []
@@ -312,10 +326,16 @@ def _result_passes_filters(
 
                 if prefix_set:
                     if normalized_mode == "all":
-                        if not all(filter_tag in prefix_set for filter_tag in normalized_filters):
+                        if not all(
+                            filter_tag in prefix_set
+                            for filter_tag in normalized_filters
+                        ):
                             return False
                     else:
-                        if not any(filter_tag in prefix_set for filter_tag in normalized_filters):
+                        if not any(
+                            filter_tag in prefix_set
+                            for filter_tag in normalized_filters
+                        ):
                             return False
                 else:
                     if not _tags_start_with():
@@ -388,7 +408,10 @@ def _graph_trending_results(
     """Return high-importance memories when no specific query is supplied."""
     try:
         sort_param = (
-            ((request.args.get("sort") or request.args.get("order_by") or "score") or "")
+            (
+                (request.args.get("sort") or request.args.get("order_by") or "score")
+                or ""
+            )
             .strip()
             .lower()
         )
@@ -432,7 +455,9 @@ def _graph_trending_results(
             continue
         # Use importance as a pseudo-score for ordering consistency
         importance = record["memory"].get("importance")
-        record["score"] = float(importance) if isinstance(importance, (int, float)) else 0.0
+        record["score"] = (
+            float(importance) if isinstance(importance, (int, float)) else 0.0
+        )
         record["match_score"] = record["score"]
         trending.append(record)
 
@@ -834,13 +859,17 @@ Return JSON with: {"type": "<type>", "confidence": <0.0-1.0>}"""
             # Normalize type (handles aliases and case variations)
             memory_type, was_normalized = normalize_memory_type(raw_type)
             if not memory_type:
-                logger.warning("LLM returned unmappable type '%s', using Context", raw_type)
+                logger.warning(
+                    "LLM returned unmappable type '%s', using Context", raw_type
+                )
                 return "Context", 0.5
 
             if was_normalized and memory_type != raw_type:
                 logger.debug("LLM type normalized '%s' -> '%s'", raw_type, memory_type)
 
-            logger.info("LLM classified as %s (confidence: %.2f)", memory_type, confidence)
+            logger.info(
+                "LLM classified as %s (confidence: %.2f)", memory_type, confidence
+            )
             return memory_type, confidence
 
         except Exception as exc:
@@ -866,7 +895,9 @@ def _get_spacy_nlp():  # type: ignore[return-type]
 
         try:
             _SPACY_NLP = spacy.load(ENRICHMENT_SPACY_MODEL)
-            logger.info("Loaded spaCy model '%s' for enrichment", ENRICHMENT_SPACY_MODEL)
+            logger.info(
+                "Loaded spaCy model '%s' for enrichment", ENRICHMENT_SPACY_MODEL
+            )
         except Exception:  # pragma: no cover - optional dependency
             logger.warning("Failed to load spaCy model '%s'", ENRICHMENT_SPACY_MODEL)
             _SPACY_NLP = None
@@ -908,7 +939,22 @@ def _is_valid_entity(
         return False
 
     # Reject strings starting with markdown/formatting or code characters
-    if cleaned[0] in {"-", "*", "#", ">", "|", "[", "]", "{", "}", "(", ")", "_", "'", '"'}:
+    if cleaned[0] in {
+        "-",
+        "*",
+        "#",
+        ">",
+        "|",
+        "[",
+        "]",
+        "{",
+        "}",
+        "(",
+        ")",
+        "_",
+        "'",
+        '"',
+    }:
         return False
 
     # Reject common code artifacts (suffixes that indicate class names)
@@ -1019,14 +1065,18 @@ def extract_entities(content: str) -> Dict[str, List[str]]:
 
     # Extract project names from "project called/named 'X'" pattern
     for match in re.findall(
-        r'(?:project|repo|repository)\s+(?:called|named)\s+"([^"]+)"', text, re.IGNORECASE
+        r'(?:project|repo|repository)\s+(?:called|named)\s+"([^"]+)"',
+        text,
+        re.IGNORECASE,
     ):
         cleaned = match.strip()
         if _is_valid_entity(cleaned, allow_lower=False, max_words=4):
             result["projects"].add(cleaned)
 
     # Extract project names from 'project "X"' pattern
-    for match in re.findall(r'(?:project|repo|repository)\s+"([^"]+)"', text, re.IGNORECASE):
+    for match in re.findall(
+        r'(?:project|repo|repository)\s+"([^"]+)"', text, re.IGNORECASE
+    ):
         cleaned = match.strip()
         if _is_valid_entity(cleaned, allow_lower=False, max_words=4):
             result["projects"].add(cleaned)
@@ -1037,14 +1087,19 @@ def extract_entities(content: str) -> Dict[str, List[str]]:
             result["projects"].add(cleaned)
 
     # Extract project names from "project: project-name" pattern (common in session starts)
-    for match in re.findall(r"(?:in |on )?project:\s+([a-z][a-z0-9\-]+)", text, re.IGNORECASE):
+    for match in re.findall(
+        r"(?:in |on )?project:\s+([a-z][a-z0-9\-]+)", text, re.IGNORECASE
+    ):
         cleaned = match.strip()
         if _is_valid_entity(cleaned, allow_lower=True):
             result["projects"].add(cleaned)
 
     result["tools"].difference_update(result["people"])
 
-    cleaned = {key: sorted({value for value in values if value}) for key, values in result.items()}
+    cleaned = {
+        key: sorted({value for value in values if value})
+        for key, values in result.items()
+    }
     return cleaned
 
 
@@ -1097,7 +1152,9 @@ class ServiceState:
     openai_client: Optional[OpenAI] = (
         None  # Keep for backward compatibility (e.g., memory type classification)
     )
-    embedding_provider: Optional[EmbeddingProvider] = None  # New provider pattern for embeddings
+    embedding_provider: Optional[EmbeddingProvider] = (
+        None  # New provider pattern for embeddings
+    )
     enrichment_queue: Optional[Queue] = None
     enrichment_thread: Optional[Thread] = None
     enrichment_stats: EnrichmentStats = field(default_factory=EnrichmentStats)
@@ -1183,7 +1240,9 @@ def init_openai() -> None:
 
     # Check if OpenAI is available at all
     if OpenAI is None:
-        logger.info("OpenAI package not installed (used for memory type classification)")
+        logger.info(
+            "OpenAI package not installed (used for memory type classification)"
+        )
         return
 
     api_key = os.getenv("OPENAI_API_KEY")
@@ -1220,7 +1279,9 @@ def init_embedding_provider() -> None:
     if state.embedding_provider is not None:
         return
 
-    provider_config = (os.getenv("EMBEDDING_PROVIDER", "auto") or "auto").strip().lower()
+    provider_config = (
+        (os.getenv("EMBEDDING_PROVIDER", "auto") or "auto").strip().lower()
+    )
     # Use effective dimension (auto-detected from existing collection or config default).
     # If Qdrant hasn't set it (or config was changed in-process), align to VECTOR_SIZE.
     if state.qdrant is None and state.effective_vector_size != VECTOR_SIZE:
@@ -1239,7 +1300,9 @@ def init_embedding_provider() -> None:
             state.embedding_provider = VoyageEmbeddingProvider(
                 api_key=api_key, model=voyage_model, dimension=vector_size
             )
-            logger.info("Embedding provider: %s", state.embedding_provider.provider_name())
+            logger.info(
+                "Embedding provider: %s", state.embedding_provider.provider_name()
+            )
             return
         except Exception as e:
             raise RuntimeError(f"Failed to initialize Voyage provider: {e}") from e
@@ -1258,7 +1321,9 @@ def init_embedding_provider() -> None:
                 dimension=vector_size,
                 base_url=openai_base_url,
             )
-            logger.info("Embedding provider: %s", state.embedding_provider.provider_name())
+            logger.info(
+                "Embedding provider: %s", state.embedding_provider.provider_name()
+            )
             return
         except Exception as e:
             raise RuntimeError(f"Failed to initialize OpenAI provider: {e}") from e
@@ -1268,10 +1333,14 @@ def init_embedding_provider() -> None:
             from automem.embedding.fastembed import FastEmbedProvider
 
             state.embedding_provider = FastEmbedProvider(dimension=vector_size)
-            logger.info("Embedding provider: %s", state.embedding_provider.provider_name())
+            logger.info(
+                "Embedding provider: %s", state.embedding_provider.provider_name()
+            )
             return
         except Exception as e:
-            raise RuntimeError(f"Failed to initialize local fastembed provider: {e}") from e
+            raise RuntimeError(
+                f"Failed to initialize local fastembed provider: {e}"
+            ) from e
 
     elif provider_config == "ollama":
         base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
@@ -1280,7 +1349,9 @@ def init_embedding_provider() -> None:
             timeout = float(os.getenv("OLLAMA_TIMEOUT", "30"))
             max_retries = int(os.getenv("OLLAMA_MAX_RETRIES", "2"))
         except ValueError as ve:
-            raise RuntimeError(f"Invalid OLLAMA_TIMEOUT or OLLAMA_MAX_RETRIES value: {ve}") from ve
+            raise RuntimeError(
+                f"Invalid OLLAMA_TIMEOUT or OLLAMA_MAX_RETRIES value: {ve}"
+            ) from ve
         try:
             from automem.embedding.ollama import OllamaEmbeddingProvider
 
@@ -1291,7 +1362,9 @@ def init_embedding_provider() -> None:
                 timeout=timeout,
                 max_retries=max_retries,
             )
-            logger.info("Embedding provider: %s", state.embedding_provider.provider_name())
+            logger.info(
+                "Embedding provider: %s", state.embedding_provider.provider_name()
+            )
             return
         except Exception as e:
             raise RuntimeError(f"Failed to initialize Ollama provider: {e}") from e
@@ -1321,7 +1394,9 @@ def init_embedding_provider() -> None:
                 )
                 return
             except Exception as e:
-                logger.warning("Failed to initialize Voyage provider, trying OpenAI: %s", str(e))
+                logger.warning(
+                    "Failed to initialize Voyage provider, trying OpenAI: %s", str(e)
+                )
 
         # Try OpenAI
         api_key = os.getenv("OPENAI_API_KEY")
@@ -1343,7 +1418,8 @@ def init_embedding_provider() -> None:
                 return
             except Exception as e:
                 logger.warning(
-                    "Failed to initialize OpenAI provider, trying local model: %s", str(e)
+                    "Failed to initialize OpenAI provider, trying local model: %s",
+                    str(e),
                 )
 
         ollama_base_url = os.getenv("OLLAMA_BASE_URL")
@@ -1358,7 +1434,9 @@ def init_embedding_provider() -> None:
                     timeout = float(os.getenv("OLLAMA_TIMEOUT", "30"))
                     max_retries = int(os.getenv("OLLAMA_MAX_RETRIES", "2"))
                 except ValueError:
-                    logger.warning("Invalid OLLAMA_TIMEOUT or OLLAMA_MAX_RETRIES, using defaults")
+                    logger.warning(
+                        "Invalid OLLAMA_TIMEOUT or OLLAMA_MAX_RETRIES, using defaults"
+                    )
                     timeout = 30.0
                     max_retries = 2
                 state.embedding_provider = OllamaEmbeddingProvider(
@@ -1375,7 +1453,8 @@ def init_embedding_provider() -> None:
                 return
             except Exception as e:
                 logger.warning(
-                    "Failed to initialize Ollama provider, trying local model: %s", str(e)
+                    "Failed to initialize Ollama provider, trying local model: %s",
+                    str(e),
                 )
 
         # Try local fastembed
@@ -1384,11 +1463,14 @@ def init_embedding_provider() -> None:
 
             state.embedding_provider = FastEmbedProvider(dimension=vector_size)
             logger.info(
-                "Embedding provider (auto-selected): %s", state.embedding_provider.provider_name()
+                "Embedding provider (auto-selected): %s",
+                state.embedding_provider.provider_name(),
             )
             return
         except Exception as e:
-            logger.warning("Failed to initialize fastembed provider, using placeholder: %s", str(e))
+            logger.warning(
+                "Failed to initialize fastembed provider, using placeholder: %s", str(e)
+            )
 
         # Fallback to placeholder
         from automem.embedding.placeholder import PlaceholderEmbeddingProvider
@@ -1399,7 +1481,8 @@ def init_embedding_provider() -> None:
             "Install fastembed or set VOYAGE_API_KEY/OPENAI_API_KEY for semantic embeddings."
         )
         logger.info(
-            "Embedding provider (auto-selected): %s", state.embedding_provider.provider_name()
+            "Embedding provider (auto-selected): %s",
+            state.embedding_provider.provider_name(),
         )
         return
 
@@ -1438,7 +1521,8 @@ def init_falkordb() -> None:
         state.falkordb = FalkorDB(**connection_params)
         state.memory_graph = state.falkordb.select_graph(GRAPH_NAME)
         logger.info(
-            "FalkorDB connection established (auth: %s)", "enabled" if password else "disabled"
+            "FalkorDB connection established (auth: %s)",
+            "enabled" if password else "disabled",
         )
     except Exception:  # pragma: no cover - log full stack trace in production
         logger.exception("Failed to initialize FalkorDB connection")
@@ -1496,15 +1580,21 @@ def _ensure_qdrant_collection() -> None:
         existing = {collection.name for collection in collections.collections}
         if COLLECTION_NAME not in existing:
             logger.info(
-                "Creating Qdrant collection '%s' with %dd vectors", COLLECTION_NAME, effective_dim
+                "Creating Qdrant collection '%s' with %dd vectors",
+                COLLECTION_NAME,
+                effective_dim,
             )
             state.qdrant.create_collection(
                 collection_name=COLLECTION_NAME,
-                vectors_config=VectorParams(size=effective_dim, distance=Distance.COSINE),
+                vectors_config=VectorParams(
+                    size=effective_dim, distance=Distance.COSINE
+                ),
             )
 
         # Ensure payload indexes exist for tag filtering
-        logger.info("Ensuring Qdrant payload indexes for collection '%s'", COLLECTION_NAME)
+        logger.info(
+            "Ensuring Qdrant payload indexes for collection '%s'", COLLECTION_NAME
+        )
         if PayloadSchemaType:
             # Use enum if available
             state.qdrant.create_payload_index(
@@ -1558,7 +1648,9 @@ def init_enrichment_pipeline() -> None:
     logger.info("Enrichment pipeline initialized")
 
 
-def enqueue_enrichment(memory_id: str, *, forced: bool = False, attempt: int = 0) -> None:
+def enqueue_enrichment(
+    memory_id: str, *, forced: bool = False, attempt: int = 0
+) -> None:
     if not memory_id or state.enrichment_queue is None:
         return
 
@@ -1566,7 +1658,8 @@ def enqueue_enrichment(memory_id: str, *, forced: bool = False, attempt: int = 0
 
     with state.enrichment_lock:
         if not forced and (
-            memory_id in state.enrichment_pending or memory_id in state.enrichment_inflight
+            memory_id in state.enrichment_pending
+            or memory_id in state.enrichment_inflight
         ):
             return
 
@@ -1769,7 +1862,9 @@ def _build_scheduler_from_graph(graph: Any) -> Optional[ConsolidationScheduler]:
     return scheduler
 
 
-def _build_consolidator_from_config(graph: Any, vector_store: Any) -> MemoryConsolidator:
+def _build_consolidator_from_config(
+    graph: Any, vector_store: Any
+) -> MemoryConsolidator:
     return MemoryConsolidator(
         graph,
         vector_store,
@@ -1904,7 +1999,9 @@ def enrichment_worker() -> None:
                     utc_now,
                 )
                 if not processed:
-                    logger.debug("Enrichment skipped for %s (already processed)", job.memory_id)
+                    logger.debug(
+                        "Enrichment skipped for %s (already processed)", job.memory_id
+                    )
             except Exception as exc:  # pragma: no cover - background thread
                 state.enrichment_stats.record_failure(str(exc))
                 elapsed_ms = int((time.perf_counter() - enrich_start) * 1000)
@@ -1922,7 +2019,9 @@ def enrichment_worker() -> None:
                 logger.exception("Failed to enrich memory %s", job.memory_id)
                 if job.attempt + 1 < ENRICHMENT_MAX_ATTEMPTS:
                     time.sleep(ENRICHMENT_FAILURE_BACKOFF_SECONDS)
-                    enqueue_enrichment(job.memory_id, forced=job.forced, attempt=job.attempt + 1)
+                    enqueue_enrichment(
+                        job.memory_id, forced=job.forced, attempt=job.attempt + 1
+                    )
                 else:
                     logger.error(
                         "Giving up on enrichment for %s after %s attempts",
@@ -1955,7 +2054,10 @@ def enqueue_embedding(memory_id: str, content: str) -> None:
         return
 
     with state.embedding_lock:
-        if memory_id in state.embedding_pending or memory_id in state.embedding_inflight:
+        if (
+            memory_id in state.embedding_pending
+            or memory_id in state.embedding_inflight
+        ):
             return
 
         state.embedding_pending.add(memory_id)
@@ -2045,7 +2147,9 @@ def _process_embedding_batch(batch: List[Tuple[str, str]]) -> None:
             state.embedding_queue.task_done()
 
 
-def _store_embedding_in_qdrant(memory_id: str, content: str, embedding: List[float]) -> None:
+def _store_embedding_in_qdrant(
+    memory_id: str, content: str, embedding: List[float]
+) -> None:
     """Store a pre-generated embedding in Qdrant with memory metadata."""
     qdrant_client = get_qdrant_client()
     if qdrant_client is None:
@@ -2058,7 +2162,9 @@ def _store_embedding_in_qdrant(memory_id: str, content: str, embedding: List[flo
     # Fetch latest memory data from FalkorDB for payload
     result = graph.query("MATCH (m:Memory {id: $id}) RETURN m", {"id": memory_id})
     if not getattr(result, "result_set", None):
-        logger.warning("Memory %s not found in FalkorDB, skipping Qdrant update", memory_id)
+        logger.warning(
+            "Memory %s not found in FalkorDB, skipping Qdrant update", memory_id
+        )
         return
 
     node = result.result_set[0][0]
@@ -2279,7 +2385,8 @@ def enrich_memory(memory_id: str, *, forced: bool = False) -> bool:
             "temporal_links": temporal_links,
             "patterns_detected": pattern_info,
             "semantic_neighbors": [
-                {"id": neighbour_id, "score": score} for neighbour_id, score in semantic_neighbors
+                {"id": neighbour_id, "score": score}
+                for neighbour_id, score in semantic_neighbors
             ],
         }
     )
@@ -2324,12 +2431,17 @@ def enrich_memory(memory_id: str, *, forced: bool = False) -> bool:
             # 404 means embedding upload hasn't completed yet (race condition)
             if exc.status_code == 404:
                 logger.debug(
-                    "Qdrant payload sync skipped - point not yet uploaded: %s", memory_id[:8]
+                    "Qdrant payload sync skipped - point not yet uploaded: %s",
+                    memory_id[:8],
                 )
             else:
-                logger.warning("Qdrant payload sync failed (%d): %s", exc.status_code, memory_id)
+                logger.warning(
+                    "Qdrant payload sync failed (%d): %s", exc.status_code, memory_id
+                )
         except Exception:
-            logger.exception("Failed to sync Qdrant payload for enriched memory %s", memory_id)
+            logger.exception(
+                "Failed to sync Qdrant payload for enriched memory %s", memory_id
+            )
 
     logger.debug(
         "Enriched memory %s (temporal=%s, patterns=%s, semantic=%s)",
@@ -2422,8 +2534,9 @@ def detect_patterns(graph: Any, memory_id: str, content: str) -> List[Dict[str, 
 
             top_terms = [term for term, _ in tokens.most_common(5)]
             pattern_id = f"pattern-{memory_type}-{uuid.uuid4().hex[:8]}"
-            description = f"Pattern across {similar_count + 1} {memory_type} memories" + (
-                f" highlighting {', '.join(top_terms)}" if top_terms else ""
+            description = (
+                f"Pattern across {similar_count + 1} {memory_type} memories"
+                + (f" highlighting {', '.join(top_terms)}" if top_terms else "")
             )
 
             graph.query(
@@ -2862,7 +2975,9 @@ def update_memory(memory_id: str) -> Any:
     memory_type = payload.get("type", current.get("type"))
     confidence = payload.get("confidence", current.get("confidence"))
     timestamp = payload.get("timestamp", current.get("timestamp"))
-    metadata_raw = payload.get("metadata", _parse_metadata_field(current.get("metadata")))
+    metadata_raw = payload.get(
+        "metadata", _parse_metadata_field(current.get("metadata"))
+    )
     updated_at = payload.get("updated_at", current.get("updated_at", utc_now()))
     last_accessed = payload.get("last_accessed", current.get("last_accessed"))
 
@@ -2982,7 +3097,9 @@ def delete_memory(memory_id: str) -> Any:
                 selector = qdrant_models.PointIdsList(points=[memory_id])
             else:
                 selector = {"points": [memory_id]}
-            qdrant_client.delete(collection_name=COLLECTION_NAME, points_selector=selector)
+            qdrant_client.delete(
+                collection_name=COLLECTION_NAME, points_selector=selector
+            )
         except Exception:
             logger.exception("Failed to delete vector for memory %s", memory_id)
 
@@ -3028,7 +3145,12 @@ def memories_by_tag() -> Any:
         memories.append(data)
 
     return jsonify(
-        {"status": "success", "tags": tags, "count": len(memories), "memories": memories}
+        {
+            "status": "success",
+            "tags": tags,
+            "count": len(memories),
+            "memories": memories,
+        }
     )
 
 
@@ -3146,7 +3268,9 @@ def create_association() -> Any:
     if memory1_id == memory2_id:
         abort(400, description="Cannot associate a memory with itself")
     if relation_type not in ALLOWED_RELATIONS:
-        abort(400, description=f"Relation type must be one of {sorted(ALLOWED_RELATIONS)}")
+        abort(
+            400, description=f"Relation type must be one of {sorted(ALLOWED_RELATIONS)}"
+        )
 
     graph = get_memory_graph()
     if graph is None:
@@ -3255,7 +3379,8 @@ def consolidation_status() -> Any:
                     "next_runs": next_runs,
                     "history": history,
                     "thread_alive": bool(
-                        state.consolidation_thread and state.consolidation_thread.is_alive()
+                        state.consolidation_thread
+                        and state.consolidation_thread.is_alive()
                     ),
                     "tick_seconds": CONSOLIDATION_TICK_SECONDS,
                 }
@@ -3353,14 +3478,12 @@ def analyze_memories() -> Any:
 
     try:
         # Analyze memory type distribution
-        type_result = graph.query(
-            """
+        type_result = graph.query("""
             MATCH (m:Memory)
             WHERE m.type IS NOT NULL
             RETURN m.type, COUNT(m) as count, AVG(m.confidence) as avg_confidence
             ORDER BY count DESC
-            """
-        )
+            """)
 
         for mem_type, count, avg_conf in type_result.result_set:
             analytics["memory_types"][mem_type] = {
@@ -3369,15 +3492,13 @@ def analyze_memories() -> Any:
             }
 
         # Find patterns with high confidence
-        pattern_result = graph.query(
-            """
+        pattern_result = graph.query("""
             MATCH (p:Pattern)
             WHERE p.confidence > 0.6
             RETURN p.type, p.content, p.confidence, p.observations
             ORDER BY p.confidence DESC
             LIMIT 10
-            """
-        )
+            """)
 
         for p_type, content, confidence, observations in pattern_result.result_set:
             analytics["patterns"].append(
@@ -3390,14 +3511,12 @@ def analyze_memories() -> Any:
             )
 
         # Find preferences (PREFERS_OVER relationships)
-        pref_result = graph.query(
-            """
+        pref_result = graph.query("""
             MATCH (m1:Memory)-[r:PREFERS_OVER]->(m2:Memory)
             RETURN m1.content, m2.content, r.context, r.strength
             ORDER BY r.strength DESC
             LIMIT 10
-            """
-        )
+            """)
 
         for preferred, over, context, strength in pref_result.result_set:
             analytics["preferences"].append(
@@ -3411,14 +3530,12 @@ def analyze_memories() -> Any:
 
         # Temporal insights - simplified for FalkorDB compatibility
         try:
-            temporal_result = graph.query(
-                """
+            temporal_result = graph.query("""
                 MATCH (m:Memory)
                 WHERE m.timestamp IS NOT NULL
                 RETURN m.timestamp, m.importance
                 LIMIT 100
-                """
-            )
+                """)
 
             # Process temporal data in Python
             from collections import defaultdict
@@ -3439,15 +3556,16 @@ def analyze_memories() -> Any:
                 if data["count"] > 0:
                     analytics["temporal_insights"][f"hour_{hour:02d}"] = {
                         "count": data["count"],
-                        "avg_importance": round(data["total_importance"] / data["count"], 3),
+                        "avg_importance": round(
+                            data["total_importance"] / data["count"], 3
+                        ),
                     }
         except Exception:
             # Skip temporal insights if query fails
             pass
 
         # Confidence distribution
-        conf_result = graph.query(
-            """
+        conf_result = graph.query("""
             MATCH (m:Memory)
             WHERE m.confidence IS NOT NULL
             RETURN
@@ -3457,21 +3575,18 @@ def analyze_memories() -> Any:
                     ELSE 'high'
                 END as level,
                 COUNT(m) as count
-            """
-        )
+            """)
 
         for level, count in conf_result.result_set:
             analytics["confidence_distribution"][level] = count
 
         # Entity extraction insights (top mentioned tools/projects)
-        entity_result = graph.query(
-            """
+        entity_result = graph.query("""
             MATCH (m:Memory)
             WHERE m.content IS NOT NULL
             RETURN m.content
             LIMIT 100
-            """
-        )
+            """)
 
         entity_counts: Dict[str, Dict[str, int]] = {
             "tools": {},
@@ -3483,7 +3598,9 @@ def analyze_memories() -> Any:
             for tool in entities.get("tools", []):
                 entity_counts["tools"][tool] = entity_counts["tools"].get(tool, 0) + 1
             for project in entities.get("projects", []):
-                entity_counts["projects"][project] = entity_counts["projects"].get(project, 0) + 1
+                entity_counts["projects"][project] = (
+                    entity_counts["projects"].get(project, 0) + 1
+                )
 
         # Top 5 most mentioned
         analytics["entity_frequency"]["tools"] = sorted(
@@ -3538,7 +3655,9 @@ def _coerce_embedding(value: Any) -> Optional[List[float]]:
     elif isinstance(value, str):
         vector = [part.strip() for part in value.split(",") if part.strip()]
     else:
-        raise ValueError("Embedding must be a list of floats or a comma-separated string")
+        raise ValueError(
+            "Embedding must be a list of floats or a comma-separated string"
+        )
 
     # Use effective dimension (auto-detected or config)
     expected_dim = state.effective_vector_size
@@ -3593,7 +3712,9 @@ def _generate_real_embeddings_batch(contents: List[str]) -> List[List[float]]:
         return []
 
     if state.embedding_provider is None:
-        logger.debug("No embedding provider available, falling back to placeholder embeddings")
+        logger.debug(
+            "No embedding provider available, falling back to placeholder embeddings"
+        )
         return [_generate_placeholder_embedding(c) for c in contents]
 
     expected_dim = state.effective_vector_size
@@ -3602,7 +3723,11 @@ def _generate_real_embeddings_batch(contents: List[str]) -> List[List[float]]:
         if not embeddings or any(len(e) != expected_dim for e in embeddings):
             logger.warning(
                 "Provider %s returned invalid dims in batch; using placeholders",
-                state.embedding_provider.provider_name() if state.embedding_provider else "unknown",
+                (
+                    state.embedding_provider.provider_name()
+                    if state.embedding_provider
+                    else "unknown"
+                ),
             )
             return [_generate_placeholder_embedding(c) for c in contents]
         return embeddings
@@ -3654,7 +3779,9 @@ def get_related_memories(memory_id: str) -> Any:
     # Parse and sanitize relationship types
     rel_types_param = (request.args.get("relationship_types") or "").strip()
     if rel_types_param:
-        requested = [part.strip().upper() for part in rel_types_param.split(",") if part.strip()]
+        requested = [
+            part.strip().upper() for part in rel_types_param.split(",") if part.strip()
+        ]
         rel_types = [t for t in requested if t in ALLOWED_RELATIONS]
         if not rel_types:
             rel_types = sorted(ALLOWED_RELATIONS)

--- a/automem/api/health.py
+++ b/automem/api/health.py
@@ -87,6 +87,17 @@ def create_health_blueprint(
             "timestamp": utc_now(),
             "graph": graph_name,
         }
+
+        # BM25 status
+        try:
+            from automem.search.bm25 import BM25_ENABLED, get_index_count
+            health_data["bm25"] = {
+                "enabled": BM25_ENABLED,
+                "indexed": get_index_count() if BM25_ENABLED else 0,
+            }
+        except Exception:
+            health_data["bm25"] = {"enabled": False, "error": "import_failed"}
+
         return jsonify(health_data)
 
     return bp

--- a/automem/api/health.py
+++ b/automem/api/health.py
@@ -78,7 +78,9 @@ def create_health_blueprint(
             "sync_status": sync_status,
             "enrichment": {
                 "status": "running" if enrichment_thread_alive else "stopped",
-                "queue_depth": state.enrichment_queue.qsize() if state.enrichment_queue else 0,
+                "queue_depth": (
+                    state.enrichment_queue.qsize() if state.enrichment_queue else 0
+                ),
                 "pending": enrichment_pending,
                 "inflight": enrichment_inflight,
                 "processed": state.enrichment_stats.successes,
@@ -91,6 +93,7 @@ def create_health_blueprint(
         # BM25 status
         try:
             from automem.search.bm25 import BM25_ENABLED, get_index_count
+
             health_data["bm25"] = {
                 "enabled": BM25_ENABLED,
                 "indexed": get_index_count() if BM25_ENABLED else 0,

--- a/automem/api/memory.py
+++ b/automem/api/memory.py
@@ -529,6 +529,16 @@ def create_memory_blueprint_full(
             except Exception:
                 logger.exception("Failed to delete vector for memory %s", memory_id)
 
+        # Remove from BM25 index
+        try:
+            from automem.search.bm25 import remove_memory as bm25_remove
+
+            bm25_remove(memory_id)
+        except Exception:
+            logger.exception(
+                "Failed to remove memory %s from BM25 index", memory_id
+            )
+
         return jsonify({"status": "success", "memory_id": memory_id})
 
     @bp.route("/memory/by-tag", methods=["GET"])

--- a/automem/api/recall.py
+++ b/automem/api/recall.py
@@ -967,6 +967,7 @@ def handle_recall(
     relation_limit: Optional[int] = None,
     expansion_limit_default: Optional[int] = None,
     on_access: Optional[Callable[[List[str]], None]] = None,
+    get_openai_client: Optional[Callable[[], Any]] = None,
 ):
     query_start = time.perf_counter()
     query_text = (request.args.get("query") or "").strip()
@@ -1166,22 +1167,71 @@ def handle_recall(
                         res, start_time, end_time, tag_filters, tag_mode, tag_match, exclude_tags
                     )
                 ]
-        local_results.extend(vector_matches[:per_query_limit])
 
-        remaining_slots = max(0, per_query_limit - len(local_results))
-        if remaining_slots and graph is not None:
+        graph_matches: List[Dict[str, Any]] = []
+        if graph is not None:
+            # Use a separate seen set so graph search isn't blocked by vector results
+            graph_seen: set[str] = set()
             graph_matches = graph_keyword_search(
                 graph,
                 query_str,
-                remaining_slots,
-                local_seen,
+                per_query_limit,
+                graph_seen,
                 start_time=start_time,
                 end_time=end_time,
                 tag_filters=tag_filters,
                 tag_mode=tag_mode,
                 tag_match=tag_match,
             )
-            local_results.extend(graph_matches[:remaining_slots])
+
+        # BM25 full-text search (complements vector + graph keyword)
+        bm25_matches: List[Dict[str, Any]] = []
+        try:
+            from automem.search.bm25 import search as bm25_search, BM25_ENABLED, fuse_rrf
+            if BM25_ENABLED and query_str:
+                bm25_seen: set[str] = set()
+                bm25_matches = bm25_search(
+                    query_str,
+                    limit=per_query_limit,
+                    seen_ids=bm25_seen,
+                    tag_filters=tag_filters,
+                )
+                if start_time or end_time or exclude_tags:
+                    bm25_matches = [
+                        res for res in bm25_matches
+                        if result_passes_filters(
+                            res, start_time, end_time, tag_filters, tag_mode, tag_match, exclude_tags
+                        )
+                    ]
+        except ImportError:
+            pass
+        except Exception:
+            import logging as _logging
+            _logging.getLogger(__name__).debug("BM25 recall search failed", exc_info=True)
+
+        # Fuse all sources via RRF if BM25 is active, otherwise fall back to sequential merge
+        if bm25_matches:
+            try:
+                from automem.search.bm25 import fuse_rrf
+                local_results = fuse_rrf(
+                    vector_matches[:per_query_limit],
+                    graph_matches[:per_query_limit],
+                    bm25_matches[:per_query_limit],
+                )[:per_query_limit]
+                # Update local_seen with all IDs from fused results
+                for r in local_results:
+                    mid = r.get("memory_id") or r.get("id") or ""
+                    if mid:
+                        local_seen.add(mid)
+            except Exception:
+                # Fall back to sequential merge
+                local_results.extend(vector_matches[:per_query_limit])
+                remaining = max(0, per_query_limit - len(local_results))
+                local_results.extend(graph_matches[:remaining])
+        else:
+            local_results.extend(vector_matches[:per_query_limit])
+            remaining = max(0, per_query_limit - len(local_results))
+            local_results.extend(graph_matches[:remaining])
 
         tags_only_request = (
             not query_str
@@ -1294,13 +1344,34 @@ def handle_recall(
             for topic in topics[:3]:
                 decomposed_queries.append(topic)
 
-    is_multi = bool(multi_queries) or bool(decomposed_queries)
+    # LLM query expansion — generate alternative phrasings before searching
+    expanded_queries: List[str] = []
+    expand_enabled_param = _parse_bool_param(
+        request.args.get("expand_query") or request.args.get("query_expansion"),
+        True,  # Enabled by default
+    )
+    if expand_enabled_param and query_text and not multi_queries and query_text != "*":
+        try:
+            from automem.search.query_expand import expand_query as llm_expand, EXPAND_ENABLED
+            if EXPAND_ENABLED:
+                expanded_queries = llm_expand(query_text, get_openai_client() if get_openai_client else None)
+                if expanded_queries:
+                    logger.info("Query expansion: %r → %s", query_text[:50], expanded_queries)
+        except ImportError:
+            pass
+        except Exception:
+            logger.debug("Query expansion failed", exc_info=True)
+
+    is_multi = bool(multi_queries) or bool(decomposed_queries) or bool(expanded_queries)
     queries_to_run: List[str] = [q for q in multi_queries if q]
 
     # Add decomposed queries if auto_decompose is enabled
     if decomposed_queries:
         # Original query first, then decomposed variations
         queries_to_run = [query_text] + decomposed_queries
+    elif expanded_queries:
+        # Original query first, then LLM-expanded alternatives
+        queries_to_run = [query_text] + expanded_queries
     elif not queries_to_run and query_text:
         queries_to_run = [query_text]
     if not queries_to_run:
@@ -1411,6 +1482,18 @@ def handle_recall(
             ]
         results = seed_results + expansion_results + entity_expansion_results
 
+    # LLM reranking — final pass to score actual relevance
+    try:
+        from automem.search.rerank import rerank as llm_rerank, RERANK_ENABLED
+        if RERANK_ENABLED and query_text and results:
+            # Pass main client if available; reranker also has its own dedicated client
+            openai_client = get_openai_client() if get_openai_client is not None else None
+            results = llm_rerank(query_text, results, openai_client)
+    except ImportError:
+        pass
+    except Exception:
+        logger.debug("LLM rerank skipped", exc_info=True)
+
     response = {
         "status": "success",
         "query": query_text,
@@ -1439,6 +1522,23 @@ def handle_recall(
                 _extract_entities_from_results(seed_results + expansion_results)
             )[:10],
         }
+    # Report rerank status
+    try:
+        from automem.search.rerank import RERANK_ENABLED
+        response["rerank"] = {"enabled": RERANK_ENABLED}
+    except ImportError:
+        pass
+
+    # Report query expansion status
+    try:
+        from automem.search.query_expand import EXPAND_ENABLED
+        response["query_expansion"] = {
+            "enabled": EXPAND_ENABLED,
+            "alternatives": expanded_queries if expanded_queries else [],
+        }
+    except ImportError:
+        pass
+
     if is_multi:
         response["queries"] = queries_to_run
     if query_text and not is_multi:

--- a/automem/api/recall.py
+++ b/automem/api/recall.py
@@ -8,7 +8,11 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from flask import Blueprint, abort, jsonify, request
 
-from automem.config import ALLOWED_RELATIONS, RECALL_EXPANSION_LIMIT, RECALL_RELATION_LIMIT
+from automem.config import (
+    ALLOWED_RELATIONS,
+    RECALL_EXPANSION_LIMIT,
+    RECALL_RELATION_LIMIT,
+)
 from automem.utils.graph import _serialize_node
 
 DEFAULT_STYLE_PRIORITY_TAGS: Set[str] = {
@@ -168,7 +172,9 @@ def _extract_query_entities(query: str) -> List[str]:
     return list(set(entities))
 
 
-def _extract_topic_keywords(query: str, exclude_entities: Optional[List[str]] = None) -> List[str]:
+def _extract_topic_keywords(
+    query: str, exclude_entities: Optional[List[str]] = None
+) -> List[str]:
     """
     Extract meaningful topic keywords from a query.
 
@@ -451,9 +457,15 @@ def _build_context_profile(
     context_label: str,
     query_text: str,
 ) -> Optional[Dict[str, Any]]:
-    priority_tags: Set[str] = {tag.strip().lower() for tag in manual_tags if tag and tag.strip()}
-    priority_types: Set[str] = {typ.strip().title() for typ in manual_types if typ and typ.strip()}
-    priority_ids: Set[str] = {value.strip() for value in manual_ids if value and value.strip()}
+    priority_tags: Set[str] = {
+        tag.strip().lower() for tag in manual_tags if tag and tag.strip()
+    }
+    priority_types: Set[str] = {
+        typ.strip().title() for typ in manual_types if typ and typ.strip()
+    }
+    priority_ids: Set[str] = {
+        value.strip() for value in manual_ids if value and value.strip()
+    }
     priority_keywords: Set[str] = set()
 
     style_focus = False
@@ -502,7 +514,9 @@ def _build_context_profile(
     }
 
 
-def _result_matches_context_priority(result: Dict[str, Any], profile: Dict[str, Any]) -> bool:
+def _result_matches_context_priority(
+    result: Dict[str, Any], profile: Dict[str, Any]
+) -> bool:
     memory = result.get("memory", {}) or {}
     priority_ids: Set[str] = profile.get("priority_ids", set())
     priority_tags: Set[str] = profile.get("priority_tags", set())
@@ -520,7 +534,11 @@ def _result_matches_context_priority(result: Dict[str, Any], profile: Dict[str, 
         }
         for tag in tags:
             for priority_tag in priority_tags:
-                if tag == priority_tag or tag.startswith(priority_tag) or priority_tag in tag:
+                if (
+                    tag == priority_tag
+                    or tag.startswith(priority_tag)
+                    or priority_tag in tag
+                ):
                     return True
 
     if priority_types:
@@ -627,7 +645,9 @@ def _inject_priority_memories(
     return False
 
 
-def _results_have_priority(results: List[Dict[str, Any]], profile: Dict[str, Any]) -> bool:
+def _results_have_priority(
+    results: List[Dict[str, Any]], profile: Dict[str, Any]
+) -> bool:
     for result in results:
         if _result_matches_context_priority(result, profile):
             return True
@@ -678,7 +698,8 @@ def _expand_entity_memories(
     vector_filter_only_tag_search: Callable[..., List[Dict[str, Any]]],
     qdrant_client: Any,
     compute_metadata_score: Callable[
-        [Dict[str, Any], str, List[str], Optional[Dict[str, Any]]], tuple[float, Dict[str, float]]
+        [Dict[str, Any], str, List[str], Optional[Dict[str, Any]]],
+        tuple[float, Dict[str, float]],
     ],
     query_text: str,
     query_tokens: List[str],
@@ -738,7 +759,9 @@ def _expand_entity_memories(
             continue
 
         for result in entity_results:
-            result_id = str(result.get("id") or (result.get("memory") or {}).get("id") or "")
+            result_id = str(
+                result.get("id") or (result.get("memory") or {}).get("id") or ""
+            )
             if not result_id or result_id in seen_ids:
                 continue
 
@@ -770,7 +793,9 @@ def _expand_entity_memories(
     expanded_list.sort(key=lambda r: -float(r.get("final_score", 0.0)))
 
     logger.debug(
-        "Entity expansion: added %d memories from %d entities", len(expanded_list), len(entities)
+        "Entity expansion: added %d memories from %d entities",
+        len(expanded_list),
+        len(entities),
     )
 
     return expanded_list
@@ -793,7 +818,8 @@ def _expand_related_memories(
         bool,
     ],
     compute_metadata_score: Callable[
-        [Dict[str, Any], str, List[str], Optional[Dict[str, Any]]], tuple[float, Dict[str, float]]
+        [Dict[str, Any], str, List[str], Optional[Dict[str, Any]]],
+        tuple[float, Dict[str, float]],
     ],
     query_text: str,
     query_tokens: List[str],
@@ -815,7 +841,9 @@ def _expand_related_memories(
     if graph is None or not seed_results or expansion_limit <= 0:
         return []
 
-    relation_types = sorted({rel.upper() for rel in allowed_relations}) if allowed_relations else []
+    relation_types = (
+        sorted({rel.upper() for rel in allowed_relations}) if allowed_relations else []
+    )
     per_seed_limit = max(1, per_seed_limit)
     expansion_limit = max(1, expansion_limit)
 
@@ -827,7 +855,9 @@ def _expand_related_memories(
             break
 
         memory = seed.get("memory") or {}
-        seed_id = str(seed.get("id") or memory.get("id") or memory.get("memory_id") or "").strip()
+        seed_id = str(
+            seed.get("id") or memory.get("id") or memory.get("memory_id") or ""
+        ).strip()
         if not seed_id:
             continue
 
@@ -850,7 +880,9 @@ def _expand_related_memories(
             logger.exception("Failed to expand relations for seed %s", seed_id)
             continue
 
-        for relation_type, relation_strength, related in getattr(records, "result_set", []) or []:
+        for relation_type, relation_strength, related in (
+            getattr(records, "result_set", []) or []
+        ):
             if total_added >= expansion_limit:
                 break
 
@@ -870,7 +902,10 @@ def _expand_related_memories(
             except (TypeError, ValueError):  # pragma: no cover - defensive
                 relation_strength_val = 0.0
 
-            if expand_min_strength is not None and relation_strength_val < expand_min_strength:
+            if (
+                expand_min_strength is not None
+                and relation_strength_val < expand_min_strength
+            ):
                 continue
 
             # Importance filter (applies only to expanded results)
@@ -882,11 +917,19 @@ def _expand_related_memories(
                 except (TypeError, ValueError):
                     continue
             if not result_passes_filters(
-                candidate, start_time, end_time, tag_filters, tag_mode, tag_match, exclude_tags
+                candidate,
+                start_time,
+                end_time,
+                tag_filters,
+                tag_mode,
+                tag_match,
+                exclude_tags,
             ):
                 continue
 
-            relation_score = relation_strength_val + max(seed_score, 0.0) * seed_score_boost
+            relation_score = (
+                relation_strength_val + max(seed_score, 0.0) * seed_score_boost
+            )
 
             edge_info = {
                 "type": relation_type,
@@ -941,10 +984,13 @@ def handle_recall(
     get_qdrant_client: Callable[[], Any],
     normalize_tag_list: Callable[[Any], List[str]],
     normalize_timestamp: Callable[[str], str],
-    parse_time_expression: Callable[[Optional[str]], Tuple[Optional[str], Optional[str]]],
+    parse_time_expression: Callable[
+        [Optional[str]], Tuple[Optional[str], Optional[str]]
+    ],
     extract_keywords: Callable[[str], List[str]],
     compute_metadata_score: Callable[
-        [Dict[str, Any], str, List[str], Optional[Dict[str, Any]]], tuple[float, Dict[str, float]]
+        [Dict[str, Any], str, List[str], Optional[Dict[str, Any]]],
+        tuple[float, Dict[str, float]],
     ],
     result_passes_filters: Callable[
         [
@@ -975,9 +1021,17 @@ def handle_recall(
         request.args.getlist("queries") or request.args.get("queries")
     )
     sort_param = (
-        (request.args.get("sort") or request.args.get("order_by") or "score").strip().lower()
+        (request.args.get("sort") or request.args.get("order_by") or "score")
+        .strip()
+        .lower()
     )
-    if sort_param not in {"score", "time_desc", "time_asc", "updated_desc", "updated_asc"}:
+    if sort_param not in {
+        "score",
+        "time_desc",
+        "time_asc",
+        "updated_desc",
+        "updated_asc",
+    }:
         sort_param = "score"
     try:
         requested_limit = int(request.args.get("limit", 5))
@@ -1067,7 +1121,9 @@ def handle_recall(
     )
 
     try:
-        relation_limit = max(1, min(int(request.args.get("relation_limit", relation_limit)), 200))
+        relation_limit = max(
+            1, min(int(request.args.get("relation_limit", relation_limit)), 200)
+        )
     except (TypeError, ValueError):
         relation_limit = max(1, relation_limit)
 
@@ -1091,7 +1147,9 @@ def handle_recall(
         or request.args.get("focus_path")
         or ""
     )
-    language_hint_param = (request.args.get("language") or request.args.get("lang") or "").strip()
+    language_hint_param = (
+        request.args.get("language") or request.args.get("lang") or ""
+    ).strip()
 
     context_tags_input = _split_multi_value(
         request.args.getlist("context_tags") or request.args.get("context_tags")
@@ -1164,7 +1222,13 @@ def handle_recall(
                     res
                     for res in vector_matches
                     if result_passes_filters(
-                        res, start_time, end_time, tag_filters, tag_mode, tag_match, exclude_tags
+                        res,
+                        start_time,
+                        end_time,
+                        tag_filters,
+                        tag_mode,
+                        tag_match,
+                        exclude_tags,
                     )
                 ]
 
@@ -1187,7 +1251,12 @@ def handle_recall(
         # BM25 full-text search (complements vector + graph keyword)
         bm25_matches: List[Dict[str, Any]] = []
         try:
-            from automem.search.bm25 import search as bm25_search, BM25_ENABLED, fuse_rrf
+            from automem.search.bm25 import (
+                BM25_ENABLED,
+                fuse_rrf,
+            )
+            from automem.search.bm25 import search as bm25_search
+
             if BM25_ENABLED and query_str:
                 bm25_seen: set[str] = set()
                 bm25_matches = bm25_search(
@@ -1198,21 +1267,32 @@ def handle_recall(
                 )
                 if start_time or end_time or exclude_tags:
                     bm25_matches = [
-                        res for res in bm25_matches
+                        res
+                        for res in bm25_matches
                         if result_passes_filters(
-                            res, start_time, end_time, tag_filters, tag_mode, tag_match, exclude_tags
+                            res,
+                            start_time,
+                            end_time,
+                            tag_filters,
+                            tag_mode,
+                            tag_match,
+                            exclude_tags,
                         )
                     ]
         except ImportError:
             pass
         except Exception:
             import logging as _logging
-            _logging.getLogger(__name__).debug("BM25 recall search failed", exc_info=True)
+
+            _logging.getLogger(__name__).debug(
+                "BM25 recall search failed", exc_info=True
+            )
 
         # Fuse all sources via RRF if BM25 is active, otherwise fall back to sequential merge
         if bm25_matches:
             try:
                 from automem.search.bm25 import fuse_rrf
+
                 local_results = fuse_rrf(
                     vector_matches[:per_query_limit],
                     graph_matches[:per_query_limit],
@@ -1238,7 +1318,11 @@ def handle_recall(
             and not (embedding_param and embedding_param.strip())
             and bool(tag_filters)
         )
-        if tags_only_request and qdrant_client is not None and len(local_results) < per_query_limit:
+        if (
+            tags_only_request
+            and qdrant_client is not None
+            and len(local_results) < per_query_limit
+        ):
             tag_only_results = vector_filter_only_tag_search(
                 qdrant_client,
                 tag_filters,
@@ -1287,7 +1371,13 @@ def handle_recall(
             res
             for res in local_results
             if result_passes_filters(
-                res, start_time, end_time, tag_filters, tag_mode, tag_match, exclude_tags
+                res,
+                start_time,
+                end_time,
+                tag_filters,
+                tag_mode,
+                tag_match,
+                exclude_tags,
             )
         ]
 
@@ -1304,7 +1394,9 @@ def handle_recall(
             local_results.sort(key=_time_sort_key, reverse=(sort_param == "time_desc"))
         elif sort_param in {"updated_desc", "updated_asc"}:
             # Same key, but favor updated_at (already primary) and keep the name explicit for callers
-            local_results.sort(key=_time_sort_key, reverse=(sort_param == "updated_desc"))
+            local_results.sort(
+                key=_time_sort_key, reverse=(sort_param == "updated_desc")
+            )
         if len(local_results) > per_query_limit:
             local_results = local_results[:per_query_limit]
 
@@ -1352,11 +1444,19 @@ def handle_recall(
     )
     if expand_enabled_param and query_text and not multi_queries and query_text != "*":
         try:
-            from automem.search.query_expand import expand_query as llm_expand, EXPAND_ENABLED
+            from automem.search.query_expand import (
+                EXPAND_ENABLED,
+            )
+            from automem.search.query_expand import expand_query as llm_expand
+
             if EXPAND_ENABLED:
-                expanded_queries = llm_expand(query_text, get_openai_client() if get_openai_client else None)
+                expanded_queries = llm_expand(
+                    query_text, get_openai_client() if get_openai_client else None
+                )
                 if expanded_queries:
-                    logger.info("Query expansion: %r → %s", query_text[:50], expanded_queries)
+                    logger.info(
+                        "Query expansion: %r → %s", query_text[:50], expanded_queries
+                    )
         except ImportError:
             pass
         except Exception:
@@ -1380,7 +1480,11 @@ def handle_recall(
     per_query_limit = limit
     try:
         per_query_limit = max(
-            1, min(int(request.args.get("per_query_limit", per_query_limit)), recall_max_limit)
+            1,
+            min(
+                int(request.args.get("per_query_limit", per_query_limit)),
+                recall_max_limit,
+            ),
         )
     except (TypeError, ValueError):
         per_query_limit = limit
@@ -1459,7 +1563,8 @@ def handle_recall(
     # Entity-based expansion for multi-hop reasoning
     if expand_entities and qdrant_client is not None:
         entity_expansion_results = _expand_entity_memories(
-            seed_results=seed_results + expansion_results,  # Include relation-expanded results too
+            seed_results=seed_results
+            + expansion_results,  # Include relation-expanded results too
             seen_ids=seen_ids,
             vector_filter_only_tag_search=vector_filter_only_tag_search,
             qdrant_client=qdrant_client,
@@ -1477,17 +1582,27 @@ def handle_recall(
                 r
                 for r in entity_expansion_results
                 if result_passes_filters(
-                    r, start_time, end_time, tag_filters, tag_mode, tag_match, exclude_tags
+                    r,
+                    start_time,
+                    end_time,
+                    tag_filters,
+                    tag_mode,
+                    tag_match,
+                    exclude_tags,
                 )
             ]
         results = seed_results + expansion_results + entity_expansion_results
 
     # LLM reranking — final pass to score actual relevance
     try:
-        from automem.search.rerank import rerank as llm_rerank, RERANK_ENABLED
+        from automem.search.rerank import RERANK_ENABLED
+        from automem.search.rerank import rerank as llm_rerank
+
         if RERANK_ENABLED and query_text and results:
             # Pass main client if available; reranker also has its own dedicated client
-            openai_client = get_openai_client() if get_openai_client is not None else None
+            openai_client = (
+                get_openai_client() if get_openai_client is not None else None
+            )
             results = llm_rerank(query_text, results, openai_client)
     except ImportError:
         pass
@@ -1525,6 +1640,7 @@ def handle_recall(
     # Report rerank status
     try:
         from automem.search.rerank import RERANK_ENABLED
+
         response["rerank"] = {"enabled": RERANK_ENABLED}
     except ImportError:
         pass
@@ -1532,6 +1648,7 @@ def handle_recall(
     # Report query expansion status
     try:
         from automem.search.query_expand import EXPAND_ENABLED
+
         response["query_expansion"] = {
             "enabled": EXPAND_ENABLED,
             "alternatives": expanded_queries if expanded_queries else [],
@@ -1542,7 +1659,9 @@ def handle_recall(
     if is_multi:
         response["queries"] = queries_to_run
     if query_text and not is_multi:
-        response["keywords"] = extract_keywords(query_text.lower()) if query_text else []
+        response["keywords"] = (
+            extract_keywords(query_text.lower()) if query_text else []
+        )
     if start_time or end_time:
         response["time_window"] = {"start": start_time, "end": end_time}
     if tag_filters:
@@ -1556,7 +1675,9 @@ def handle_recall(
         response["context_priority"] = {
             "language": any_context_profile.get("language"),
             "context": any_context_profile.get("context_label"),
-            "priority_tags": sorted(any_context_profile.get("priority_tags") or [])[:10],
+            "priority_tags": sorted(any_context_profile.get("priority_tags") or [])[
+                :10
+            ],
             "priority_types": sorted(any_context_profile.get("priority_types") or []),
             "injected": any_context_injected,
         }
@@ -1576,7 +1697,9 @@ def handle_recall(
             "dedup_removed": dedup_removed,
             "is_multi": is_multi,
             "context_language": (
-                (any_context_profile or {}).get("language") if any_context_profile else None
+                (any_context_profile or {}).get("language")
+                if any_context_profile
+                else None
             ),
         },
     )
@@ -1599,10 +1722,13 @@ def create_recall_blueprint(
     get_qdrant_client: Callable[[], Any],
     normalize_tag_list: Callable[[Any], List[str]],
     normalize_timestamp: Callable[[str], str],
-    parse_time_expression: Callable[[Optional[str]], Tuple[Optional[str], Optional[str]]],
+    parse_time_expression: Callable[
+        [Optional[str]], Tuple[Optional[str], Optional[str]]
+    ],
     extract_keywords: Callable[[str], List[str]],
     compute_metadata_score: Callable[
-        [Dict[str, Any], str, List[str], Optional[Dict[str, Any]]], tuple[float, Dict[str, float]]
+        [Dict[str, Any], str, List[str], Optional[Dict[str, Any]]],
+        tuple[float, Dict[str, float]],
     ],
     result_passes_filters: Callable[
         [
@@ -1645,7 +1771,9 @@ def create_recall_blueprint(
             vector_filter_only_tag_search,
             recall_max_limit,
             logger,
-            allowed_relations=allowed_relations if allowed_relations else set(ALLOWED_RELATIONS),
+            allowed_relations=(
+                allowed_relations if allowed_relations else set(ALLOWED_RELATIONS)
+            ),
             relation_limit=relation_limit,
             expansion_limit_default=RECALL_EXPANSION_LIMIT,
             on_access=on_access,
@@ -1694,7 +1822,11 @@ def create_recall_blueprint(
             if getattr(system_results, "result_set", None):
                 for row in system_results.result_set:
                     system_rules.append(
-                        {"id": row[0], "content": row[1], "tags": row[2] if row[2] else []}
+                        {
+                            "id": row[0],
+                            "content": row[1],
+                            "tags": row[2] if row[2] else [],
+                        }
                     )
 
             response = {
@@ -1702,7 +1834,9 @@ def create_recall_blueprint(
                 "critical_lessons": lessons,
                 "system_rules": system_rules,
                 "lesson_count": len(lessons),
-                "has_critical": any(lesson.get("importance", 0) >= 0.9 for lesson in lessons),
+                "has_critical": any(
+                    lesson.get("importance", 0) >= 0.9 for lesson in lessons
+                ),
                 "summary": f"Recalled {len(lessons)} lesson(s) and {len(system_rules)} system rule(s)",
             }
             return jsonify(response), 200
@@ -1724,29 +1858,27 @@ def create_recall_blueprint(
             "confidence_distribution": {},
         }
         try:
-            type_result = graph.query(
-                """
+            type_result = graph.query("""
                 MATCH (m:Memory)
                 WHERE m.type IS NOT NULL
                 RETURN m.type, COUNT(m) as count, AVG(m.confidence) as avg_confidence
                 ORDER BY count DESC
-                """
-            )
-            for mem_type, count, avg_conf in getattr(type_result, "result_set", []) or []:
+                """)
+            for mem_type, count, avg_conf in (
+                getattr(type_result, "result_set", []) or []
+            ):
                 analytics["memory_types"][mem_type] = {
                     "count": count,
                     "average_confidence": round(avg_conf, 3) if avg_conf else 0,
                 }
 
-            pattern_result = graph.query(
-                """
+            pattern_result = graph.query("""
                 MATCH (p:Pattern)
                 WHERE p.confidence > 0.6
                 RETURN p.type, p.content, p.confidence, p.observations
                 ORDER BY p.confidence DESC
                 LIMIT 10
-                """
-            )
+                """)
             for p_type, content, confidence, observations in (
                 getattr(pattern_result, "result_set", []) or []
             ):
@@ -1759,15 +1891,15 @@ def create_recall_blueprint(
                     }
                 )
 
-            pref_result = graph.query(
-                """
+            pref_result = graph.query("""
                 MATCH (m1:Memory)-[r:PREFERS_OVER]->(m2:Memory)
                 RETURN m1.content, m2.content, r.context, r.strength
                 ORDER BY r.strength DESC
                 LIMIT 10
-                """
-            )
-            for preferred, over, context, strength in getattr(pref_result, "result_set", []) or []:
+                """)
+            for preferred, over, context, strength in (
+                getattr(pref_result, "result_set", []) or []
+            ):
                 analytics["preferences"].append(
                     {
                         "prefers": preferred,
@@ -1778,18 +1910,18 @@ def create_recall_blueprint(
                 )
 
             try:
-                temporal_result = graph.query(
-                    """
+                temporal_result = graph.query("""
                     MATCH (m:Memory)
                     WHERE m.timestamp IS NOT NULL
                     RETURN m.timestamp, m.importance
                     LIMIT 100
-                    """
-                )
+                    """)
                 from collections import defaultdict
 
                 hour_data = defaultdict(lambda: {"count": 0, "total_importance": 0})
-                for timestamp, importance in getattr(temporal_result, "result_set", []) or []:
+                for timestamp, importance in (
+                    getattr(temporal_result, "result_set", []) or []
+                ):
                     if timestamp and len(timestamp) > 13:
                         hour_str = timestamp[11:13]
                         if hour_str.isdigit():
@@ -1800,19 +1932,19 @@ def create_recall_blueprint(
                     if data["count"] > 0:
                         analytics["temporal_insights"][f"hour_{hour:02d}"] = {
                             "count": data["count"],
-                            "avg_importance": round(data["total_importance"] / data["count"], 3),
+                            "avg_importance": round(
+                                data["total_importance"] / data["count"], 3
+                            ),
                         }
             except Exception:
                 pass
 
-            entity_result = graph.query(
-                """
+            entity_result = graph.query("""
                 MATCH (m:Memory)
                 WHERE m.metadata IS NOT NULL
                 RETURN m.metadata
                 LIMIT 200
-                """
-            )
+                """)
             from collections import Counter
 
             entities = Counter()
@@ -1835,14 +1967,12 @@ def create_recall_blueprint(
                             entities[val] += 1
             analytics["entity_frequency"] = dict(entities.most_common(50))
 
-            conf_result = graph.query(
-                """
+            conf_result = graph.query("""
                 MATCH (m:Memory)
                 WHERE m.confidence IS NOT NULL
                 RETURN m.confidence
                 LIMIT 500
-                """
-            )
+                """)
             conf_dist: Dict[str, int] = {"low": 0, "medium": 0, "high": 0}
             for (conf,) in getattr(conf_result, "result_set", []) or []:
                 try:
@@ -1856,7 +1986,10 @@ def create_recall_blueprint(
                 else:
                     conf_dist["high"] += 1
             analytics["confidence_distribution"] = conf_dist
-            return jsonify({"status": "success", "analytics": analytics, "elapsed_ms": 0}), 200
+            return (
+                jsonify({"status": "success", "analytics": analytics, "elapsed_ms": 0}),
+                200,
+            )
         except Exception as e:
             logger.error(f"Analyze failed: {e}")
             return jsonify({"error": "Analyze failed", "details": str(e)}), 500
@@ -1872,7 +2005,9 @@ def create_recall_blueprint(
         rel_types_param = (request.args.get("relationship_types") or "").strip()
         if rel_types_param:
             requested = [
-                part.strip().upper() for part in rel_types_param.split(",") if part.strip()
+                part.strip().upper()
+                for part in rel_types_param.split(",")
+                if part.strip()
             ]
             rel_types = [t for t in requested if (t in allowed if allowed else True)]
             if not rel_types and allowed:
@@ -1922,7 +2057,9 @@ def create_recall_blueprint(
             try:
                 result = graph.query(fallback_query, params)
             except Exception:
-                logger.exception("Failed to traverse related memories for %s", memory_id)
+                logger.exception(
+                    "Failed to traverse related memories for %s", memory_id
+                )
                 abort(500, description="Failed to fetch related memories")
 
         related: List[Dict[str, Any]] = []

--- a/automem/search/bm25.py
+++ b/automem/search/bm25.py
@@ -1,0 +1,369 @@
+"""BM25 full-text search via SQLite FTS5.
+
+Provides exact keyword matching to complement Qdrant vector search.
+Memories are indexed on store and searched on recall, with results
+fused into the existing pipeline via Reciprocal Rank Fusion (RRF).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+BM25_ENABLED = os.environ.get("BM25_ENABLED", "true").lower() in ("1", "true", "yes")
+BM25_DB_PATH = os.environ.get("BM25_DB_PATH", "/app/data/bm25_index.db")
+
+# RRF constant (k) — higher = less emphasis on top ranks
+RRF_K = int(os.environ.get("BM25_RRF_K", "60"))
+
+# How many BM25 results to fetch before fusion
+BM25_FETCH_LIMIT = int(os.environ.get("BM25_FETCH_LIMIT", "50"))
+
+
+# ---------------------------------------------------------------------------
+# Thread-local connections (SQLite is not thread-safe by default)
+# ---------------------------------------------------------------------------
+
+_local = threading.local()
+
+
+def _get_conn() -> sqlite3.Connection:
+    """Return a thread-local SQLite connection, creating the DB if needed."""
+    conn: Optional[sqlite3.Connection] = getattr(_local, "conn", None)
+    if conn is not None:
+        return conn
+
+    db_path = BM25_DB_PATH
+    Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(db_path, check_same_thread=False)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=NORMAL")
+
+    # Create tables if needed
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS memories (
+            memory_id TEXT PRIMARY KEY,
+            content   TEXT NOT NULL,
+            tags      TEXT DEFAULT '',
+            type      TEXT DEFAULT '',
+            stored_at TEXT DEFAULT ''
+        );
+
+        CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+            content,
+            tags,
+            type,
+            content='memories',
+            content_rowid='rowid',
+            tokenize='porter unicode61 remove_diacritics 2'
+        );
+
+        -- Triggers to keep FTS in sync with content table
+        CREATE TRIGGER IF NOT EXISTS memories_ai AFTER INSERT ON memories BEGIN
+            INSERT INTO memories_fts(rowid, content, tags, type)
+            VALUES (new.rowid, new.content, new.tags, new.type);
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS memories_ad AFTER DELETE ON memories BEGIN
+            INSERT INTO memories_fts(memories_fts, rowid, content, tags, type)
+            VALUES ('delete', old.rowid, old.content, old.tags, old.type);
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE ON memories BEGIN
+            INSERT INTO memories_fts(memories_fts, rowid, content, tags, type)
+            VALUES ('delete', old.rowid, old.content, old.tags, old.type);
+            INSERT INTO memories_fts(rowid, content, tags, type)
+            VALUES (new.rowid, new.content, new.tags, new.type);
+        END;
+        """
+    )
+    conn.commit()
+
+    _local.conn = conn
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Index operations
+# ---------------------------------------------------------------------------
+
+
+def index_memory(
+    memory_id: str,
+    content: str,
+    tags: Optional[List[str]] = None,
+    memory_type: Optional[str] = None,
+    stored_at: Optional[str] = None,
+) -> None:
+    """Add or update a memory in the FTS index."""
+    if not BM25_ENABLED:
+        return
+
+    conn = _get_conn()
+    tag_str = " ".join(tags) if tags else ""
+    type_str = memory_type or ""
+    stored_str = stored_at or ""
+
+    try:
+        conn.execute(
+            """
+            INSERT INTO memories (memory_id, content, tags, type, stored_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(memory_id) DO UPDATE SET
+                content = excluded.content,
+                tags = excluded.tags,
+                type = excluded.type,
+                stored_at = excluded.stored_at
+            """,
+            (memory_id, content, tag_str, type_str, stored_str),
+        )
+        conn.commit()
+    except Exception:
+        logger.exception("BM25 index_memory failed for %s", memory_id)
+
+
+def remove_memory(memory_id: str) -> None:
+    """Remove a memory from the FTS index."""
+    if not BM25_ENABLED:
+        return
+
+    conn = _get_conn()
+    try:
+        conn.execute("DELETE FROM memories WHERE memory_id = ?", (memory_id,))
+        conn.commit()
+    except Exception:
+        logger.exception("BM25 remove_memory failed for %s", memory_id)
+
+
+def search(
+    query: str,
+    limit: int = BM25_FETCH_LIMIT,
+    seen_ids: Optional[Set[str]] = None,
+    tag_filters: Optional[List[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Search the FTS index. Returns list of {memory_id, score, snippet, source}."""
+    if not BM25_ENABLED or not query or not query.strip():
+        return []
+
+    conn = _get_conn()
+    seen = seen_ids or set()
+
+    # Sanitize query for FTS5 — escape double quotes, strip operators
+    fts_query = _build_fts_query(query)
+    if not fts_query:
+        return []
+
+    try:
+        t0 = time.monotonic()
+        rows = conn.execute(
+            """
+            SELECT
+                m.memory_id,
+                m.content,
+                m.tags,
+                m.type,
+                m.stored_at,
+                rank
+            FROM memories_fts
+            JOIN memories m ON memories_fts.rowid = m.rowid
+            WHERE memories_fts MATCH ?
+            ORDER BY rank
+            LIMIT ?
+            """,
+            (fts_query, limit),
+        ).fetchall()
+        elapsed_ms = (time.monotonic() - t0) * 1000
+
+        results = []
+        for memory_id, content, tags_str, mtype, stored_at, rank in rows:
+            if memory_id in seen:
+                continue
+
+            # Apply tag filter if provided
+            if tag_filters:
+                mem_tags = set(tags_str.lower().split()) if tags_str else set()
+                if not any(t.lower() in mem_tags for t in tag_filters):
+                    continue
+
+            # FTS5 rank is negative (more negative = better match)
+            # Normalize to 0-1 range for fusion
+            bm25_score = -rank if rank else 0.0
+
+            results.append(
+                {
+                    "memory_id": memory_id,
+                    "id": memory_id,
+                    "score": bm25_score,
+                    "source": "bm25",
+                    "memory": {
+                        "id": memory_id,
+                        "memory_id": memory_id,
+                        "content": content,
+                        "tags": tags_str.split() if tags_str else [],
+                        "type": mtype,
+                        "stored_at": stored_at,
+                    },
+                }
+            )
+            seen.add(memory_id)
+
+        logger.debug(
+            "BM25 search: query=%r results=%d time=%.1fms",
+            fts_query,
+            len(results),
+            elapsed_ms,
+        )
+        return results
+
+    except Exception:
+        logger.exception("BM25 search failed for query: %s", query)
+        return []
+
+
+def get_index_count() -> int:
+    """Return the number of indexed memories."""
+    if not BM25_ENABLED:
+        return 0
+    try:
+        conn = _get_conn()
+        row = conn.execute("SELECT COUNT(*) FROM memories").fetchone()
+        return row[0] if row else 0
+    except Exception:
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Backfill: index all existing memories from the graph
+# ---------------------------------------------------------------------------
+
+
+def backfill_from_graph(graph: Any) -> int:
+    """Index all memories from FalkorDB graph into BM25. Returns count indexed."""
+    if not BM25_ENABLED:
+        return 0
+
+    try:
+        result = graph.query(
+            "MATCH (m:Memory) RETURN m.id, m.content, m.tags, m.type, m.stored_at"
+        )
+        count = 0
+        for row in result.result_set:
+            mid, content, tags_raw, mtype, stored_at = row
+            if not mid or not content:
+                continue
+            tags = []
+            if tags_raw:
+                if isinstance(tags_raw, list):
+                    tags = tags_raw
+                elif isinstance(tags_raw, str):
+                    # Could be JSON array or space-separated
+                    tags_raw = tags_raw.strip()
+                    if tags_raw.startswith("["):
+                        import json
+
+                        try:
+                            tags = json.loads(tags_raw)
+                        except Exception:
+                            tags = tags_raw.split()
+                    else:
+                        tags = tags_raw.split()
+            index_memory(mid, content, tags, mtype, stored_at)
+            count += 1
+        logger.info("BM25 backfill complete: %d memories indexed", count)
+        return count
+    except Exception:
+        logger.exception("BM25 backfill failed")
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# RRF fusion helper
+# ---------------------------------------------------------------------------
+
+
+def fuse_rrf(
+    *result_lists: List[Dict[str, Any]],
+    k: int = RRF_K,
+) -> List[Dict[str, Any]]:
+    """Reciprocal Rank Fusion across multiple ranked result lists.
+
+    Each result must have 'memory_id' or 'id'. Returns merged list sorted
+    by fused score descending. Original scores preserved in score_components.
+    """
+    scores: Dict[str, float] = {}
+    results_by_id: Dict[str, Dict[str, Any]] = {}
+    source_ranks: Dict[str, Dict[str, int]] = {}  # id -> {source: rank}
+
+    for result_list in result_lists:
+        for rank, result in enumerate(result_list):
+            mid = result.get("memory_id") or result.get("id") or ""
+            if not mid:
+                continue
+
+            rrf_score = 1.0 / (k + rank + 1)
+            scores[mid] = scores.get(mid, 0.0) + rrf_score
+
+            if mid not in results_by_id:
+                results_by_id[mid] = result.copy()
+                source_ranks[mid] = {}
+
+            source = result.get("source", "unknown")
+            source_ranks[mid][source] = rank + 1
+
+    # Build final list
+    fused = []
+    for mid, score in sorted(scores.items(), key=lambda x: -x[1]):
+        entry = results_by_id[mid]
+        entry["rrf_score"] = score
+        entry.setdefault("score_components", {})
+        entry["score_components"]["rrf"] = score
+        entry["score_components"]["source_ranks"] = source_ranks.get(mid, {})
+        fused.append(entry)
+
+    return fused
+
+
+# ---------------------------------------------------------------------------
+# FTS5 query builder
+# ---------------------------------------------------------------------------
+
+# Characters that are FTS5 operators or would break the query
+_FTS_STRIP = re.compile(r'["\'\(\)\*\:\^\~\{\}\[\]\\]')
+_WHITESPACE = re.compile(r"\s+")
+
+
+def _build_fts_query(raw_query: str) -> str:
+    """Convert a natural language query into an FTS5 query string.
+
+    Strategy: extract words, join with implicit AND (FTS5 default).
+    For multi-word queries we also add an OR-joined phrase match
+    to boost results that have the words adjacent.
+    """
+    cleaned = _FTS_STRIP.sub(" ", raw_query)
+    words = _WHITESPACE.split(cleaned.strip())
+    words = [w for w in words if w and len(w) > 1]
+
+    if not words:
+        return ""
+
+    if len(words) == 1:
+        return words[0]
+
+    # Individual terms (implicit AND) OR exact phrase
+    terms_part = " ".join(words)
+    phrase_part = '"' + " ".join(words) + '"'
+    return f"({terms_part}) OR ({phrase_part})"

--- a/automem/search/bm25.py
+++ b/automem/search/bm25.py
@@ -53,8 +53,7 @@ def _get_conn() -> sqlite3.Connection:
     conn.execute("PRAGMA synchronous=NORMAL")
 
     # Create tables if needed
-    conn.executescript(
-        """
+    conn.executescript("""
         CREATE TABLE IF NOT EXISTS memories (
             memory_id TEXT PRIMARY KEY,
             content   TEXT NOT NULL,
@@ -89,8 +88,7 @@ def _get_conn() -> sqlite3.Connection:
             INSERT INTO memories_fts(rowid, content, tags, type)
             VALUES (new.rowid, new.content, new.tags, new.type);
         END;
-        """
-    )
+        """)
     conn.commit()
 
     _local.conn = conn

--- a/automem/search/query_expand.py
+++ b/automem/search/query_expand.py
@@ -22,7 +22,11 @@ logger = logging.getLogger(__name__)
 # Config
 # ---------------------------------------------------------------------------
 
-EXPAND_ENABLED = os.environ.get("QUERY_EXPAND_ENABLED", "true").lower() in ("1", "true", "yes")
+EXPAND_ENABLED = os.environ.get("QUERY_EXPAND_ENABLED", "true").lower() in (
+    "1",
+    "true",
+    "yes",
+)
 EXPAND_MODEL = os.environ.get("QUERY_EXPAND_MODEL", "gpt-4.1-nano")
 EXPAND_TIMEOUT = float(os.environ.get("QUERY_EXPAND_TIMEOUT", "10.0"))
 EXPAND_MAX_ALTERNATIVES = int(os.environ.get("QUERY_EXPAND_MAX", "3"))
@@ -52,6 +56,7 @@ def _get_expand_client() -> Any:
     if EXPAND_API_KEY.startswith("sk-ant-"):
         try:
             import anthropic
+
             _expand_client = anthropic.Anthropic(api_key=EXPAND_API_KEY)
             _expand_client_type = "anthropic"
             return _expand_client
@@ -61,6 +66,7 @@ def _get_expand_client() -> Any:
     else:
         try:
             from openai import OpenAI
+
             kwargs: Dict[str, Any] = {"api_key": EXPAND_API_KEY}
             if EXPAND_BASE_URL:
                 kwargs["base_url"] = EXPAND_BASE_URL
@@ -122,13 +128,20 @@ def expand_query(
     try:
         t0 = time.monotonic()
 
-        if _expand_client_type == "anthropic" and client is not None and hasattr(client, 'messages'):
+        if (
+            _expand_client_type == "anthropic"
+            and client is not None
+            and hasattr(client, "messages")
+        ):
             response = client.messages.create(
                 model=model,
                 max_tokens=200,
                 system=SYSTEM_PROMPT,
                 messages=[
-                    {"role": "user", "content": f"Query: {query}\n\nRespond with ONLY a JSON array of alternative queries."},
+                    {
+                        "role": "user",
+                        "content": f"Query: {query}\n\nRespond with ONLY a JSON array of alternative queries.",
+                    },
                 ],
                 timeout=EXPAND_TIMEOUT,
             )
@@ -136,13 +149,18 @@ def expand_query(
         else:
             extra_params: Dict[str, Any] = {"max_tokens": 200}
             if not model.startswith(("o", "gpt-5")):
-                extra_params["temperature"] = 0.7  # Some creativity for diverse alternatives
+                extra_params["temperature"] = (
+                    0.7  # Some creativity for diverse alternatives
+                )
 
             response = client.chat.completions.create(
                 model=model,
                 messages=[
                     {"role": "system", "content": SYSTEM_PROMPT},
-                    {"role": "user", "content": f"Query: {query}\n\nRespond with ONLY a JSON array of alternative queries."},
+                    {
+                        "role": "user",
+                        "content": f"Query: {query}\n\nRespond with ONLY a JSON array of alternative queries.",
+                    },
                 ],
                 timeout=EXPAND_TIMEOUT,
                 **extra_params,
@@ -153,7 +171,8 @@ def expand_query(
 
         # Extract JSON array
         import re as _re
-        json_match = _re.search(r'\[.*\]', raw, _re.DOTALL)
+
+        json_match = _re.search(r"\[.*\]", raw, _re.DOTALL)
         if json_match:
             raw = json_match.group(0)
 
@@ -186,5 +205,7 @@ def expand_query(
         return alternatives
 
     except Exception:
-        logger.warning("Query expansion failed, using original query only", exc_info=True)
+        logger.warning(
+            "Query expansion failed, using original query only", exc_info=True
+        )
         return []

--- a/automem/search/query_expand.py
+++ b/automem/search/query_expand.py
@@ -1,0 +1,190 @@
+"""LLM-based query expansion for recall.
+
+Before searching, generates alternative phrasings of the query so we catch
+memories stored with different wording. For example:
+  "Jeff's workout routine" → ["exercise program", "fitness schedule", "gym sessions"]
+
+Uses a cheap, fast model to keep latency low. Results are merged with the
+original query via the existing multi-query/RRF pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+EXPAND_ENABLED = os.environ.get("QUERY_EXPAND_ENABLED", "true").lower() in ("1", "true", "yes")
+EXPAND_MODEL = os.environ.get("QUERY_EXPAND_MODEL", "gpt-4.1-nano")
+EXPAND_TIMEOUT = float(os.environ.get("QUERY_EXPAND_TIMEOUT", "10.0"))
+EXPAND_MAX_ALTERNATIVES = int(os.environ.get("QUERY_EXPAND_MAX", "3"))
+# Reuse the rerank API key/base since it's the same cheap-model endpoint
+EXPAND_API_KEY = os.environ.get("RERANK_API_KEY", "")
+EXPAND_BASE_URL = os.environ.get("RERANK_BASE_URL", "")
+
+# Minimum query length to bother expanding (very short queries are already broad)
+MIN_QUERY_LENGTH = 8
+
+# Cache recent expansions to avoid repeated LLM calls for the same query
+_expansion_cache: Dict[str, List[str]] = {}
+_CACHE_MAX_SIZE = 100
+
+_expand_client: Any = None
+_expand_client_type: str = ""
+
+
+def _get_expand_client() -> Any:
+    """Get or create a dedicated client for query expansion."""
+    global _expand_client, _expand_client_type
+    if _expand_client is not None:
+        return _expand_client
+    if not EXPAND_API_KEY:
+        return None
+
+    if EXPAND_API_KEY.startswith("sk-ant-"):
+        try:
+            import anthropic
+            _expand_client = anthropic.Anthropic(api_key=EXPAND_API_KEY)
+            _expand_client_type = "anthropic"
+            return _expand_client
+        except ImportError:
+            logger.warning("anthropic package not installed for query expansion")
+            return None
+    else:
+        try:
+            from openai import OpenAI
+            kwargs: Dict[str, Any] = {"api_key": EXPAND_API_KEY}
+            if EXPAND_BASE_URL:
+                kwargs["base_url"] = EXPAND_BASE_URL
+            _expand_client = OpenAI(**kwargs)
+            _expand_client_type = "openai"
+            return _expand_client
+        except Exception:
+            logger.warning("Failed to create query expansion client", exc_info=True)
+            return None
+
+
+SYSTEM_PROMPT = """You generate alternative search queries to find relevant memories in a personal knowledge base.
+
+Given a search query, produce alternative phrasings that would match memories stored with different wording.
+
+Rules:
+- Generate 2-3 short alternative queries (2-5 words each)
+- Focus on synonyms, related terms, and different framings
+- Include both broader and more specific alternatives
+- Don't repeat the original query
+- Think about how a memory might have been STORED vs how it's being SEARCHED
+
+Return a JSON array of strings. Example: ["alternative 1", "alternative 2", "alternative 3"]"""
+
+
+def expand_query(
+    query: str,
+    openai_client: Any = None,
+    max_alternatives: int = EXPAND_MAX_ALTERNATIVES,
+    model: Optional[str] = None,
+) -> List[str]:
+    """Generate alternative phrasings for a search query.
+
+    Args:
+        query: Original search query
+        openai_client: Fallback OpenAI client
+        max_alternatives: Max number of alternatives to generate
+        model: Override model name
+
+    Returns:
+        List of alternative query strings (may be empty on failure)
+    """
+    if not EXPAND_ENABLED or not query or len(query.strip()) < MIN_QUERY_LENGTH:
+        return []
+
+    query_key = query.strip().lower()
+
+    # Check cache
+    if query_key in _expansion_cache:
+        logger.debug("Query expansion cache hit: %s", query_key[:50])
+        return _expansion_cache[query_key]
+
+    client = _get_expand_client() or openai_client
+    if client is None:
+        return []
+
+    model = model or EXPAND_MODEL
+
+    try:
+        t0 = time.monotonic()
+
+        if _expand_client_type == "anthropic" and client is not None and hasattr(client, 'messages'):
+            response = client.messages.create(
+                model=model,
+                max_tokens=200,
+                system=SYSTEM_PROMPT,
+                messages=[
+                    {"role": "user", "content": f"Query: {query}\n\nRespond with ONLY a JSON array of alternative queries."},
+                ],
+                timeout=EXPAND_TIMEOUT,
+            )
+            raw = response.content[0].text.strip()
+        else:
+            extra_params: Dict[str, Any] = {"max_tokens": 200}
+            if not model.startswith(("o", "gpt-5")):
+                extra_params["temperature"] = 0.7  # Some creativity for diverse alternatives
+
+            response = client.chat.completions.create(
+                model=model,
+                messages=[
+                    {"role": "system", "content": SYSTEM_PROMPT},
+                    {"role": "user", "content": f"Query: {query}\n\nRespond with ONLY a JSON array of alternative queries."},
+                ],
+                timeout=EXPAND_TIMEOUT,
+                **extra_params,
+            )
+            raw = response.choices[0].message.content.strip()
+
+        elapsed_ms = (time.monotonic() - t0) * 1000
+
+        # Extract JSON array
+        import re as _re
+        json_match = _re.search(r'\[.*\]', raw, _re.DOTALL)
+        if json_match:
+            raw = json_match.group(0)
+
+        parsed = json.loads(raw)
+        if not isinstance(parsed, list):
+            return []
+
+        alternatives = [
+            str(item).strip()
+            for item in parsed
+            if isinstance(item, str) and len(item.strip()) >= 3
+        ][:max_alternatives]
+
+        # Cache the result
+        if len(_expansion_cache) >= _CACHE_MAX_SIZE:
+            # Evict oldest entries (simple FIFO via dict ordering)
+            keys_to_remove = list(_expansion_cache.keys())[: _CACHE_MAX_SIZE // 2]
+            for k in keys_to_remove:
+                del _expansion_cache[k]
+        _expansion_cache[query_key] = alternatives
+
+        logger.info(
+            "Query expansion: query=%r model=%s alternatives=%d time=%.0fms",
+            query[:50],
+            model,
+            len(alternatives),
+            elapsed_ms,
+        )
+
+        return alternatives
+
+    except Exception:
+        logger.warning("Query expansion failed, using original query only", exc_info=True)
+        return []

--- a/automem/search/rerank.py
+++ b/automem/search/rerank.py
@@ -1,0 +1,216 @@
+"""LLM-based reranking for recall results.
+
+After initial retrieval (vector + graph + BM25), an LLM scores each
+result's actual relevance to the query. This catches false positives
+from vector search and promotes results that are genuinely relevant.
+
+Uses a cheap, fast model (gpt-4.1-nano by default) to keep latency low.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+RERANK_ENABLED = os.environ.get("RERANK_ENABLED", "true").lower() in ("1", "true", "yes")
+RERANK_MODEL = os.environ.get("RERANK_MODEL", "gpt-4.1-nano")
+RERANK_TOP_N = int(os.environ.get("RERANK_TOP_N", "20"))  # How many candidates to rerank
+RERANK_TIMEOUT = float(os.environ.get("RERANK_TIMEOUT", "15.0"))  # Seconds
+# Separate API key/base for reranking (falls back to main OpenAI client if not set)
+RERANK_API_KEY = os.environ.get("RERANK_API_KEY", "")
+RERANK_BASE_URL = os.environ.get("RERANK_BASE_URL", "")
+
+_rerank_client: Any = None
+_rerank_client_type: str = ""  # "anthropic" or "openai"
+
+
+def _get_rerank_client() -> Any:
+    """Get or create a dedicated client for reranking."""
+    global _rerank_client, _rerank_client_type
+    if _rerank_client is not None:
+        return _rerank_client
+    if not RERANK_API_KEY:
+        return None
+
+    # Detect Anthropic key
+    if RERANK_API_KEY.startswith("sk-ant-"):
+        try:
+            import anthropic
+            _rerank_client = anthropic.Anthropic(api_key=RERANK_API_KEY)
+            _rerank_client_type = "anthropic"
+            return _rerank_client
+        except ImportError:
+            logger.warning("anthropic package not installed for reranking")
+            return None
+    else:
+        try:
+            from openai import OpenAI
+            kwargs: Dict[str, Any] = {"api_key": RERANK_API_KEY}
+            if RERANK_BASE_URL:
+                kwargs["base_url"] = RERANK_BASE_URL
+            _rerank_client = OpenAI(**kwargs)
+            _rerank_client_type = "openai"
+            return _rerank_client
+        except Exception:
+            logger.warning("Failed to create rerank OpenAI client", exc_info=True)
+            return None
+
+SYSTEM_PROMPT = """You are a memory relevance scorer. Given a search query and a list of memory snippets, score each snippet's relevance to the query on a scale of 0-10.
+
+Scoring guide:
+- 10: Directly answers the query or is exactly what was asked for
+- 7-9: Highly relevant, contains key information related to the query
+- 4-6: Somewhat relevant, tangentially related
+- 1-3: Barely relevant, only loosely connected
+- 0: Completely irrelevant
+
+Return a JSON array of objects with "index" (0-based) and "score" (0-10) for each snippet.
+Example: [{"index": 0, "score": 8}, {"index": 1, "score": 3}]
+
+Be strict — only high scores for genuinely relevant results."""
+
+
+def rerank(
+    query: str,
+    results: List[Dict[str, Any]],
+    openai_client: Any,
+    top_n: int = RERANK_TOP_N,
+    model: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Rerank results using an LLM. Returns reordered list with rerank_score added.
+
+    Args:
+        query: The original search query
+        results: List of recall results (must have 'memory' dict with 'content')
+        openai_client: OpenAI client instance
+        top_n: Max number of candidates to send to the LLM
+        model: Override model name
+
+    Returns:
+        Reordered results list with 'rerank_score' added to each result
+    """
+    if not RERANK_ENABLED or not results or not query:
+        return results
+
+    # Try dedicated rerank client first, then fall back to passed-in client
+    client = _get_rerank_client() or openai_client
+    if client is None:
+        return results
+
+    model = model or RERANK_MODEL
+    candidates = results[:top_n]
+    remainder = results[top_n:]
+
+    # Build the prompt with numbered snippets
+    snippets = []
+    for i, r in enumerate(candidates):
+        mem = r.get("memory") or r
+        content = mem.get("content", "")
+        # Truncate long content to keep prompt manageable
+        if len(content) > 300:
+            content = content[:300] + "..."
+        snippets.append(f"[{i}] {content}")
+
+    user_prompt = f"Query: {query}\n\nSnippets:\n" + "\n".join(snippets)
+
+    try:
+        t0 = time.monotonic()
+
+        # Route to appropriate API
+        if _rerank_client_type == "anthropic" and client is not None and hasattr(client, 'messages'):
+            response = client.messages.create(
+                model=model,
+                max_tokens=500,
+                system=SYSTEM_PROMPT,
+                messages=[
+                    {"role": "user", "content": user_prompt + "\n\nRespond with ONLY a JSON array, no other text."},
+                ],
+                timeout=RERANK_TIMEOUT,
+            )
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            raw = response.content[0].text.strip()
+        else:
+            # OpenAI-compatible path
+            extra_params: Dict[str, Any] = {"max_tokens": 500}
+            if not model.startswith(("o", "gpt-5")):
+                extra_params["temperature"] = 0.0
+
+            response = client.chat.completions.create(
+                model=model,
+                messages=[
+                    {"role": "system", "content": SYSTEM_PROMPT},
+                    {"role": "user", "content": user_prompt + "\n\nRespond with ONLY a JSON array, no other text."},
+                ],
+                timeout=RERANK_TIMEOUT,
+                **extra_params,
+            )
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            raw = response.choices[0].message.content.strip()
+
+        # Extract JSON from response (may have markdown fences or preamble)
+        import re as _re
+        json_match = _re.search(r'[\[{].*[\]}]', raw, _re.DOTALL)
+        if json_match:
+            raw = json_match.group(0)
+
+        parsed = json.loads(raw)
+        if isinstance(parsed, dict):
+            scores_list = parsed.get("results") or parsed.get("scores") or parsed.get("rankings") or []
+            if not scores_list:
+                # Try to find any list value
+                for v in parsed.values():
+                    if isinstance(v, list):
+                        scores_list = v
+                        break
+        elif isinstance(parsed, list):
+            scores_list = parsed
+        else:
+            scores_list = []
+
+        # Build index -> score map
+        score_map: Dict[int, float] = {}
+        for item in scores_list:
+            if isinstance(item, dict) and "index" in item and "score" in item:
+                idx = int(item["index"])
+                score = float(item["score"])
+                if 0 <= idx < len(candidates):
+                    score_map[idx] = score
+
+        # Apply scores and sort
+        for i, r in enumerate(candidates):
+            rerank_score = score_map.get(i, 5.0)  # Default to middle if not scored
+            r["rerank_score"] = rerank_score
+            r.setdefault("score_components", {})
+            r["score_components"]["rerank"] = rerank_score
+
+        # Sort by rerank score descending
+        candidates.sort(key=lambda r: -r.get("rerank_score", 0))
+
+        # Remainder gets a default score
+        for r in remainder:
+            r["rerank_score"] = 0.0
+            r.setdefault("score_components", {})
+            r["score_components"]["rerank"] = 0.0
+
+        logger.info(
+            "LLM rerank: model=%s candidates=%d scored=%d time=%.0fms",
+            model,
+            len(candidates),
+            len(score_map),
+            elapsed_ms,
+        )
+
+        return candidates + remainder
+
+    except Exception:
+        logger.warning("LLM rerank failed, returning original order", exc_info=True)
+        return results

--- a/automem/search/rerank.py
+++ b/automem/search/rerank.py
@@ -21,9 +21,15 @@ logger = logging.getLogger(__name__)
 # Config
 # ---------------------------------------------------------------------------
 
-RERANK_ENABLED = os.environ.get("RERANK_ENABLED", "true").lower() in ("1", "true", "yes")
+RERANK_ENABLED = os.environ.get("RERANK_ENABLED", "true").lower() in (
+    "1",
+    "true",
+    "yes",
+)
 RERANK_MODEL = os.environ.get("RERANK_MODEL", "gpt-4.1-nano")
-RERANK_TOP_N = int(os.environ.get("RERANK_TOP_N", "20"))  # How many candidates to rerank
+RERANK_TOP_N = int(
+    os.environ.get("RERANK_TOP_N", "20")
+)  # How many candidates to rerank
 RERANK_TIMEOUT = float(os.environ.get("RERANK_TIMEOUT", "15.0"))  # Seconds
 # Separate API key/base for reranking (falls back to main OpenAI client if not set)
 RERANK_API_KEY = os.environ.get("RERANK_API_KEY", "")
@@ -45,6 +51,7 @@ def _get_rerank_client() -> Any:
     if RERANK_API_KEY.startswith("sk-ant-"):
         try:
             import anthropic
+
             _rerank_client = anthropic.Anthropic(api_key=RERANK_API_KEY)
             _rerank_client_type = "anthropic"
             return _rerank_client
@@ -54,6 +61,7 @@ def _get_rerank_client() -> Any:
     else:
         try:
             from openai import OpenAI
+
             kwargs: Dict[str, Any] = {"api_key": RERANK_API_KEY}
             if RERANK_BASE_URL:
                 kwargs["base_url"] = RERANK_BASE_URL
@@ -63,6 +71,7 @@ def _get_rerank_client() -> Any:
         except Exception:
             logger.warning("Failed to create rerank OpenAI client", exc_info=True)
             return None
+
 
 SYSTEM_PROMPT = """You are a memory relevance scorer. Given a search query and a list of memory snippets, score each snippet's relevance to the query on a scale of 0-10.
 
@@ -126,13 +135,21 @@ def rerank(
         t0 = time.monotonic()
 
         # Route to appropriate API
-        if _rerank_client_type == "anthropic" and client is not None and hasattr(client, 'messages'):
+        if (
+            _rerank_client_type == "anthropic"
+            and client is not None
+            and hasattr(client, "messages")
+        ):
             response = client.messages.create(
                 model=model,
                 max_tokens=500,
                 system=SYSTEM_PROMPT,
                 messages=[
-                    {"role": "user", "content": user_prompt + "\n\nRespond with ONLY a JSON array, no other text."},
+                    {
+                        "role": "user",
+                        "content": user_prompt
+                        + "\n\nRespond with ONLY a JSON array, no other text.",
+                    },
                 ],
                 timeout=RERANK_TIMEOUT,
             )
@@ -148,7 +165,11 @@ def rerank(
                 model=model,
                 messages=[
                     {"role": "system", "content": SYSTEM_PROMPT},
-                    {"role": "user", "content": user_prompt + "\n\nRespond with ONLY a JSON array, no other text."},
+                    {
+                        "role": "user",
+                        "content": user_prompt
+                        + "\n\nRespond with ONLY a JSON array, no other text.",
+                    },
                 ],
                 timeout=RERANK_TIMEOUT,
                 **extra_params,
@@ -158,13 +179,19 @@ def rerank(
 
         # Extract JSON from response (may have markdown fences or preamble)
         import re as _re
-        json_match = _re.search(r'[\[{].*[\]}]', raw, _re.DOTALL)
+
+        json_match = _re.search(r"[\[{].*[\]}]", raw, _re.DOTALL)
         if json_match:
             raw = json_match.group(0)
 
         parsed = json.loads(raw)
         if isinstance(parsed, dict):
-            scores_list = parsed.get("results") or parsed.get("scores") or parsed.get("rankings") or []
+            scores_list = (
+                parsed.get("results")
+                or parsed.get("scores")
+                or parsed.get("rankings")
+                or []
+            )
             if not scores_list:
                 # Try to find any list value
                 for v in parsed.values():

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ fastembed==0.4.2
 onnxruntime<1.20  # Pin to avoid issues with fastembed 0.4.2
 en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0.tar.gz
 httpx>=0.27.0
+anthropic>=0.40.0


### PR DESCRIPTION
Three new retrieval enhancements that work together to improve recall quality.

## BM25 Full-Text Search (`automem/search/bm25.py`)
- SQLite FTS5 keyword index alongside Qdrant vector + FalkorDB graph
- Catches exact keyword matches vector search misses (e.g. searching "Hetzner" when stored as "Hetzner VPS")
- Results fused via Reciprocal Rank Fusion (RRF) across all 3 sources
- Auto-indexed on memory store/delete, persistent under `/app/data/`

## LLM Reranking (`automem/search/rerank.py`)
- After retrieval, LLM scores each result's actual relevance (0-10)
- Catches vector search false positives and promotes genuinely relevant results
- Supports both OpenAI-compatible and Anthropic SDK clients

## Query Expansion (`automem/search/query_expand.py`)
- Generates 2-3 alternative phrasings before searching
- e.g. `brother in law` → `Christina's brother`, `family in-law`
- In-memory cache for repeated queries
- Disable per-request: `?expand_query=false`

**Full pipeline:** query expansion → vector + graph + BM25 search → RRF fusion → metadata scoring → LLM reranking

All three features are independently toggleable via env vars (`BM25_ENABLED`, `RERANK_ENABLED`, `QUERY_EXPAND_ENABLED`) and degrade gracefully on failure.

Also fixes BM25 crash on queries containing apostrophes (FTS5 syntax error).