### PR TITLE
[codex] fix issue #144 memory-by-tag pagination and bulk delete

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -678,15 +678,35 @@ Filter memories by tags.
 **Query Parameters:**
 
 - `tags` - One or more tags (multiple `tags` params or comma-separated)
-- `limit` - Max results (default 50)
+- `limit` - Max results per page (default 20, max 200)
+- `offset` - Zero-based page offset (default 0)
 
 **Example:**
 
 ```bash
-GET /memory/by-tag?tags=deployment&tags=success&limit=20
+GET /memory/by-tag?tags=deployment&tags=success&limit=20&offset=0
 ```
 
-Returns most recent/important memories matching any requested tag.
+Returns the current page of most important/recent memories matching any requested tag, plus
+pagination metadata (`limit`, `offset`, `has_more`).
+
+---
+
+#### `DELETE /memory/by-tag`
+
+Delete all memories matching any requested tag.
+
+**Query Parameters:**
+
+- `tags` - One or more tags (multiple `tags` params or comma-separated)
+
+**Example:**
+
+```bash
+DELETE /memory/by-tag?tags=deployment&tags=success
+```
+
+Returns a success payload with `deleted_count`.
 
 ---
 

--- a/automem/api/memory.py
+++ b/automem/api/memory.py
@@ -117,6 +117,23 @@ def _delete_qdrant_points(
         logger.exception("Failed to delete vectors for %d memories", len(memory_ids))
 
 
+def _delete_graph_memories(
+    *,
+    graph: Any,
+    memory_ids: List[str],
+    logger: Any,
+    abort_fn: Any,
+) -> None:
+    if not memory_ids:
+        return
+
+    try:
+        graph.query("MATCH (m:Memory) WHERE m.id IN $ids DETACH DELETE m", {"ids": memory_ids})
+    except Exception:
+        logger.exception("Bulk delete by tag failed for %d memories", len(memory_ids))
+        abort_fn(500, description="Failed to delete memories by tag")
+
+
 def create_memory_blueprint(
     store_memory: Callable[[], Any],
     update_memory: Callable[[str], Any],
@@ -144,7 +161,7 @@ def create_memory_blueprint(
     def _by_tag() -> Any:
         if request.method == "DELETE":
             if delete_by_tag is None:
-                abort(405)
+                return by_tag()
             return delete_by_tag()
         return by_tag()
 
@@ -675,8 +692,12 @@ def create_memory_blueprint_full(
                 if not memory_ids:
                     break
 
-                for memory_id in memory_ids:
-                    graph.query("MATCH (m:Memory {id: $id}) DETACH DELETE m", {"id": memory_id})
+                _delete_graph_memories(
+                    graph=graph,
+                    memory_ids=memory_ids,
+                    logger=logger,
+                    abort_fn=abort,
+                )
 
                 _delete_qdrant_points(
                     qdrant_client=get_qdrant_client(),

--- a/automem/api/memory.py
+++ b/automem/api/memory.py
@@ -26,12 +26,104 @@ def _validate_memory_id(memory_id: str) -> None:
         abort(400, description="memory_id must be a valid UUID")
 
 
+def _parse_by_tag_request(
+    *,
+    request_args: Any,
+    normalize_tag_list_fn: Callable[[Any], List[str]],
+    abort_fn: Callable[..., Any],
+) -> tuple[List[str], int, int]:
+    raw_tags = request_args.getlist("tags") or request_args.get("tags")
+    tags = normalize_tag_list_fn(raw_tags)
+    if not tags:
+        abort_fn(400, description="'tags' query parameter is required")
+
+    try:
+        limit = int(request_args.get("limit", 20))
+    except (TypeError, ValueError):
+        limit = 20
+    limit = max(1, min(limit, 200))
+
+    try:
+        offset = int(request_args.get("offset", 0))
+    except (TypeError, ValueError):
+        offset = 0
+    offset = max(0, offset)
+
+    return tags, limit, offset
+
+
+def _load_memories_by_tag_page(
+    *,
+    graph: Any,
+    tags: List[str],
+    limit: int,
+    offset: int,
+    serialize_node_fn: Callable[[Any], Dict[str, Any]],
+    parse_metadata_field_fn: Callable[[Any], Any],
+    logger: Any,
+    abort_fn: Callable[..., Any],
+) -> tuple[List[Dict[str, Any]], bool]:
+    params = {
+        "tags": [tag.lower() for tag in tags],
+        "offset": offset,
+        "limit_plus_one": limit + 1,
+    }
+    query = """
+        MATCH (m:Memory)
+        WHERE ANY(tag IN coalesce(m.tags, []) WHERE toLower(tag) IN $tags)
+        RETURN m
+        ORDER BY m.importance DESC, m.timestamp DESC, m.id ASC
+        SKIP $offset
+        LIMIT $limit_plus_one
+    """
+    try:
+        result = graph.query(query, params)
+    except Exception:
+        logger.exception("Tag search failed")
+        abort_fn(500, description="Failed to search by tag")
+
+    rows = list(getattr(result, "result_set", []) or [])
+    has_more = len(rows) > limit
+    memories: List[Dict[str, Any]] = []
+    for row in rows[:limit]:
+        data = serialize_node_fn(row[0])
+        data["metadata"] = parse_metadata_field_fn(data.get("metadata"))
+        memories.append(data)
+
+    return memories, has_more
+
+
+def _delete_qdrant_points(
+    *,
+    qdrant_client: Any,
+    collection_name: str,
+    memory_ids: List[str],
+    logger: Any,
+) -> None:
+    if qdrant_client is None or not memory_ids:
+        return
+
+    selector: Any = {"points": memory_ids}
+    try:
+        from qdrant_client.http import models as http_models  # type: ignore
+
+        selector = http_models.PointIdsList(points=memory_ids)
+    except Exception:
+        pass
+
+    try:
+        qdrant_client.delete(collection_name=collection_name, points_selector=selector)
+    except Exception:
+        logger.exception("Failed to delete vectors for %d memories", len(memory_ids))
+
+
 def create_memory_blueprint(
     store_memory: Callable[[], Any],
     update_memory: Callable[[str], Any],
     delete_memory: Callable[[str], Any],
     by_tag: Callable[[], Any],
     associate: Callable[[], Any],
+    delete_by_tag: Optional[Callable[[], Any]] = None,
 ) -> Blueprint:
     """Compatibility wrapper around the legacy handlers in app.py."""
     bp = Blueprint("memory", __name__)
@@ -48,8 +140,12 @@ def create_memory_blueprint(
     def _delete(memory_id: str) -> Any:
         return delete_memory(memory_id)
 
-    @bp.route("/memory/by-tag", methods=["GET"])
+    @bp.route("/memory/by-tag", methods=["GET", "DELETE"])
     def _by_tag() -> Any:
+        if request.method == "DELETE":
+            if delete_by_tag is None:
+                abort(405)
+            return delete_by_tag()
         return by_tag()
 
     @bp.route("/associate", methods=["POST"])
@@ -541,62 +637,68 @@ def create_memory_blueprint_full(
 
         graph.query("MATCH (m:Memory {id: $id}) DETACH DELETE m", {"id": memory_id})
 
-        qdrant_client = get_qdrant_client()
-        if qdrant_client is not None:
-            try:
-                selector = {"points": [memory_id]}
-                if hasattr(qdrant_client, "http"):
-                    # Try to use HTTP models selector if available
-                    try:
-                        from qdrant_client.http import models as http_models  # type: ignore
-
-                        selector = http_models.PointIdsList(points=[memory_id])
-                    except Exception as e:
-                        logger.warning(f"Failed to import qdrant_client.http.models: {e}")
-                qdrant_client.delete(collection_name=collection_name, points_selector=selector)
-            except Exception:
-                logger.exception("Failed to delete vector for memory %s", memory_id)
+        _delete_qdrant_points(
+            qdrant_client=get_qdrant_client(),
+            collection_name=collection_name,
+            memory_ids=[memory_id],
+            logger=logger,
+        )
 
         return jsonify({"status": "success", "memory_id": memory_id})
 
-    @bp.route("/memory/by-tag", methods=["GET"])
+    @bp.route("/memory/by-tag", methods=["GET", "DELETE"])
     def by_tag() -> Any:
-        raw_tags = request.args.getlist("tags") or request.args.get("tags")
-        tags = normalize_tag_list(raw_tags)
-        if not tags:
-            abort(400, description="'tags' query parameter is required")
-
-        try:
-            limit = int(request.args.get("limit", 20))
-        except (TypeError, ValueError):
-            limit = 20
-        limit = max(1, min(limit, 200))
-
         graph = get_memory_graph()
         if graph is None:
             abort(503, description="FalkorDB is unavailable")
 
-        params = {"tags": [tag.lower() for tag in tags], "limit": limit}
-        query = """
-            MATCH (m:Memory)
-            WHERE ANY(tag IN coalesce(m.tags, []) WHERE toLower(tag) IN $tags)
-            RETURN m
-            ORDER BY m.importance DESC, m.timestamp DESC
-            LIMIT $limit
-        """
-        try:
-            result = graph.query(query, params)
-        except Exception:
-            logger.exception("Tag search failed")
-            abort(500, description="Failed to search by tag")
+        tags, limit, offset = _parse_by_tag_request(
+            request_args=request.args,
+            normalize_tag_list_fn=normalize_tag_list,
+            abort_fn=abort,
+        )
 
-        memories: List[Dict[str, Any]] = []
-        for row in getattr(result, "result_set", []) or []:
-            data = serialize_node(row[0])
-            data["metadata"] = parse_metadata_field(data.get("metadata"))
-            memories.append(data)
+        if request.method == "DELETE":
+            deleted_count = 0
+            while True:
+                memories, _ = _load_memories_by_tag_page(
+                    graph=graph,
+                    tags=tags,
+                    limit=200,
+                    offset=0,
+                    serialize_node_fn=serialize_node,
+                    parse_metadata_field_fn=parse_metadata_field,
+                    logger=logger,
+                    abort_fn=abort,
+                )
+                memory_ids = [str(memory.get("id")) for memory in memories if memory.get("id")]
+                if not memory_ids:
+                    break
 
-        # Update last_accessed for retrieved memories
+                for memory_id in memory_ids:
+                    graph.query("MATCH (m:Memory {id: $id}) DETACH DELETE m", {"id": memory_id})
+
+                _delete_qdrant_points(
+                    qdrant_client=get_qdrant_client(),
+                    collection_name=collection_name,
+                    memory_ids=memory_ids,
+                    logger=logger,
+                )
+                deleted_count += len(memory_ids)
+
+            return jsonify({"status": "success", "tags": tags, "deleted_count": deleted_count})
+
+        memories, has_more = _load_memories_by_tag_page(
+            graph=graph,
+            tags=tags,
+            limit=limit,
+            offset=offset,
+            serialize_node_fn=serialize_node,
+            parse_metadata_field_fn=parse_metadata_field,
+            logger=logger,
+            abort_fn=abort,
+        )
+
         if on_access and memories:
             accessed_ids = [str(m.get("id")) for m in memories if m.get("id")]
             if accessed_ids:
@@ -610,6 +712,9 @@ def create_memory_blueprint_full(
                 "status": "success",
                 "tags": tags,
                 "count": len(memories),
+                "limit": limit,
+                "offset": offset,
+                "has_more": has_more,
                 "memories": memories,
             }
         )

--- a/automem/api/runtime_memory_routes.py
+++ b/automem/api/runtime_memory_routes.py
@@ -8,6 +8,98 @@ MEMORY_CONTENT_SOFT_LIMIT = 500
 MEMORY_CONTENT_HARD_LIMIT = 2000
 
 
+def _parse_by_tag_request(
+    *,
+    request_obj: Any,
+    normalize_tag_list_fn: Any,
+    abort_fn: Any,
+) -> tuple[List[str], int, int]:
+    raw_tags = request_obj.args.getlist("tags") or request_obj.args.get("tags")
+    tags = normalize_tag_list_fn(raw_tags)
+    if not tags:
+        abort_fn(400, description="'tags' query parameter is required")
+
+    try:
+        limit = int(request_obj.args.get("limit", 20))
+    except (TypeError, ValueError):
+        limit = 20
+    limit = max(1, min(limit, 200))
+
+    try:
+        offset = int(request_obj.args.get("offset", 0))
+    except (TypeError, ValueError):
+        offset = 0
+    offset = max(0, offset)
+
+    return tags, limit, offset
+
+
+def _load_memories_by_tag_page(
+    *,
+    graph: Any,
+    tags: List[str],
+    limit: int,
+    offset: int,
+    serialize_node_fn: Any,
+    parse_metadata_field_fn: Any,
+    logger: Any,
+    abort_fn: Any,
+) -> tuple[List[Dict[str, Any]], bool]:
+    params = {
+        "tags": [tag.lower() for tag in tags],
+        "offset": offset,
+        "limit_plus_one": limit + 1,
+    }
+    query = """
+        MATCH (m:Memory)
+        WHERE ANY(tag IN coalesce(m.tags, []) WHERE toLower(tag) IN $tags)
+        RETURN m
+        ORDER BY m.importance DESC, m.timestamp DESC, m.id ASC
+        SKIP $offset
+        LIMIT $limit_plus_one
+    """
+
+    try:
+        result = graph.query(query, params)
+    except Exception:
+        logger.exception("Tag search failed")
+        abort_fn(500, description="Failed to search by tag")
+
+    rows = list(getattr(result, "result_set", []) or [])
+    has_more = len(rows) > limit
+    memories: List[Dict[str, Any]] = []
+    for row in rows[:limit]:
+        data = serialize_node_fn(row[0])
+        data["metadata"] = parse_metadata_field_fn(data.get("metadata"))
+        memories.append(data)
+
+    return memories, has_more
+
+
+def _delete_qdrant_points(
+    *,
+    qdrant_client: Any,
+    collection_name: str,
+    memory_ids: List[str],
+    logger: Any,
+) -> None:
+    if qdrant_client is None or not memory_ids:
+        return
+
+    selector: Any = {"points": memory_ids}
+    try:
+        from qdrant_client.http import models as http_models  # type: ignore
+
+        selector = http_models.PointIdsList(points=memory_ids)
+    except Exception:
+        pass
+
+    try:
+        qdrant_client.delete(collection_name=collection_name, points_selector=selector)
+    except Exception:
+        logger.exception("Failed to delete vectors for %d memories", len(memory_ids))
+
+
 def store_memory(
     *,
     request_obj: Any,
@@ -485,16 +577,13 @@ def delete_memory(
 
     graph.query("MATCH (m:Memory {id: $id}) DETACH DELETE m", {"id": memory_id})
 
-    qdrant_client = get_qdrant_client_fn()
-    if qdrant_client is not None:
-        try:
-            if qdrant_models_obj is not None:
-                selector = qdrant_models_obj.PointIdsList(points=[memory_id])
-            else:
-                selector = {"points": [memory_id]}
-            qdrant_client.delete(collection_name=collection_name, points_selector=selector)
-        except Exception:
-            logger.exception("Failed to delete vector for memory %s", memory_id)
+    _ = qdrant_models_obj
+    _delete_qdrant_points(
+        qdrant_client=get_qdrant_client_fn(),
+        collection_name=collection_name,
+        memory_ids=[memory_id],
+        logger=logger,
+    )
 
     return jsonify_fn({"status": "success", "memory_id": memory_id})
 
@@ -509,47 +598,75 @@ def memories_by_tag(
     abort_fn: Any,
     jsonify_fn: Any,
     logger: Any,
+    get_qdrant_client_fn: Any = None,
+    collection_name: str = "",
+    on_access_fn: Any = None,
 ) -> Any:
-    raw_tags = request_obj.args.getlist("tags") or request_obj.args.get("tags")
-    tags = normalize_tag_list_fn(raw_tags)
-    if not tags:
-        abort_fn(400, description="'tags' query parameter is required")
-
-    try:
-        limit = int(request_obj.args.get("limit", 20))
-    except (TypeError, ValueError):
-        limit = 20
-    limit = max(1, min(limit, 200))
-
     graph = get_memory_graph_fn()
     if graph is None:
         abort_fn(503, description="FalkorDB is unavailable")
 
-    params = {
-        "tags": [tag.lower() for tag in tags],
-        "limit": limit,
-    }
+    tags, limit, offset = _parse_by_tag_request(
+        request_obj=request_obj,
+        normalize_tag_list_fn=normalize_tag_list_fn,
+        abort_fn=abort_fn,
+    )
 
-    query = """
-        MATCH (m:Memory)
-        WHERE ANY(tag IN coalesce(m.tags, []) WHERE toLower(tag) IN $tags)
-        RETURN m
-        ORDER BY m.importance DESC, m.timestamp DESC
-        LIMIT $limit
-    """
+    if request_obj.method == "DELETE":
+        deleted_count = 0
+        while True:
+            memories, _ = _load_memories_by_tag_page(
+                graph=graph,
+                tags=tags,
+                limit=200,
+                offset=0,
+                serialize_node_fn=serialize_node_fn,
+                parse_metadata_field_fn=parse_metadata_field_fn,
+                logger=logger,
+                abort_fn=abort_fn,
+            )
+            memory_ids = [str(memory.get("id")) for memory in memories if memory.get("id")]
+            if not memory_ids:
+                break
 
-    try:
-        result = graph.query(query, params)
-    except Exception:
-        logger.exception("Tag search failed")
-        abort_fn(500, description="Failed to search by tag")
+            for memory_id in memory_ids:
+                graph.query("MATCH (m:Memory {id: $id}) DETACH DELETE m", {"id": memory_id})
 
-    memories: List[Dict[str, Any]] = []
-    for row in getattr(result, "result_set", []) or []:
-        data = serialize_node_fn(row[0])
-        data["metadata"] = parse_metadata_field_fn(data.get("metadata"))
-        memories.append(data)
+            if get_qdrant_client_fn and collection_name:
+                _delete_qdrant_points(
+                    qdrant_client=get_qdrant_client_fn(),
+                    collection_name=collection_name,
+                    memory_ids=memory_ids,
+                    logger=logger,
+                )
+            deleted_count += len(memory_ids)
+
+        return jsonify_fn({"status": "success", "tags": tags, "deleted_count": deleted_count})
+
+    memories, has_more = _load_memories_by_tag_page(
+        graph=graph,
+        tags=tags,
+        limit=limit,
+        offset=offset,
+        serialize_node_fn=serialize_node_fn,
+        parse_metadata_field_fn=parse_metadata_field_fn,
+        logger=logger,
+        abort_fn=abort_fn,
+    )
+
+    if on_access_fn and memories:
+        accessed_ids = [str(memory.get("id")) for memory in memories if memory.get("id")]
+        if accessed_ids:
+            on_access_fn(accessed_ids)
 
     return jsonify_fn(
-        {"status": "success", "tags": tags, "count": len(memories), "memories": memories}
+        {
+            "status": "success",
+            "tags": tags,
+            "count": len(memories),
+            "limit": limit,
+            "offset": offset,
+            "has_more": has_more,
+            "memories": memories,
+        }
     )

--- a/automem/api/runtime_memory_routes.py
+++ b/automem/api/runtime_memory_routes.py
@@ -100,6 +100,23 @@ def _delete_qdrant_points(
         logger.exception("Failed to delete vectors for %d memories", len(memory_ids))
 
 
+def _delete_graph_memories(
+    *,
+    graph: Any,
+    memory_ids: List[str],
+    logger: Any,
+    abort_fn: Any,
+) -> None:
+    if not memory_ids:
+        return
+
+    try:
+        graph.query("MATCH (m:Memory) WHERE m.id IN $ids DETACH DELETE m", {"ids": memory_ids})
+    except Exception:
+        logger.exception("Bulk delete by tag failed for %d memories", len(memory_ids))
+        abort_fn(500, description="Failed to delete memories by tag")
+
+
 def store_memory(
     *,
     request_obj: Any,
@@ -556,7 +573,6 @@ def delete_memory(
     memory_id: str,
     get_memory_graph_fn: Any,
     get_qdrant_client_fn: Any,
-    qdrant_models_obj: Any,
     collection_name: str,
     abort_fn: Any,
     jsonify_fn: Any,
@@ -577,7 +593,6 @@ def delete_memory(
 
     graph.query("MATCH (m:Memory {id: $id}) DETACH DELETE m", {"id": memory_id})
 
-    _ = qdrant_models_obj
     _delete_qdrant_points(
         qdrant_client=get_qdrant_client_fn(),
         collection_name=collection_name,
@@ -629,8 +644,12 @@ def memories_by_tag(
             if not memory_ids:
                 break
 
-            for memory_id in memory_ids:
-                graph.query("MATCH (m:Memory {id: $id}) DETACH DELETE m", {"id": memory_id})
+            _delete_graph_memories(
+                graph=graph,
+                memory_ids=memory_ids,
+                logger=logger,
+                abort_fn=abort_fn,
+            )
 
             if get_qdrant_client_fn and collection_name:
                 _delete_qdrant_points(

--- a/docs/API.md
+++ b/docs/API.md
@@ -32,8 +32,11 @@ Memory
 - DELETE `/memory/{id}`
   - Response: `{ "status": "success", "memory_id": "..." }`
 
-- GET `/memory/by-tag?tags=foo&tags=bar&limit=20`
-  - Response: `{ "status": "success", "tags": ["foo","bar"], "count": N, "memories": [...] }`
+- GET `/memory/by-tag?tags=foo&tags=bar&limit=20&offset=0`
+  - Response: `{ "status": "success", "tags": ["foo","bar"], "count": N, "limit": 20, "offset": 0, "has_more": false, "memories": [...] }`
+
+- DELETE `/memory/by-tag?tags=foo&tags=bar`
+  - Response: `{ "status": "success", "tags": ["foo","bar"], "deleted_count": N }`
 
 - POST `/associate`
   - Body: `{ "memory1_id": "...", "memory2_id": "...", "type": "RELATES_TO", "strength": 0.9 }`

--- a/tests/contracts/test_routes_contract.py
+++ b/tests/contracts/test_routes_contract.py
@@ -10,6 +10,7 @@ EXPECTED_ROUTE_METHODS = {
     ("PATCH", "/memory/<memory_id>"),
     ("DELETE", "/memory/<memory_id>"),
     ("GET", "/memory/by-tag"),
+    ("DELETE", "/memory/by-tag"),
     ("POST", "/associate"),
     ("GET", "/recall"),
     ("GET", "/startup-recall"),

--- a/tests/support/fake_graph.py
+++ b/tests/support/fake_graph.py
@@ -266,17 +266,16 @@ class FakeGraph:
                 if any(tag in tags for tag in memory_tags):
                     results.append(memory)
 
-            results.sort(
-                key=lambda memory: (
-                    float(memory.get("importance") or 0.0),
-                    str(memory.get("timestamp") or ""),
-                ),
-                reverse=True,
-            )
+            results.sort(key=lambda memory: str(memory.get("id") or ""))
+            results.sort(key=lambda memory: str(memory.get("timestamp") or ""), reverse=True)
+            results.sort(key=lambda memory: float(memory.get("importance") or 0.0), reverse=True)
 
-            limit_param = params.get("limit")
+            offset_param = params.get("offset")
+            offset = 0 if offset_param is None else max(0, int(offset_param))
+            limit_param = params.get("limit_plus_one", params.get("limit"))
             limit = len(results) if limit_param is None else int(limit_param)
-            return FakeResult([[FakeNode(memory)] for memory in results[:limit]])
+            paged = results[offset : offset + limit]
+            return FakeResult([[FakeNode(memory)] for memory in paged])
 
         # Bulk fetch for reembed
         if "MATCH (m:Memory)" in query and "RETURN m.id, m.content" in query:

--- a/tests/support/fake_graph.py
+++ b/tests/support/fake_graph.py
@@ -239,6 +239,17 @@ class FakeGraph:
                 return FakeResult([["deleted"]])
             return FakeResult([])
 
+        if "MATCH (m:Memory) WHERE m.id IN $ids DETACH DELETE m" in query:
+            deleted = []
+            for memory_id in params.get("ids") or []:
+                memory_id = str(memory_id)
+                if memory_id:
+                    self.deleted.append(memory_id)
+                if memory_id in self.memories:
+                    del self.memories[memory_id]
+                    deleted.append(memory_id)
+            return FakeResult([[memory_id] for memory_id in deleted])
+
         # Search by exact tag pattern
         if "MATCH (m:Memory)" in query and "$tag IN m.tags" in query:
             tag = str(params.get("tag") or "").strip().lower()

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -69,6 +69,10 @@ class MockQdrantClient:
             for point_id in points_selector.points:
                 if point_id in self.points:
                     del self.points[point_id]
+        elif isinstance(points_selector, dict):
+            for point_id in points_selector.get("points", []):
+                if point_id in self.points:
+                    del self.points[point_id]
 
     def scroll(self, collection_name, scroll_filter=None, limit=10, with_payload=True):
         """Mock scroll to support tag-only queries."""
@@ -720,6 +724,9 @@ def test_memory_by_tag_single(client, mock_state, auth_headers):
     data = response.get_json()
     assert data["status"] == "success"
     assert "memories" in data  # API returns 'memories' not 'results'
+    assert data["limit"] == 20
+    assert data["offset"] == 0
+    assert data["has_more"] is False
 
 
 def test_memory_by_tag_multiple(client, mock_state, auth_headers):
@@ -734,6 +741,101 @@ def test_memory_by_tag_no_tags(client, mock_state, auth_headers):
     """Test error when no tags provided."""
     response = client.get("/memory/by-tag", headers=auth_headers)
     assert response.status_code == 400
+
+
+def test_memory_by_tag_pagination(client, mock_state, auth_headers):
+    """Test offset pagination for /memory/by-tag."""
+    tag = "paged-tag"
+    timestamp = utc_now()
+    for i in range(205):
+        memory_id = f"00000000-0000-0000-0000-{i:012d}"
+        memory = {
+            "id": memory_id,
+            "content": f"Paged memory {i}",
+            "tags": [tag],
+            "importance": 0.5,
+            "timestamp": timestamp,
+        }
+        mock_state.memory_graph.memories[memory_id] = memory
+
+    first = client.get("/memory/by-tag?tags=paged-tag&limit=200", headers=auth_headers)
+    assert first.status_code == 200
+    first_data = first.get_json()
+    assert first_data["count"] == 200
+    assert first_data["limit"] == 200
+    assert first_data["offset"] == 0
+    assert first_data["has_more"] is True
+
+    second = client.get("/memory/by-tag?tags=paged-tag&limit=200&offset=200", headers=auth_headers)
+    assert second.status_code == 200
+    second_data = second.get_json()
+    assert second_data["count"] == 5
+    assert second_data["limit"] == 200
+    assert second_data["offset"] == 200
+    assert second_data["has_more"] is False
+
+    first_ids = {memory["id"] for memory in first_data["memories"]}
+    second_ids = {memory["id"] for memory in second_data["memories"]}
+    assert first_ids.isdisjoint(second_ids)
+
+
+def test_memory_by_tag_invalid_offset_normalized(client, mock_state, auth_headers):
+    """Test invalid or negative offset normalizes to zero."""
+    mock_state.memory_graph.memories["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab"] = {
+        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab",
+        "content": "Offset memory",
+        "tags": ["offset-tag"],
+        "importance": 0.8,
+        "timestamp": utc_now(),
+    }
+
+    invalid = client.get("/memory/by-tag?tags=offset-tag&offset=nope", headers=auth_headers)
+    assert invalid.status_code == 200
+    invalid_data = invalid.get_json()
+    assert invalid_data["offset"] == 0
+    assert invalid_data["count"] == 1
+
+    negative = client.get("/memory/by-tag?tags=offset-tag&offset=-10", headers=auth_headers)
+    assert negative.status_code == 200
+    negative_data = negative.get_json()
+    assert negative_data["offset"] == 0
+    assert negative_data["count"] == 1
+
+
+def test_delete_memory_by_tag_bulk(client, mock_state, auth_headers):
+    """Test bulk delete by tag removes graph and vector entries."""
+    tag = "bulk-delete-tag"
+    for i in range(3):
+        memory_id = f"00000000-0000-0000-0000-0000000001{i:02d}"
+        payload = {
+            "content": f"Bulk delete memory {i}",
+            "tags": [tag],
+            "importance": 0.7,
+            "timestamp": utc_now(),
+        }
+        mock_state.memory_graph.memories[memory_id] = {"id": memory_id, **payload}
+        mock_state.qdrant.points[memory_id] = {"vector": [0.1] * 3, "payload": payload}
+
+    response = client.delete("/memory/by-tag?tags=bulk-delete-tag", headers=auth_headers)
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data == {"status": "success", "tags": [tag], "deleted_count": 3}
+
+    follow_up = client.get("/memory/by-tag?tags=bulk-delete-tag", headers=auth_headers)
+    assert follow_up.status_code == 200
+    follow_up_data = follow_up.get_json()
+    assert follow_up_data["count"] == 0
+    assert follow_up_data["has_more"] is False
+    deleted_ids = [f"00000000-0000-0000-0000-0000000001{i:02d}" for i in range(3)]
+    assert all(point_id not in mock_state.qdrant.points for point_id in deleted_ids)
+
+
+def test_delete_memory_by_tag_no_matches(client, mock_state, auth_headers):
+    """Test bulk delete by tag succeeds with zero matches."""
+    response = client.delete("/memory/by-tag?tags=missing-tag", headers=auth_headers)
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data == {"status": "success", "tags": ["missing-tag"], "deleted_count": 0}
 
 
 # ==================== Test Admin Reembed ====================

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -397,6 +397,74 @@ def test_tag_filtering_real(api_client):
         api_client.delete(f"{api_client.base_url}/memory/{memory_id}")
 
 
+def test_tag_pagination_and_bulk_delete_real(api_client):
+    """Test paging through a tag set and bulk-deleting it."""
+    unique_tag = f"tagpage_{uuid.uuid4().hex[:8]}"
+    memory_ids = []
+
+    for i in range(5):
+        response = api_client.post(
+            f"{api_client.base_url}/memory",
+            json={
+                "content": f"Paged delete memory {i} {unique_tag}",
+                "tags": [unique_tag, f"page_{i}"],
+                "importance": 0.5,
+            },
+        )
+        assert response.status_code == 201
+        memory_ids.append(response.json()["memory_id"])
+
+    seen_ids = []
+    offset = 0
+    limit = 2
+    while True:
+        response = api_client.get(
+            f"{api_client.base_url}/memory/by-tag",
+            params={"tags": unique_tag, "limit": limit, "offset": offset},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["limit"] == limit
+        assert data["offset"] == offset
+        seen_ids.extend(memory["id"] for memory in data["memories"])
+        if not data["has_more"]:
+            break
+        offset += limit
+
+    assert set(seen_ids) == set(memory_ids)
+    assert len(seen_ids) == len(memory_ids)
+
+    delete_response = api_client.delete(
+        f"{api_client.base_url}/memory/by-tag", params={"tags": unique_tag}
+    )
+    assert delete_response.status_code == 200
+    delete_data = delete_response.json()
+    assert delete_data["status"] == "success"
+    assert delete_data["deleted_count"] == len(memory_ids)
+
+    post_delete = api_client.get(
+        f"{api_client.base_url}/memory/by-tag", params={"tags": unique_tag, "limit": 10}
+    )
+    assert post_delete.status_code == 200
+    post_delete_data = post_delete.json()
+    assert post_delete_data["count"] == 0
+    assert post_delete_data["has_more"] is False
+
+    for _ in range(5):
+        recall_response = api_client.get(
+            f"{api_client.base_url}/recall",
+            params={"query": unique_tag, "tags": unique_tag, "limit": 20},
+        )
+        assert recall_response.status_code == 200
+        results = recall_response.json().get("results", [])
+        if not any(result.get("id") in memory_ids for result in results):
+            break
+        time.sleep(0.5)
+    else:
+        pytest.fail("Deleted memories still surfaced in recall after bulk delete")
+
+
 def test_time_range_recall_real(api_client):
     """Test recalling memories within time ranges."""
     # Store a memory with current timestamp


### PR DESCRIPTION
## Summary
- add `offset` pagination metadata to `GET /memory/by-tag`
- add `DELETE /memory/by-tag` for bulk delete using existing auth and delete semantics
- update docs, route contract coverage, endpoint tests, and live integration coverage

## Why
Issue #144 needs a safe way to enumerate all memories for a tag set and a matching cleanup endpoint for benchmark and sweep workflows.

## Validation
- `./.venv/bin/python -m pytest tests/contracts/test_routes_contract.py tests/test_api_endpoints.py tests/test_app.py -q`
- `AUTOMEM_RUN_INTEGRATION_TESTS=1 ./.venv/bin/python -m pytest tests/test_integration.py -q -k tag_pagination_and_bulk_delete_real`

## Notes
- rebuilt local `flask-api` with `docker compose up -d --build flask-api` before the live integration run so the container served the new endpoint behavior.

Refs #144