### PR TITLE
fix(mcp-sse): decouple /health liveness from upstream readiness

### DIFF
--- a/mcp-sse-server/server.js
+++ b/mcp-sse-server/server.js
@@ -775,12 +775,17 @@ export function createApp() {
   healthProbeTimer.unref?.();
   void probeUpstreamHealth('startup');
 
+  // Liveness probe: returns 200 whenever the Node process is able to serve HTTP.
+  // Upstream AutoMem status is reported in the body for observability but does
+  // NOT gate this endpoint — a bridge should be deployable and able to return
+  // errors to clients even when its upstream is temporarily unavailable.
+  // For strict upstream-gated readiness, point your orchestrator at /ready.
   app.get('/health', async (req, res) => {
     if (!healthState.checked_at) {
       await probeUpstreamHealth('request');
     }
 
-    const body = {
+    res.status(200).json({
       status: healthState.status,
       transports: ['streamable-http', 'sse'],
       endpoints: { streamableHttp: '/mcp', sse: '/mcp/sse' },
@@ -790,9 +795,25 @@ export function createApp() {
       checked_at: healthState.checked_at,
       timestamp: new Date().toISOString(),
       request_id: req.requestId,
-    };
+    });
+  });
 
-    res.status(healthState.status === 'healthy' ? 200 : 503).json(body);
+  // Readiness probe: 200 iff upstream is healthy, 503 otherwise.
+  // Use this when the orchestrator should block traffic/deploy on upstream
+  // availability. Not recommended as Railway's healthcheckPath for this bridge.
+  app.get('/ready', async (req, res) => {
+    if (!healthState.checked_at) {
+      await probeUpstreamHealth('request');
+    }
+
+    res.status(healthState.status === 'healthy' ? 200 : 503).json({
+      status: healthState.status,
+      upstream: healthState.upstream,
+      upstream_error: healthState.error,
+      checked_at: healthState.checked_at,
+      timestamp: new Date().toISOString(),
+      request_id: req.requestId,
+    });
   });
 
 // Helper: validate and extract token from multiple sources

--- a/mcp-sse-server/server.js
+++ b/mcp-sse-server/server.js
@@ -782,7 +782,7 @@ export function createApp() {
   // For strict upstream-gated readiness, point your orchestrator at /ready.
   app.get('/health', async (req, res) => {
     if (!healthState.checked_at) {
-      await probeUpstreamHealth('request');
+      void probeUpstreamHealth('request');
     }
 
     res.status(200).json({
@@ -802,9 +802,7 @@ export function createApp() {
   // Use this when the orchestrator should block traffic/deploy on upstream
   // availability. Not recommended as Railway's healthcheckPath for this bridge.
   app.get('/ready', async (req, res) => {
-    if (!healthState.checked_at) {
-      await probeUpstreamHealth('request');
-    }
+    await probeUpstreamHealth('request');
 
     res.status(healthState.status === 'healthy' ? 200 : 503).json({
       status: healthState.status,

--- a/mcp-sse-server/test/server.test.js
+++ b/mcp-sse-server/test/server.test.js
@@ -408,7 +408,7 @@ test("GET /health returns healthy when upstream is reachable", async () => {
   }
 });
 
-test("GET /health returns degraded when upstream is unreachable", async () => {
+test("GET /health returns 200 with degraded body when upstream is unreachable", async () => {
   const originalFetch = globalThis.fetch;
   const prevToken = process.env.AUTOMEM_API_TOKEN;
   const prevEndpoint = process.env.AUTOMEM_API_URL;
@@ -426,12 +426,83 @@ test("GET /health returns degraded when upstream is unreachable", async () => {
   try {
     await withServer(createApp(), async (port) => {
       const res = await originalFetch(`http://127.0.0.1:${port}/health`);
+      // /health is a liveness probe — always 200 while the process serves HTTP.
+      // Degraded upstream is reported in the body, not via HTTP status.
+      assert.equal(res.status, 200);
+
+      const body = await res.json();
+      assert.equal(body.status, "degraded");
+      assert.equal(body.upstream, "unreachable");
+      assert.match(body.upstream_error, /fetch failed/);
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+    process.env.AUTOMEM_API_TOKEN = prevToken;
+    process.env.AUTOMEM_API_URL = prevEndpoint;
+  }
+});
+
+test("GET /ready returns 503 when upstream is unreachable", async () => {
+  const originalFetch = globalThis.fetch;
+  const prevToken = process.env.AUTOMEM_API_TOKEN;
+  const prevEndpoint = process.env.AUTOMEM_API_URL;
+  process.env.AUTOMEM_API_TOKEN = "test-token";
+  process.env.AUTOMEM_API_URL = "http://example.test";
+
+  globalThis.fetch = async (url, options) => {
+    if (typeof url === "string" && url.startsWith("http://127.0.0.1:")) {
+      return originalFetch(url, options);
+    }
+
+    throw new TypeError("fetch failed");
+  };
+
+  try {
+    await withServer(createApp(), async (port) => {
+      const res = await originalFetch(`http://127.0.0.1:${port}/ready`);
       assert.equal(res.status, 503);
 
       const body = await res.json();
       assert.equal(body.status, "degraded");
       assert.equal(body.upstream, "unreachable");
       assert.match(body.upstream_error, /fetch failed/);
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+    process.env.AUTOMEM_API_TOKEN = prevToken;
+    process.env.AUTOMEM_API_URL = prevEndpoint;
+  }
+});
+
+test("GET /ready returns 200 when upstream is healthy", async () => {
+  const originalFetch = globalThis.fetch;
+  const prevToken = process.env.AUTOMEM_API_TOKEN;
+  const prevEndpoint = process.env.AUTOMEM_API_URL;
+  process.env.AUTOMEM_API_TOKEN = "test-token";
+  process.env.AUTOMEM_API_URL = "http://example.test";
+
+  globalThis.fetch = async (url, options) => {
+    if (typeof url === "string" && url.startsWith("http://127.0.0.1:")) {
+      return originalFetch(url, options);
+    }
+
+    return new Response(
+      JSON.stringify({ status: "healthy", falkordb: "connected", qdrant: "connected" }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }
+    );
+  };
+
+  try {
+    await withServer(createApp(), async (port) => {
+      const res = await originalFetch(`http://127.0.0.1:${port}/ready`);
+      assert.equal(res.status, 200);
+
+      const body = await res.json();
+      assert.equal(body.status, "healthy");
+      assert.equal(body.upstream, "reachable");
     });
   } finally {
     globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Summary

PR #114's `/health` endpoint returns HTTP **503** whenever upstream AutoMem reports anything other than `"healthy"` — including *any* non-zero FalkorDB/Qdrant sync drift. Railway treats 503 as unavailable and blocks the deploy, so the SSE bridge becomes undeployable during brief upstream degradation even though the Node process itself is perfectly able to serve traffic.

In an eventually-consistent system, drift between FalkorDB writes and Qdrant embedding is **normal** under write load. Gating container liveness on zero drift causes the bridge to fail to deploy whenever writes are happening — defeating the point of a bridge (which should be able to serve errors upstream when its backend is unavailable).

This PR:

- **`GET /health`** now always returns **200** when the Node process is able to serve HTTP. The response body still carries upstream status (`status`, `upstream`, `upstream_error`, `upstream_details`) for observability, so the richer info the PR #114 change wanted to expose is still there — just not as HTTP status.
- **`GET /ready`** (new) keeps the old strict behavior: 200 iff upstream is healthy, 503 otherwise. For orchestrators that explicitly want to gate traffic on upstream availability (e.g. Kubernetes readiness probes), this is the right endpoint.
- Railway's `healthcheckPath` should remain `/health`.

## Test plan

- [x] Existing health tests updated — the "upstream unreachable" test now asserts 200 + degraded body (was 503)
- [x] New tests for `/ready`: 200 when upstream healthy, 503 when unreachable
- [x] All 13 node tests pass locally (`node --test test/server.test.js`)

## Context

Surfaced while trying to ship the `release 0.15.1` deployment on Railway — build succeeded, but every deploy was killed by healthcheck failing with 503, even though the Node process was up and the upstream was only showing minor sync drift (17 in-flight memories out of 29,012 — 0.06%, and self-healing). The same failure mode will happen on any deployment where upstream is temporarily degraded for *any* reason, which this PR addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)