### PR TITLE
Always return 200 from health check endpoint

### DIFF
--- a/mcp-sse-server/server.js
+++ b/mcp-sse-server/server.js
@@ -792,7 +792,11 @@ export function createApp() {
       request_id: req.requestId,
     };
 
-    res.status(healthState.status === 'healthy' ? 200 : 503).json(body);
+    // Always return 200 so Railway (and other orchestrators) consider this
+    // service healthy as long as the process is running.  Upstream reachability
+    // is reported in the response body for observability but must not block the
+    // platform health-check — the upstream may start after this service.
+    res.status(200).json(body);
   });
 
 // Helper: validate and extract token from multiple sources

--- a/mcp-sse-server/server.js
+++ b/mcp-sse-server/server.js
@@ -1057,8 +1057,19 @@ const port = process.env.PORT || 8080;
 
 // Avoid side effects on import (tests/tools may import this module).
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const endpoint = process.env.AUTOMEM_API_URL || process.env.AUTOMEM_ENDPOINT || 'http://127.0.0.1:8001';
+  const hasToken = !!process.env.AUTOMEM_API_TOKEN;
+  if (!hasToken) {
+    log('warn', 'startup_missing_token', { msg: 'AUTOMEM_API_TOKEN is not set — upstream health probes will report degraded' });
+  }
+  if (endpoint === 'http://127.0.0.1:8001' && !process.env.AUTOMEM_API_URL && !process.env.AUTOMEM_ENDPOINT) {
+    log('warn', 'startup_default_endpoint', {
+      msg: 'No AUTOMEM_API_URL or AUTOMEM_ENDPOINT set — defaulting to http://127.0.0.1:8001 which will not work on Railway',
+      hint: 'Set AUTOMEM_API_URL to your AutoMem API service URL (e.g. http://automem.railway.internal:8001)',
+    });
+  }
   const app = createApp();
   app.listen(port, () => {
-    log('info', 'mcp_bridge_listening', { port });
+    log('info', 'mcp_bridge_listening', { port, upstream: sanitizeUrlForLog(endpoint), hasToken });
   });
 }


### PR DESCRIPTION
## Summary
Modified the health check endpoint to always return HTTP 200 status, regardless of upstream service health. The upstream health status is still reported in the response body for observability purposes.

## Key Changes
- Changed health check endpoint to return HTTP 200 status unconditionally instead of returning 503 when upstream is unhealthy
- Upstream reachability information remains available in the response body for monitoring and debugging
- This allows container orchestrators like Railway to consider the service healthy as long as the process is running, preventing unnecessary restarts when upstream dependencies are temporarily unavailable

## Implementation Details
The health check endpoint now decouples the HTTP status code from upstream health status. This is important because upstream services may start after this service, and returning 503 would cause orchestrators to mark the service as unhealthy and potentially restart it prematurely. The actual health state is still communicated through the response body for observability.

https://claude.ai/code/session_015SyVKdDa2jaFLBhb9GpTeA