### PR TITLE
test(locomo): make cat5 judge fixture deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,6 @@ Reference point:
 | AutoMem `locomo` judge on | 87.56% |
 
 > **Methodology note:** We do not present this as a strict leaderboard claim. The published CORE number is a useful reference point, but the public LoCoMo setups are not perfectly apples-to-apples, especially around category-5 handling. AutoMem is above that published reference on the `locomo-mini` categories 1-4 run and below it on the full judge-enabled run.
->
 > **History note:** Earlier versions reported 90.53%, but that included two evaluator bugs: temporal matching compared the wrong text (false negatives) and category 5 matched empty strings (false positives). See [`benchmarks/EXPERIMENT_LOG.md`](benchmarks/EXPERIMENT_LOG.md) for the corrected timeline.
 
 Run benchmarks: `make bench-eval BENCH=locomo-mini CONFIG=baseline` (quick) or `BENCH_JUDGE_MODEL=gpt-4o make bench-eval BENCH=locomo CONFIG=baseline` (full, includes category 5)

--- a/tests/test_locomo_cat5_judge.py
+++ b/tests/test_locomo_cat5_judge.py
@@ -28,11 +28,14 @@ def locomo_module() -> Any:
 
 
 @pytest.fixture()
-def locomo_evaluator(locomo_module: Any) -> Any:
+def locomo_evaluator(locomo_module: Any, monkeypatch: pytest.MonkeyPatch) -> Any:
+    monkeypatch.delenv("BENCH_JUDGE_MODEL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     config = locomo_module.LoCoMoConfig()
     config.judge_model = None
     evaluator = locomo_module.LoCoMoEvaluator(config)
     evaluator.openai_client = None
+    evaluator.has_openai_api_key = False
     evaluator.use_embedding_similarity = False
     return evaluator
 


### PR DESCRIPTION
## Summary
- clear `BENCH_JUDGE_MODEL` and `OPENAI_API_KEY` before building the LoCoMo test evaluator fixture
- force the fixture into a judge-off / no-OpenAI baseline so env state cannot leak into tests
- remove the blank blockquote line in the README to avoid MD028

## Test Plan
- `make test`
- result: `185 passed, 1 skipped, 12 deselected`

Follow-up to the already-merged cat-5 judge work so we can keep moving without reopening the larger PR.