### PR TITLE
chore(ops): add deploy-freshness check for Railway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ help:
 	@echo "Deployment:"
 	@echo "  make deploy       - Deploy to Railway"
 	@echo "  make status       - Check deployment status"
-	@echo "  make deploy-check - Compare deployed vs main (maintainers only, needs Railway CLI)"
+	@echo "  make deploy-check - Compare deployed vs main (maintainers only, needs Railway CLI and gh)"
 
 # Set up development environment
 install:
@@ -106,8 +106,10 @@ status:
 
 # Compare deployed commit vs origin/main HEAD (detect stale deploys)
 deploy-check:
-	@./scripts/deploy_check.sh memory-service
-	@./scripts/deploy_check.sh automem-mcp-sse
+	@rc=0; \
+	./scripts/deploy_check.sh memory-service   || rc=1; \
+	./scripts/deploy_check.sh automem-mcp-sse  || rc=1; \
+	exit $$rc
 
 # Run LoCoMo benchmark (local)
 test-locomo:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Makefile - Development commands
-.PHONY: help install dev test fmt lint test-integration test-live test-locomo test-locomo-live test-longmemeval test-longmemeval-live test-longmemeval-watch clean logs deploy bench-health
+.PHONY: help install dev test fmt lint test-integration test-live test-locomo test-locomo-live test-longmemeval test-longmemeval-live test-longmemeval-watch clean logs deploy deploy-check bench-health
 
 # Default target
 help:
@@ -33,8 +33,9 @@ help:
 	@echo "  make test-longmemeval-watch - Full LongMemEval with notifications"
 	@echo ""
 	@echo "Deployment:"
-	@echo "  make deploy     - Deploy to Railway"
-	@echo "  make status     - Check deployment status"
+	@echo "  make deploy       - Deploy to Railway"
+	@echo "  make status       - Check deployment status"
+	@echo "  make deploy-check - Compare deployed vs main (maintainers only, needs Railway CLI)"
 
 # Set up development environment
 install:
@@ -102,6 +103,11 @@ deploy:
 status:
 	@echo "📊 Checking deployment status..."
 	railway status || railway logs
+
+# Compare deployed commit vs origin/main HEAD (detect stale deploys)
+deploy-check:
+	@./scripts/deploy_check.sh memory-service
+	@./scripts/deploy_check.sh automem-mcp-sse
 
 # Run LoCoMo benchmark (local)
 test-locomo:

--- a/scripts/deploy_check.sh
+++ b/scripts/deploy_check.sh
@@ -11,7 +11,6 @@ set -euo pipefail
 
 SERVICE="${1:-memory-service}"
 QUIET="${DEPLOY_CHECK_QUIET:-0}"
-WORKSPACE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 MAX_AGE_HOURS="${DEPLOY_CHECK_MAX_AGE:-24}"
 
 log() { [[ "$QUIET" == "1" ]] || echo "$@"; }
@@ -29,7 +28,7 @@ fi
 
 log "🔍 Checking deploy freshness for service: $SERVICE"
 
