### PR TITLE
fix(runtime): support OPENAI_BASE_URL for classification client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ AutoMem uses a provider pattern with multiple embedding backends:
 2. **OpenAI / OpenAI-compatible** (`openai:text-embedding-3-small`) - If `OPENAI_API_KEY` is set
    - Semantic embeddings via API, truncated to `VECTOR_SIZE` via Matryoshka (OpenAI native only)
    - If `VECTOR_SIZE` > 1536, auto-upgrades to `text-embedding-3-large` (set `EMBEDDING_MODEL=text-embedding-3-large` to silence)
-   - Supports any OpenAI-compatible endpoint via `OPENAI_BASE_URL` (OpenRouter, LiteLLM, vLLM, Azure, etc.)
+   - Supports any OpenAI-compatible endpoint via `OPENAI_BASE_URL` (OpenRouter, LiteLLM, vLLM, Azure, etc.) for both embeddings and classification/enrichment LLM calls
    - The `dimensions` parameter is only sent to OpenAI's own API; omitted for third-party providers
 
 3. **Ollama** (`ollama:nomic-embed-text`) - If `OLLAMA_BASE_URL` or `OLLAMA_MODEL` is configured
@@ -236,7 +236,7 @@ ADMIN_API_TOKEN=             # For admin endpoints
 # Embedding configuration
 EMBEDDING_PROVIDER=auto      # auto|voyage|openai|ollama|local|placeholder
 OPENAI_API_KEY=              # For OpenAI or compatible provider (optional)
-OPENAI_BASE_URL=             # Custom endpoint for OpenAI-compatible APIs (optional)
+OPENAI_BASE_URL=             # Custom endpoint for OpenAI-compatible APIs used by embeddings and classification/enrichment (optional)
 
 # Consolidation intervals (seconds)
 CONSOLIDATION_DECAY_INTERVAL_SECONDS=86400    # 1 day (default)

--- a/automem/service_runtime.py
+++ b/automem/service_runtime.py
@@ -24,7 +24,11 @@ def init_openai(
         return
 
     try:
-        state.openai_client = openai_cls(api_key=api_key)
+        openai_base_url = (get_env_fn("OPENAI_BASE_URL") or "").strip() or None
+        client_kwargs = {"api_key": api_key}
+        if openai_base_url:
+            client_kwargs["base_url"] = openai_base_url
+        state.openai_client = openai_cls(**client_kwargs)
         logger.info("OpenAI client initialized for memory type classification")
     except Exception:
         logger.exception("Failed to initialize OpenAI client")

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -57,7 +57,7 @@ AutoMem supports five embedding backends with automatic fallback.
 | `VOYAGE_API_KEY` | Voyage API key (for Voyage provider) | - | `pa-...` |
 | `VOYAGE_MODEL` | Voyage embedding model | `voyage-4` | `voyage-4`, `voyage-4-large`, `voyage-4-lite` |
 | `OPENAI_API_KEY` | API key (OpenAI or compatible provider) | - | `sk-proj-...` |
-| `OPENAI_BASE_URL` | Custom base URL for OpenAI-compatible APIs | - | `https://openrouter.ai/api/v1` |
+| `OPENAI_BASE_URL` | Custom base URL for OpenAI-compatible APIs (embeddings and classification/enrichment LLM calls) | - | `https://openrouter.ai/api/v1` |
 | `OLLAMA_BASE_URL` | Ollama API base URL | `http://localhost:11434` | `http://localhost:11434` |
 | `OLLAMA_MODEL` | Ollama embedding model | `nomic-embed-text` | `nomic-embed-text` |
 | `OLLAMA_TIMEOUT` | Ollama request timeout (seconds) | `30` | `10`, `30`, `60` |

--- a/tests/test_service_runtime.py
+++ b/tests/test_service_runtime.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from automem.service_runtime import init_openai
+
+
+def test_init_openai_passes_base_url_when_configured():
+    state = SimpleNamespace(openai_client=None)
+    logger = Mock()
+    openai_cls = Mock()
+    openai_client = Mock()
+    openai_cls.return_value = openai_client
+
+    env = {
+        "OPENAI_API_KEY": "test-key",
+        "OPENAI_BASE_URL": " https://openrouter.ai/api/v1 ",
+    }
+
+    init_openai(
+        state=state,
+        logger=logger,
+        openai_cls=openai_cls,
+        get_env_fn=env.get,
+    )
+
+    openai_cls.assert_called_once_with(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+    )
+    assert state.openai_client is openai_client
+
+
+def test_init_openai_omits_base_url_when_unset():
+    state = SimpleNamespace(openai_client=None)
+    logger = Mock()
+    openai_cls = Mock()
+    openai_client = Mock()
+    openai_cls.return_value = openai_client
+
+    env = {
+        "OPENAI_API_KEY": "test-key",
+        "OPENAI_BASE_URL": "",
+    }
+
+    init_openai(
+        state=state,
+        logger=logger,
+        openai_cls=openai_cls,
+        get_env_fn=env.get,
+    )
+
+    openai_cls.assert_called_once_with(api_key="test-key")
+    assert state.openai_client is openai_client


### PR DESCRIPTION
## Summary

Fixes #96 by wiring `OPENAI_BASE_URL` into the runtime OpenAI client used for classification/enrichment, not just embeddings.

- Pass `base_url` to `init_openai()` when `OPENAI_BASE_URL` is configured
- Preserve existing behavior when the variable is unset
- Add direct unit tests for both paths
- Clarify docs that `OPENAI_BASE_URL` affects embeddings and classification/enrichment LLM calls

## Why this is safe

- No behavior change unless `OPENAI_BASE_URL` is set
- Same OpenAI client class, same API key path, same model config
- Does not touch recall/retrieval/scoring paths, so no benchmark risk

## Test plan

- [x] `tests/test_service_runtime.py`
- [x] Full unit suite: 195 passed, 1 skipped

Closes #96

Made with [Cursor](https://cursor.com)