### PR TITLE
fix: FalkorDB data not persisting across restarts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,11 @@ services:
       - ./backups/falkordb:/backups # Local backups
     environment:
       # Aggressive persistence: save every 60s if 1 key changed, enable AOF
-      - REDIS_ARGS=--save 60 1 --appendonly yes --appendfsync everysec --dir /data
+      # Note: --dir is NOT set here because FalkorDB's run.sh always appends
+      # --dir $FALKORDB_DATA_PATH after REDIS_ARGS, so any --dir in REDIS_ARGS
+      # is silently overridden. We set FALKORDB_DATA_PATH=/data instead.
+      - REDIS_ARGS=--save 60 1 --appendonly yes --appendfsync everysec
+      - FALKORDB_DATA_PATH=/data
       - REDIS_PASSWORD=${FALKORDB_PASSWORD:-}
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]


### PR DESCRIPTION
## Problem

FalkorDB's entrypoint script (`run.sh`) always appends `--dir $FALKORDB_DATA_PATH` **after** `$REDIS_ARGS`, so the `--dir /data` in `REDIS_ARGS` is silently overridden by the default `FALKORDB_DATA_PATH=/var/lib/falkordb/data`.

This means Redis writes its RDB dumps and AOF files to `/var/lib/falkordb/data` (ephemeral container filesystem) instead of `/data` (the Docker volume). On any container restart or recreate, all FalkorDB graph data is lost.

The failure is silent — FalkorDB comes back healthy with `memory_count=0` while Qdrant still has all vectors, making it look like a FalkorDB bug rather than a persistence misconfiguration.

## Fix

- Remove `--dir /data` from `REDIS_ARGS` (it was being ignored anyway)
- Set `FALKORDB_DATA_PATH=/data` so the entrypoint's own `--dir` flag points to the volume mount

## Verification

After this change:
- `redis-cli CONFIG GET dir` returns `/data` (the volume) instead of `/var/lib/falkordb/data`
- `BGSAVE` writes to the volume-mounted path
- Data survives container restarts