-deploy_json=$(railway deployment list --json --service "$SERVICE" --limit 5 2>/dev/null) || {
+deploy_json=$(railway deployment list --json --service "$SERVICE" 2>/dev/null) || {
     err "Failed to list deployments for $SERVICE. Is the Railway CLI linked?"
     exit 2
 }
@@ -101,19 +100,19 @@ print(int(datetime.fromisoformat(ts).timestamp()))
     fi
 fi
 
-echo ""
-echo "⚠️  $SERVICE is BEHIND origin/main"
-echo "   Deployed commit:  $deploy_short ($deploy_ts)"
-echo "   main HEAD:        $main_short"
-[[ -n "$behind_count" ]] && echo "   Commits behind:   $behind_count"
-[[ -n "$age_hours" ]]    && echo "   Deploy age:       ${age_hours}h"
-echo ""
+log ""
+log "⚠️  $SERVICE is BEHIND origin/main"
+log "   Deployed commit:  $deploy_short ($deploy_ts)"
+log "   main HEAD:        $main_short"
+[[ -n "$behind_count" ]] && log "   Commits behind:   $behind_count"
+[[ -n "$age_hours" ]]    && log "   Deploy age:       ${age_hours}h"
+log ""
 
 if [[ -n "$age_hours" ]] && (( age_hours > MAX_AGE_HOURS )); then
-    echo "🚨 Deploy is ${age_hours}h old (threshold: ${MAX_AGE_HOURS}h)"
-    echo "   Railway's GitHub integration may have disconnected."
-    echo "   Fix: Railway dashboard → $SERVICE → Settings → Source → Reconnect repo"
-    echo ""
+    log "🚨 Deploy is ${age_hours}h old (threshold: ${MAX_AGE_HOURS}h)"
+    log "   Railway's GitHub integration may have disconnected."
+    log "   Fix: Railway dashboard → $SERVICE → Settings → Source → Reconnect repo"
+    log ""
 fi
 
 exit 1

--- a/scripts/deploy_check.sh
+++ b/scripts/deploy_check.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Compare the latest Railway deployment commit against origin/main HEAD
+# to detect when Railway's GitHub integration silently disconnects.
+#
+# Usage:
+#   ./scripts/deploy_check.sh                    # check memory-service (default)
+#   ./scripts/deploy_check.sh automem-mcp-sse    # check a specific service
+#   DEPLOY_CHECK_QUIET=1 ./scripts/deploy_check.sh  # exit code only (for CI)
+
+set -euo pipefail
+
+SERVICE="${1:-memory-service}"
+QUIET="${DEPLOY_CHECK_QUIET:-0}"
+WORKSPACE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MAX_AGE_HOURS="${DEPLOY_CHECK_MAX_AGE:-24}"
+
+log() { [[ "$QUIET" == "1" ]] || echo "$@"; }
+err() { echo "❌ $*" >&2; }
+
+if ! command -v railway &>/dev/null; then
+    err "railway CLI not found. Install: https://docs.railway.app/guides/cli"
+    exit 2
+fi
+
+if ! command -v gh &>/dev/null; then
+    err "gh CLI not found. Install: https://cli.github.com"
+    exit 2
+fi
+
+log "🔍 Checking deploy freshness for service: $SERVICE"
+
+deploy_json=$(railway deployment list --json --service "$SERVICE" --limit 5 2>/dev/null) || {
+    err "Failed to list deployments for $SERVICE. Is the Railway CLI linked?"
+    exit 2
+}
+
+deploy_commit=$(echo "$deploy_json" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for d in data:
+    if d.get('status') == 'SUCCESS':
+        print(d.get('meta', {}).get('commitHash', ''))
+        break
+" 2>/dev/null)
+
+deploy_ts=$(echo "$deploy_json" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for d in data:
+    if d.get('status') == 'SUCCESS':
+        print(d.get('createdAt', ''))
+        break
+" 2>/dev/null)
+
+if [[ -z "$deploy_commit" ]]; then
+    err "No successful deployment found for $SERVICE"
+    exit 1
+fi
+
+repo_slug=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) || {
+    err "Failed to detect GitHub repo. Run from within the repo directory."
+    exit 2
+}
+
+main_sha=$(gh api "repos/$repo_slug/commits/main" --jq .sha 2>/dev/null) || {
+    err "Failed to fetch HEAD of main from GitHub."
+    exit 2
+}
+
+deploy_short="${deploy_commit:0:7}"
+main_short="${main_sha:0:7}"
+
+if [[ "$main_sha" == "$deploy_commit"* ]] || [[ "$deploy_commit" == "$main_sha"* ]]; then
+    log "✅ $SERVICE is up to date (deployed: $deploy_short, main: $main_short)"
+    exit 0
+fi
+
+git fetch origin main --quiet 2>/dev/null || true
+
+is_ancestor=0
+if git merge-base --is-ancestor "$deploy_commit" origin/main 2>/dev/null; then
+    is_ancestor=1
+fi
+
+behind_count=""
+if [[ "$is_ancestor" == "1" ]]; then
+    behind_count=$(git rev-list --count "$deploy_commit..origin/main" 2>/dev/null || echo "?")
+fi
+
+age_hours=""
+if [[ -n "$deploy_ts" ]]; then
+    deploy_epoch=$(python3 -c "
+from datetime import datetime, timezone
+ts = '$deploy_ts'.replace('Z', '+00:00')
+print(int(datetime.fromisoformat(ts).timestamp()))
+" 2>/dev/null || echo "")
+    if [[ -n "$deploy_epoch" ]]; then
+        now_epoch=$(date +%s)
+        age_secs=$((now_epoch - deploy_epoch))
+        age_hours=$((age_secs / 3600))
+    fi
+fi
+
+echo ""
+echo "⚠️  $SERVICE is BEHIND origin/main"
+echo "   Deployed commit:  $deploy_short ($deploy_ts)"
+echo "   main HEAD:        $main_short"
+[[ -n "$behind_count" ]] && echo "   Commits behind:   $behind_count"
+[[ -n "$age_hours" ]]    && echo "   Deploy age:       ${age_hours}h"
+echo ""
+
+if [[ -n "$age_hours" ]] && (( age_hours > MAX_AGE_HOURS )); then
+    echo "🚨 Deploy is ${age_hours}h old (threshold: ${MAX_AGE_HOURS}h)"
+    echo "   Railway's GitHub integration may have disconnected."
+    echo "   Fix: Railway dashboard → $SERVICE → Settings → Source → Reconnect repo"
+    echo ""
+fi
+
+exit 1


### PR DESCRIPTION
## Summary

- Adds `scripts/deploy_check.sh` — compares latest Railway deployment commit against `origin/main` HEAD
- Adds `make deploy-check` target that checks both `memory-service` and `automem-mcp-sse`
- Exits 0 if up to date, exits 1 if behind, with commit-behind count and deploy age
- Flags deploys older than 24h as potential Railway GitHub integration disconnects

## Context

Railway's GitHub App integration silently disconnects with no alert or dashboard warning. We discovered this when release 0.15.0 was merged but Railway didn't redeploy — the connection had been broken since ~March 10 (5 PRs went undeployed). This check makes stale deploys detectable before they become incidents.

## Test plan

- [x] Tested against live Railway — correctly reports memory-service as behind and automem-mcp-sse as up to date
- [x] Graceful failure when `railway` or `gh` CLI not installed (exits 2 with message)
- [x] Safe for public repo users — maintainer-only, opt-in, read-only, no mutations

Made with [Cursor](https://cursor.com)