### PR TITLE
fix(benchmarks): make LoCoMo judge runs reliable

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -227,15 +227,15 @@ Category 5 uses evidence-grounded complex reasoning and is opt-in for cost reaso
 make bench-eval BENCH=locomo-mini CONFIG=baseline
 
 # Enable cat-5 judge with env var
-BENCH_JUDGE_MODEL=gpt-4o make bench-eval BENCH=locomo-mini CONFIG=baseline
+BENCH_JUDGE_MODEL=gpt-5.1 make bench-eval BENCH=locomo-mini CONFIG=baseline
 
 # Or use the runner CLI flags directly
 ./test-locomo-benchmark.sh --conversations 0,1 --judge
-./test-locomo-benchmark.sh --conversations 0,1 --judge-model gpt-4o-mini
+./test-locomo-benchmark.sh --conversations 0,1 --judge-model gpt-5.1
 ```
 
 - `BENCH_JUDGE_MODEL` enables category-5 judging for `tests/benchmarks/test_locomo.py`.
-- `--judge` and `--judge-model` both enable the judge; `--judge` defaults to `gpt-4o` unless overridden by `BENCH_JUDGE_MODEL` or `--judge-model`.
+- `--judge` and `--judge-model` both enable the judge; `--judge` defaults to `gpt-5.1` unless overridden by `BENCH_JUDGE_MODEL` or `--judge-model`.
 - If the judge is disabled, category 5 remains `N/A`.
 - If the judge is enabled but evidence is missing or the LLM response is invalid, the affected category-5 questions are skipped rather than counted wrong.
 

--- a/test-locomo-benchmark.sh
+++ b/test-locomo-benchmark.sh
@@ -73,7 +73,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --live              Run against Railway deployment (default: local Docker)"
             echo "  --recall-limit N    Number of memories to recall per question (default: 10)"
             echo "  --conversations I,J Comma-separated conversation indices (e.g. 0,1 for mini mode)"
-            echo "  --judge             Enable category-5 LLM judge (defaults to gpt-4o)"
+            echo "  --judge             Enable category-5 LLM judge (defaults to gpt-5.1)"
             echo "  --judge-model MODEL Set the category-5 judge model (also enables judge)"
             echo "  --no-cleanup        Don't cleanup test data after evaluation"
             echo "  --output FILE       Save results to JSON file"

--- a/tests/benchmarks/longmemeval/test_longmemeval.py
+++ b/tests/benchmarks/longmemeval/test_longmemeval.py
@@ -38,10 +38,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, TypedDict
 
+from dotenv import load_dotenv
+
 # Add project root to path for imports (file -> longmemeval -> benchmarks -> tests -> project root)
 _project_root = str(Path(__file__).resolve().parent.parent.parent.parent)
 if _project_root not in sys.path:
     sys.path.insert(0, _project_root)
+
+load_dotenv()
+load_dotenv(Path.home() / ".config" / "automem" / ".env")
 
 try:
     from openai import OpenAI

--- a/tests/benchmarks/test_locomo.py
+++ b/tests/benchmarks/test_locomo.py
@@ -32,12 +32,20 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 from dateutil import parser as date_parser
+from dotenv import load_dotenv
 from openai import OpenAI
 
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
+# Match the app/script env loading behavior so standalone benchmark runs pick up
+# local secrets from either the repo root or ~/.config/automem/.env.
+load_dotenv()
+load_dotenv(Path.home() / ".config" / "automem" / ".env")
+
 from tests.benchmarks.backends import MemoryRecord, SearchRequest, create_backend
+
+DEFAULT_CAT5_JUDGE_MODEL = "gpt-5.1"
 
 
 @dataclass
@@ -91,6 +99,7 @@ class LoCoMoEvaluator:
     """Evaluates AutoMem against the LoCoMo benchmark"""
 
     OPENAI_REQUEST_TIMEOUT_SECONDS = 90.0
+    GPT5_JUDGE_MAX_COMPLETION_TOKENS = (250, 400, 600)
 
     def __init__(self, config: LoCoMoConfig):
         self.config = config
@@ -1092,6 +1101,54 @@ Respond in JSON format:
             content = fence_match.group("body").strip()
         return json.loads(content)
 
+    @staticmethod
+    def _judge_model_uses_structured_outputs(model_name: Optional[str]) -> bool:
+        """GPT-5 family models prefer strict json_schema over legacy json_object mode."""
+        return bool(model_name and model_name.strip().lower().startswith("gpt-5"))
+
+    def _judge_response_format(self) -> Dict[str, Any]:
+        if self._judge_model_uses_structured_outputs(self.config.judge_model):
+            return {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "locomo_cat5_judge",
+                    "strict": True,
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "generated_answer": {"type": "string"},
+                            "verdict": {
+                                "type": "string",
+                                "enum": [
+                                    "supported",
+                                    "abstain",
+                                    "contradiction",
+                                    "unsupported",
+                                    "incorrect",
+                                ],
+                            },
+                            "correct": {"type": "boolean"},
+                            "confidence": {"type": "number"},
+                            "reasoning": {"type": "string"},
+                        },
+                        "required": [
+                            "generated_answer",
+                            "verdict",
+                            "correct",
+                            "confidence",
+                            "reasoning",
+                        ],
+                        "additionalProperties": False,
+                    },
+                },
+            }
+        return {"type": "json_object"}
+
+    def _judge_token_attempts(self) -> Tuple[int, ...]:
+        if self._judge_model_uses_structured_outputs(self.config.judge_model):
+            return self.GPT5_JUDGE_MAX_COMPLETION_TOKENS
+        return (250,)
+
     def judge_complex_reasoning(
         self,
         question: str,
@@ -1169,47 +1226,62 @@ Respond with ONLY a JSON object:
   "reasoning": "brief explanation grounded in the evidence dialogs"
 }}"""
 
-        try:
-            response = self.openai_client.chat.completions.create(
-                model=self.config.judge_model,
-                messages=[
-                    {
-                        "role": "system",
-                        "content": (
-                            "You are a strict benchmark judge. "
-                            "Use recalled memories to draft the answer and evidence dialogs "
-                            "only to verify correctness."
-                        ),
-                    },
-                    {"role": "user", "content": prompt},
-                ],
-                temperature=0.0,
-                max_tokens=250,
-                response_format={"type": "json_object"},
-                timeout=self.OPENAI_REQUEST_TIMEOUT_SECONDS,
-            )
-            result = self._parse_json_object_response(response.choices[0].message.content)
-            correct = result.get("correct")
-            if not isinstance(correct, bool):
-                raise ValueError("Judge response missing boolean 'correct'")
+        last_error: Optional[Exception] = None
+        for token_budget in self._judge_token_attempts():
+            try:
+                request_kwargs: Dict[str, Any] = {
+                    "model": self.config.judge_model,
+                    "messages": [
+                        {
+                            "role": "system",
+                            "content": (
+                                "You are a strict benchmark judge. "
+                                "Use recalled memories to draft the answer and evidence dialogs "
+                                "only to verify correctness."
+                            ),
+                        },
+                        {"role": "user", "content": prompt},
+                    ],
+                    "response_format": self._judge_response_format(),
+                    "timeout": self.OPENAI_REQUEST_TIMEOUT_SECONDS,
+                }
+                if self._judge_model_uses_structured_outputs(self.config.judge_model):
+                    request_kwargs["max_completion_tokens"] = token_budget
+                else:
+                    request_kwargs["max_tokens"] = token_budget
+                    request_kwargs["temperature"] = 0.0
 
-            confidence = float(result.get("confidence", 0.0))
-            generated_answer = str(result.get("generated_answer", "")).strip() or None
-            reasoning = str(result.get("reasoning", "")).strip()
-            explanation = f"LLM judge: {reasoning}" if reasoning else "LLM judge"
-            judge_result = (correct, confidence, explanation, generated_answer, reasoning or None)
-            self.llm_cache[cache_key] = judge_result
-            return judge_result
-        except Exception as e:
-            error_result = (
-                None,
-                0.0,
-                f"Skipped: LLM judge error: {e}",
-                None,
-                f"LLM judge error: {e}",
-            )
-            self.llm_cache[cache_key] = error_result
-            return error_result
+                response = self.openai_client.chat.completions.create(**request_kwargs)
+                result = self._parse_json_object_response(response.choices[0].message.content)
+                correct = result.get("correct")
+                if not isinstance(correct, bool):
+                    raise ValueError("Judge response missing boolean 'correct'")
+
+                confidence = float(result.get("confidence", 0.0))
+                generated_answer = str(result.get("generated_answer", "")).strip() or None
+                reasoning = str(result.get("reasoning", "")).strip()
+                explanation = f"LLM judge: {reasoning}" if reasoning else "LLM judge"
+                judge_result = (
+                    correct,
+                    confidence,
+                    explanation,
+                    generated_answer,
+                    reasoning or None,
+                )
+                self.llm_cache[cache_key] = judge_result
+                return judge_result
+            except Exception as e:
+                last_error = e
+
+        error_result = (
+            None,
+            0.0,
+            f"Skipped: LLM judge error: {last_error}",
+            None,
+            f"LLM judge error: {last_error}",
+        )
+        self.llm_cache[cache_key] = error_result
+        return error_result
 
     def check_answer_in_memories(
         self,
@@ -1949,7 +2021,10 @@ def main():
     parser.add_argument(
         "--judge",
         action="store_true",
-        help="Enable category-5 LLM judging (defaults to gpt-4o unless BENCH_JUDGE_MODEL is set).",
+        help=(
+            "Enable category-5 LLM judging "
+            f"(defaults to {DEFAULT_CAT5_JUDGE_MODEL} unless BENCH_JUDGE_MODEL is set)."
+        ),
     )
     parser.add_argument(
         "--judge-model",
@@ -1977,7 +2052,7 @@ def main():
     if args.data_file:
         config.data_file = args.data_file
     if args.judge or args.judge_model:
-        config.judge_model = args.judge_model or config.judge_model or "gpt-4o"
+        config.judge_model = args.judge_model or config.judge_model or DEFAULT_CAT5_JUDGE_MODEL
 
     # Run evaluation
     evaluator = LoCoMoEvaluator(config)

--- a/tests/test_benchmark_env_loading.py
+++ b/tests/test_benchmark_env_loading.py
@@ -1,0 +1,60 @@
+import sys
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from typing import Any
+
+
+class _DummyBackend:
+    name = "automem"
+
+    def health_check(self) -> bool:
+        return True
+
+
+def _load_module(module_name: str, path: Path) -> Any:
+    spec = spec_from_file_location(module_name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_global_env(tmp_path: Path) -> None:
+    env_dir = tmp_path / ".config" / "automem"
+    env_dir.mkdir(parents=True)
+    (env_dir / ".env").write_text("OPENAI_API_KEY=file-openai-key\n", encoding="utf-8")
+
+
+def test_locomo_benchmark_loads_openai_api_key_from_global_env(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_global_env(tmp_path)
+
+    module_path = Path(__file__).resolve().parent / "benchmarks" / "test_locomo.py"
+    module = _load_module("locomo_benchmark_env_loading", module_path)
+    monkeypatch.setattr(module, "create_backend", lambda *args, **kwargs: _DummyBackend())
+
+    evaluator = module.LoCoMoEvaluator(module.LoCoMoConfig())
+
+    assert evaluator.has_openai_api_key is True
+    assert evaluator.openai_client is not None
+
+
+def test_longmemeval_benchmark_loads_openai_api_key_from_global_env(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_global_env(tmp_path)
+
+    module_path = (
+        Path(__file__).resolve().parent / "benchmarks" / "longmemeval" / "test_longmemeval.py"
+    )
+    module = _load_module("longmemeval_benchmark_env_loading", module_path)
+    monkeypatch.setattr(module, "create_backend", lambda *args, **kwargs: _DummyBackend())
+
+    benchmark = module.LongMemEvalBenchmark(module.get_config("baseline"))
+
+    assert benchmark.openai_client is not None

--- a/tests/test_locomo_cat5_judge.py
+++ b/tests/test_locomo_cat5_judge.py
@@ -71,9 +71,9 @@ def test_cat5_without_judge_still_skips(locomo_evaluator: Any) -> None:
 
 
 def test_cat5_with_judge_counts_toward_category_results(
-    locomo_evaluator: Any, monkeypatch: pytest.MonkeyPatch
+    locomo_module: Any, locomo_evaluator: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    locomo_evaluator.config.judge_model = "gpt-4o"
+    locomo_evaluator.config.judge_model = locomo_module.DEFAULT_CAT5_JUDGE_MODEL
     monkeypatch.setattr(
         locomo_evaluator,
         "_recall_memories_for_qa",
@@ -117,8 +117,10 @@ def test_fetch_evidence_memories_uses_local_conversation_cache(
     assert [memory["metadata"]["dialog_id"] for memory in evidence] == ["D2:3", "D5:8"]
 
 
-def test_cat5_judge_uses_cache(locomo_evaluator: Any, monkeypatch: pytest.MonkeyPatch) -> None:
-    locomo_evaluator.config.judge_model = "gpt-4o"
+def test_cat5_judge_uses_cache(
+    locomo_module: Any, locomo_evaluator: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    locomo_evaluator.config.judge_model = locomo_module.DEFAULT_CAT5_JUDGE_MODEL
     calls = {"count": 0}
 
     class FakeCompletions:
@@ -172,9 +174,9 @@ def test_cat5_judge_uses_cache(locomo_evaluator: Any, monkeypatch: pytest.Monkey
 
 
 def test_cat5_judge_sets_request_timeout(
-    locomo_evaluator: Any, monkeypatch: pytest.MonkeyPatch
+    locomo_module: Any, locomo_evaluator: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    locomo_evaluator.config.judge_model = "gpt-4o"
+    locomo_evaluator.config.judge_model = locomo_module.DEFAULT_CAT5_JUDGE_MODEL
     captured = {}
 
     class FakeCompletions:
@@ -218,6 +220,160 @@ def test_cat5_judge_sets_request_timeout(
     assert captured["timeout"] == locomo_evaluator.OPENAI_REQUEST_TIMEOUT_SECONDS
 
 
+def test_cat5_judge_uses_structured_outputs_for_gpt5_models(
+    locomo_module: Any, locomo_evaluator: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    locomo_evaluator.config.judge_model = locomo_module.DEFAULT_CAT5_JUDGE_MODEL
+    captured: dict[str, Any] = {}
+
+    class FakeCompletions:
+        def create(self, **kwargs: Any) -> Any:
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(
+                            content=(
+                                '{"generated_answer": "She will research and train.", '
+                                '"verdict": "supported", '
+                                '"correct": true, "confidence": 0.88, '
+                                '"reasoning": "Matches the evidence dialog."}'
+                            )
+                        )
+                    )
+                ]
+            )
+
+    locomo_evaluator.openai_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=FakeCompletions())
+    )
+    monkeypatch.setattr(
+        locomo_evaluator,
+        "fetch_evidence_memories",
+        lambda evidence_dialog_ids, sample_id, use_local_cache=False: [
+            _fake_memory("D10:20", "Jolene is gathering information and watching videos.")
+        ],
+    )
+
+    result = locomo_evaluator.judge_complex_reasoning(
+        _cat5_qa()["question"],
+        _cat5_qa()["adversarial_answer"],
+        [_fake_memory("R1", "Jolene is gathering information and watching videos.")],
+        ["D10:20"],
+        "conv-1",
+    )
+
+    request = captured["kwargs"]
+    assert result[0] is True
+    assert "temperature" not in request
+    assert "max_tokens" not in request
+    assert request["max_completion_tokens"] == 250
+    assert request["response_format"]["type"] == "json_schema"
+    assert request["response_format"]["json_schema"]["name"] == "locomo_cat5_judge"
+    assert request["response_format"]["json_schema"]["strict"] is True
+    assert "reasoning_effort" not in request
+
+
+def test_cat5_judge_keeps_json_mode_for_non_gpt5_models(
+    locomo_evaluator: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    locomo_evaluator.config.judge_model = "gpt-4o-mini"
+    captured: dict[str, Any] = {}
+
+    class FakeCompletions:
+        def create(self, **kwargs: Any) -> Any:
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(
+                            content=(
+                                '{"generated_answer": "She will research and train.", '
+                                '"verdict": "supported", '
+                                '"correct": true, "confidence": 0.88, '
+                                '"reasoning": "Matches the evidence dialog."}'
+                            )
+                        )
+                    )
+                ]
+            )
+
+    locomo_evaluator.openai_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=FakeCompletions())
+    )
+    monkeypatch.setattr(
+        locomo_evaluator,
+        "fetch_evidence_memories",
+        lambda evidence_dialog_ids, sample_id, use_local_cache=False: [
+            _fake_memory("D10:20", "Jolene is gathering information and watching videos.")
+        ],
+    )
+
+    result = locomo_evaluator.judge_complex_reasoning(
+        _cat5_qa()["question"],
+        _cat5_qa()["adversarial_answer"],
+        [_fake_memory("R1", "Jolene is gathering information and watching videos.")],
+        ["D10:20"],
+        "conv-1",
+    )
+
+    request = captured["kwargs"]
+    assert result[0] is True
+    assert request["response_format"] == {"type": "json_object"}
+    assert request["temperature"] == 0.0
+    assert request["max_tokens"] == 250
+    assert "reasoning_effort" not in request
+
+
+def test_cat5_judge_retries_transient_parse_failures_for_gpt5(
+    locomo_module: Any, locomo_evaluator: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    locomo_evaluator.config.judge_model = locomo_module.DEFAULT_CAT5_JUDGE_MODEL
+    captured_requests: list[dict[str, Any]] = []
+    response_bodies = iter(
+        [
+            '{"generated_answer":"partial',
+            (
+                '{"generated_answer": "She will research and train.", '
+                '"verdict": "supported", '
+                '"correct": true, "confidence": 0.88, '
+                '"reasoning": "Matches the evidence dialog."}'
+            ),
+        ]
+    )
+
+    class FakeCompletions:
+        def create(self, **kwargs: Any) -> Any:
+            captured_requests.append(kwargs)
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content=next(response_bodies)))]
+            )
+
+    locomo_evaluator.openai_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=FakeCompletions())
+    )
+    monkeypatch.setattr(
+        locomo_evaluator,
+        "fetch_evidence_memories",
+        lambda evidence_dialog_ids, sample_id, use_local_cache=False: [
+            _fake_memory("D10:20", "Jolene is gathering information and watching videos.")
+        ],
+    )
+
+    result = locomo_evaluator.judge_complex_reasoning(
+        _cat5_qa()["question"],
+        _cat5_qa()["adversarial_answer"],
+        [_fake_memory("R1", "Jolene is gathering information and watching videos.")],
+        ["D10:20"],
+        "conv-1",
+    )
+
+    assert result[0] is True
+    assert len(captured_requests) == 2
+    assert captured_requests[0]["max_completion_tokens"] == 250
+    assert captured_requests[1]["max_completion_tokens"] == 400
+
+
 @pytest.mark.parametrize(
     ("evidence_memories", "response_content", "expected_message"),
     [
@@ -234,13 +390,14 @@ def test_cat5_judge_sets_request_timeout(
     ],
 )
 def test_cat5_judge_failures_skip_instead_of_marking_wrong(
+    locomo_module: Any,
     locomo_evaluator: Any,
     monkeypatch: pytest.MonkeyPatch,
     evidence_memories: List[Dict[str, Any]],
     response_content: str,
     expected_message: str,
 ) -> None:
-    locomo_evaluator.config.judge_model = "gpt-4o"
+    locomo_evaluator.config.judge_model = locomo_module.DEFAULT_CAT5_JUDGE_MODEL
 
     class FakeCompletions:
         def create(self, **kwargs: Any) -> Any:
@@ -272,9 +429,9 @@ def test_cat5_judge_failures_skip_instead_of_marking_wrong(
 
 
 def test_cat5_judge_prompt_allows_abstention_and_wrong_premise(
-    locomo_evaluator: Any, monkeypatch: pytest.MonkeyPatch
+    locomo_module: Any, locomo_evaluator: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    locomo_evaluator.config.judge_model = "gpt-4o"
+    locomo_evaluator.config.judge_model = locomo_module.DEFAULT_CAT5_JUDGE_MODEL
     captured = {}
 
     class FakeCompletions:
@@ -324,9 +481,9 @@ def test_cat5_judge_prompt_allows_abstention_and_wrong_premise(
 
 
 def test_cat5_judge_prompt_includes_more_than_old_top_12_memories(
-    locomo_evaluator: Any, monkeypatch: pytest.MonkeyPatch
+    locomo_module: Any, locomo_evaluator: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    locomo_evaluator.config.judge_model = "gpt-4o"
+    locomo_evaluator.config.judge_model = locomo_module.DEFAULT_CAT5_JUDGE_MODEL
     captured = {}
 
     class FakeCompletions:
@@ -372,9 +529,9 @@ def test_cat5_judge_prompt_includes_more_than_old_top_12_memories(
 
 
 def test_cat5_with_canonical_answer_stays_deterministic(
-    locomo_evaluator: Any, monkeypatch: pytest.MonkeyPatch
+    locomo_module: Any, locomo_evaluator: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    locomo_evaluator.config.judge_model = "gpt-4o"
+    locomo_evaluator.config.judge_model = locomo_module.DEFAULT_CAT5_JUDGE_MODEL
     monkeypatch.setattr(
         locomo_evaluator,
         "_recall_memories_for_qa",
@@ -409,3 +566,45 @@ def test_cat5_with_canonical_answer_stays_deterministic(
     assert result["expected_answer"] == "No"
     assert result["judge_generated_answer"] is None
     assert result["explanation"].startswith("Deterministic cat-5 scoring:")
+
+
+def test_main_defaults_judge_to_gpt_5_1_when_env_unset(
+    locomo_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("BENCH_JUDGE_MODEL", raising=False)
+    captured: dict[str, Any] = {}
+
+    class FakeEvaluator:
+        def __init__(self, config: Any) -> None:
+            captured["config"] = config
+
+        def run_benchmark(self, **kwargs: Any) -> Dict[str, Any]:
+            _ = kwargs
+            return {"overall": {"accuracy": 1.0}}
+
+    monkeypatch.setattr(locomo_module, "LoCoMoEvaluator", FakeEvaluator)
+    monkeypatch.setattr(sys, "argv", ["test_locomo.py", "--judge"])
+
+    assert locomo_module.main() == 0
+    assert captured["config"].judge_model == locomo_module.DEFAULT_CAT5_JUDGE_MODEL
+
+
+def test_main_prefers_bench_judge_model_env_override(
+    locomo_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("BENCH_JUDGE_MODEL", "custom-judge-model")
+    captured: dict[str, Any] = {}
+
+    class FakeEvaluator:
+        def __init__(self, config: Any) -> None:
+            captured["config"] = config
+
+        def run_benchmark(self, **kwargs: Any) -> Dict[str, Any]:
+            _ = kwargs
+            return {"overall": {"accuracy": 1.0}}
+
+    monkeypatch.setattr(locomo_module, "LoCoMoEvaluator", FakeEvaluator)
+    monkeypatch.setattr(sys, "argv", ["test_locomo.py", "--judge"])
+
+    assert locomo_module.main() == 0
+    assert captured["config"].judge_model == "custom-judge-model"


### PR DESCRIPTION
## Summary
- load benchmark env files from the repo and `~/.config/automem/.env` so standalone LoCoMo and LongMemEval runs see `OPENAI_API_KEY`
- switch the LoCoMo cat-5 judge to a GPT-5-compatible request path and retry transient malformed/truncated JSON responses instead of skipping questions
- update the mini-runner/docs to reflect the `gpt-5.1` default and add regression coverage for env loading plus GPT-5/non-GPT-5 judge behavior

## Test plan
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/jgarturo/Projects/OpenAI/automem/.venv/bin/pytest tests/test_locomo_cat5_judge.py tests/test_benchmark_env_loading.py tests/test_benchmark_backends.py -q`
- [x] `/Users/jgarturo/Projects/OpenAI/automem/.venv/bin/flake8 tests/benchmarks/test_locomo.py tests/benchmarks/longmemeval/test_longmemeval.py tests/test_locomo_cat5_judge.py tests/test_benchmark_env_loading.py`
- [x] `PYTHONUNBUFFERED=1 .venv/bin/python tests/benchmarks/test_locomo.py --base-url http://localhost:8001 --api-token test-token --recall-limit 10 --conversations 0 --output benchmarks/results/locomo_judge_debug_conv0_retry.json --judge`