### PR TITLE
test(benchmarks): improve benchmark judge provenance and debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,15 +572,14 @@ AutoMem publishes two reference baselines with Voyage 4 embeddings:
 | **Multi-hop Reasoning**    | **46.15%** | Connecting disparate memories           |
 | **Complex Reasoning**      | N/A        | Skipped in this setup; use judge-on run |
 
-Reference point:
+Current AutoMem baselines:
 
 | System | Score |
 |--------|-------|
-| Published CORE result | 88.24% |
 | AutoMem `locomo-mini` judge off | 89.27% |
 | AutoMem `locomo` judge on | 87.56% |
 
-> **Methodology note:** We do not present this as a strict leaderboard claim. The published CORE number is a useful reference point, but the public LoCoMo setups are not perfectly apples-to-apples, especially around category-5 handling. AutoMem is above that published reference on the `locomo-mini` categories 1-4 run and below it on the full judge-enabled run.
+> **Methodology note:** We do not present LoCoMo as a strict public leaderboard claim. Older external references such as CORE's published 88.24% remain useful historical context, but the setup and evaluator differences are large enough that AutoMem tracks its own corrected baselines in [`benchmarks/EXPERIMENT_LOG.md`](benchmarks/EXPERIMENT_LOG.md).
 > **History note:** Earlier versions reported 90.53%, but that included two evaluator bugs: temporal matching compared the wrong text (false negatives) and category 5 matched empty strings (false positives). See [`benchmarks/EXPERIMENT_LOG.md`](benchmarks/EXPERIMENT_LOG.md) for the corrected timeline.
 
 Run benchmarks: `make bench-eval BENCH=locomo-mini CONFIG=baseline` (quick) or `BENCH_JUDGE_MODEL=gpt-4o make bench-eval BENCH=locomo CONFIG=baseline` (full, includes category 5)

--- a/benchmarks/EXPERIMENT_LOG.md
+++ b/benchmarks/EXPERIMENT_LOG.md
@@ -25,7 +25,7 @@ on the snapshot-based bench infrastructure (PR #97, merged 2026-03-02).
 | 2026-03-02 | PR #87 | jescalan/feat/write-time-dedup | 76.97% (+0.0) | -- | -- | Write-time dedup gate. Neutral on recall (expected) |
 | 2026-03-02 | #78 | exp/78-decay-fix | 76.97% (+0.0) | 79.51% (-0.55) | -- | Decay rate 0.1→0.01, importance floor, archive filter. Within variance. Impact is on production (rehabilitated via rescore) |
 | 2026-03-10 | pre-refactor | main (@ 795368a) | 76.97% (+0.0) | -- | -- | Baseline re-confirmed after #73, #78, #115, #116 merged. Stable. Pre-relation-tier-refactor checkpoint. |
-| 2026-03-10 | eval-fix | docs/benchmark-agent-guidelines | **89.27% (208/233)** | -- | -- | Fix temporal matching (answer vs memory dates) + skip cat5 (no ground truth). Honest score, beats CORE by 1.03pp. |
+| 2026-03-10 | eval-fix | docs/benchmark-agent-guidelines | **89.27% (208/233)** | -- | -- | Fix temporal matching (answer vs memory dates) + skip cat5 (no ground truth). Honest corrected baseline after evaluator fixes. |
 | 2026-03-10 | cat5-judge | feat/bench-cat5-judge | **89.80% (273/304)** | **87.56% (1739/1986)** | -- | Opt-in GPT-4o judge for cat5. Full run scored cat5 at 95.74% (427/446) with 0 judge skips/errors; added 90s OpenAI request timeout to prevent stuck full runs. |
 | 2026-03-10 | main-refresh (no judge) | main | **89.36% (210/235)** | -- | -- | Fresh current-main rerun before PR #80 experiment. Comparison anchor for judge-off. |
 | 2026-03-10 | main-refresh (judge) | main | **90.13% (274/304)** | -- | -- | Fresh current-main rerun with `BENCH_JUDGE_MODEL=gpt-4o`. Comparison anchor for judge-on. |

--- a/docs/BENCHMARK_JUDGE_POLICY.md
+++ b/docs/BENCHMARK_JUDGE_POLICY.md
@@ -1,0 +1,16 @@
+# Benchmark Judge Policy
+
+AutoMem internal benchmark runs use a pinned OpenAI judge snapshot:
+
+- Model: `gpt-5.4-mini-2026-03-17`
+- Profile: `openai-gpt-5.4-mini-2026-03-17`
+- Provider: `openai`
+
+Use this judge for routine LoCoMo, LongMemEval, and regression tracking so
+scores remain comparable over time. Result JSON should record `judge_model`,
+`judge_profile`, `judge_provider`, and `judge_snapshot_pinned`.
+
+External published comparisons are separate runs. Match the published judge
+configuration exactly and label the run with an explicit non-canonical profile
+such as `published-mem0-gpt-5`. Do not compare scores unless judge metadata
+matches or the difference is called out directly.

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -271,7 +271,7 @@ VECTOR_SIZE=768
 |-------|-------|--------|-------|
 | `gpt-4o-mini` | $0.15/1M | $0.60/1M | **Default** - Good enough for classification |
 | `gpt-4.1` | ~$2/1M | ~$8/1M | Better reasoning |
-| `gpt-5.1` | $1.25/1M | $10/1M | Best reasoning, use for benchmarks |
+| `gpt-5.1` | $1.25/1M | $10/1M | Higher reasoning; benchmark judge defaults are documented in `docs/BENCHMARK_JUDGE_POLICY.md` |
 
 **⚠️ Changing embedding models requires re-embedding all memories.** See [Re-embedding Guide](#re-embedding-memories) below.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -227,17 +227,28 @@ Category 5 uses evidence-grounded complex reasoning and is opt-in for cost reaso
 make bench-eval BENCH=locomo-mini CONFIG=baseline
 
 # Enable cat-5 judge with env var
-BENCH_JUDGE_MODEL=gpt-5.1 make bench-eval BENCH=locomo-mini CONFIG=baseline
+BENCH_JUDGE_MODEL=gpt-5.4-mini-2026-03-17 make bench-eval BENCH=locomo-mini CONFIG=baseline
 
-# Or use the runner CLI flags directly
-./test-locomo-benchmark.sh --conversations 0,1 --judge
-./test-locomo-benchmark.sh --conversations 0,1 --judge-model gpt-5.1
+# Direct runner: 1 conversation, judge enabled
+./test-locomo-benchmark.sh --conversations 0 --judge --output benchmarks/results/locomo-smoke.json
+
+# Direct runner: mini mode (same 2 conversations as locomo-mini)
+./test-locomo-benchmark.sh --conversations 0,1 --judge --output benchmarks/results/locomo-mini.json
 ```
 
-- `BENCH_JUDGE_MODEL` enables category-5 judging for `tests/benchmarks/test_locomo.py`.
-- `--judge` and `--judge-model` both enable the judge; `--judge` defaults to `gpt-5.1` unless overridden by `BENCH_JUDGE_MODEL` or `--judge-model`.
-- If the judge is disabled, category 5 remains `N/A`.
-- If the judge is enabled but evidence is missing or the LLM response is invalid, the affected category-5 questions are skipped rather than counted wrong.
+Relevant flags for `./test-locomo-benchmark.sh`:
+
+- `--conversations I,J,...` runs only the selected **0-based** conversation indices from `locomo10.json`. Default: all 10 conversations. Example: `0` runs the first conversation only; `0,1` is the same 2-conversation scope as `locomo-mini`.
+- `--judge` enables category-5 judging. Default: disabled.
+- `--judge-model MODEL` enables category-5 judging and uses `MODEL`. Default when judge is enabled: `gpt-5.4-mini-2026-03-17`, unless overridden by `BENCH_JUDGE_MODEL`.
+- `--output PATH` saves JSON results to `PATH`. Default: no output file is written.
+- `--recall-limit N` sets memories recalled per question. Default: `10`.
+- `--live` runs against Railway instead of local Docker. Default: local Docker.
+- `--no-cleanup` keeps benchmark test data after the run. Default: cleanup enabled.
+
+`make bench-eval` wraps the snapshot-based benchmark flow and always writes results to `benchmarks/results/<bench>_<config>_<timestamp>.json`.
+
+If the judge is disabled, category 5 remains `N/A`. If the judge is enabled but evidence is missing or the LLM response is invalid, the affected category-5 questions are skipped rather than counted wrong.
 
 ### What is LoCoMo?
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -260,7 +260,7 @@ LoCoMo evaluates AI systems' ability to remember and reason across very long con
 4. **Open Domain** (Category 4) - General knowledge questions
 5. **Complex Reasoning** (Category 5) - Advanced inference tasks
 
-Published reference point: CORE is widely cited at **88.24%** (June 2025), but public LoCoMo setups are not perfectly apples-to-apples, especially around category-5 handling.
+Historical note: older public LoCoMo references such as CORE's **88.24%** are still useful background context, but they are not AutoMem's primary comparison target because the public setups are not perfectly apples-to-apples, especially around category-5 handling.
 
 AutoMem currently publishes two LoCoMo baselines:
 
@@ -315,13 +315,9 @@ Example benchmark output:
   Open Domain              : 95.24% (801/841)
   Complex Reasoning        : 95.74% (427/446)
 
-📊 Comparison with published CORE reference:
-  CORE: 88.24%
-  AutoMem: 87.56%
-  📉 AutoMem is 0.68% behind that reference
 ```
 
-If you run without the judge, category 5 will show as `N/A` and the comparison should be treated as directional rather than apples-to-apples.
+If you run without the judge, category 5 will show as `N/A`.
 
 Current baselines and methodology notes live in `benchmarks/EXPERIMENT_LOG.md`.
 
@@ -341,7 +337,7 @@ If you are building an external eval harness against local AutoMem, use the cont
 
 AutoMem is expected to perform well due to:
 
-1. **Richer Graph**: 11 relationship types vs CORE's basic temporal links
+1. **Richer Graph**: 11 relationship types, beyond simple temporal-link-only baselines
    - `RELATES_TO`, `LEADS_TO`, `OCCURRED_BEFORE`
    - `PREFERS_OVER`, `EXEMPLIFIES`, `CONTRADICTS`
    - `REINFORCES`, `INVALIDATED_BY`, `EVOLVED_INTO`

--- a/scripts/bench/analyze_locomo_results.py
+++ b/scripts/bench/analyze_locomo_results.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Generate a markdown failure report from a LoCoMo results JSON file.
+
+Usage:
+    python scripts/bench/analyze_locomo_results.py benchmarks/results/locomo-mini.json
+    python scripts/bench/analyze_locomo_results.py results.json --output report.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Dict, List
+
+CATEGORY_NAMES = {
+    1: "Single-hop Recall",
+    2: "Temporal Understanding",
+    3: "Multi-hop Reasoning",
+    4: "Open Domain",
+    5: "Complex Reasoning",
+}
+
+
+def load_results(path: str) -> Dict[str, Any]:
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        print(f"ERROR: Result file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: Invalid JSON in {path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def format_pct(value: float) -> str:
+    return f"{value:.2%}"
+
+
+def escape_md(value: Any) -> str:
+    return str(value).replace("|", "\\|").replace("\n", " ").strip()
+
+
+def collect_question_rows(results: Dict[str, Any]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for conversation in results.get("conversations", []):
+        sample_id = conversation.get("sample_id", "unknown")
+        for qa in conversation.get("qa_results", []):
+            rows.append(
+                {
+                    "sample_id": sample_id,
+                    "category": qa.get("category"),
+                    "question": qa.get("question", ""),
+                    "expected_answer": qa.get("expected_answer"),
+                    "is_correct": qa.get("is_correct"),
+                    "confidence": float(qa.get("confidence") or 0.0),
+                    "recalled_count": int(qa.get("recalled_count") or 0),
+                    "explanation": qa.get("explanation", ""),
+                }
+            )
+    return rows
+
+
+def render_report(results: Dict[str, Any], source_path: Path) -> str:
+    rows = collect_question_rows(results)
+    failed = [row for row in rows if row["is_correct"] is False]
+    skipped = [row for row in rows if row["is_correct"] is None]
+
+    overall = results.get("overall", {})
+    accuracy = float(overall.get("accuracy") or 0.0)
+    correct = overall.get("correct", 0)
+    total = overall.get("total", 0)
+
+    by_category: Dict[int, List[Dict[str, Any]]] = defaultdict(list)
+    for row in failed:
+        if isinstance(row["category"], int):
+            by_category[row["category"]].append(row)
+
+    category_counts = sorted(by_category.items(), key=lambda item: item[0])
+    conversation_counts = Counter(row["sample_id"] for row in failed)
+    explanation_counts = Counter(row["explanation"] for row in failed)
+
+    lines: List[str] = []
+    lines.append(f"# LoCoMo Failure Report: `{source_path.name}`")
+    lines.append("")
+    lines.append("## Overview")
+    lines.append(f"- Overall accuracy: {format_pct(accuracy)} ({correct}/{total})")
+    lines.append(f"- Failed questions: {len(failed)}")
+    lines.append(f"- Skipped questions: {len(skipped)}")
+    lines.append(f"- Conversations with failures: {len(conversation_counts)}")
+    lines.append("")
+
+    lines.append("## Failures by Category")
+    lines.append("| Category | Name | Failed |")
+    lines.append("|---|---|---:|")
+    for category, category_rows in category_counts:
+        lines.append(
+            f"| {category} | {CATEGORY_NAMES.get(category, f'Category {category}')} | {len(category_rows)} |"
+        )
+    if not category_counts:
+        lines.append("| - | None | 0 |")
+    lines.append("")
+
+    lines.append("## Failures by Conversation")
+    lines.append("| Conversation | Failed |")
+    lines.append("|---|---:|")
+    for sample_id, count in sorted(
+        conversation_counts.items(), key=lambda item: (-item[1], item[0])
+    ):
+        lines.append(f"| {escape_md(sample_id)} | {count} |")
+    if not conversation_counts:
+        lines.append("| None | 0 |")
+    lines.append("")
+
+    lines.append("## Top Failure Explanations")
+    lines.append("| Explanation | Count |")
+    lines.append("|---|---:|")
+    for explanation, count in explanation_counts.most_common():
+        lines.append(f"| {escape_md(explanation)} | {count} |")
+    if not explanation_counts:
+        lines.append("| None | 0 |")
+    lines.append("")
+
+    lines.append("## Failed Questions by Category")
+    for category, category_rows in category_counts:
+        lines.append(
+            f"### Category {category}: {CATEGORY_NAMES.get(category, f'Category {category}')}"
+        )
+        for row in sorted(category_rows, key=lambda item: (item["sample_id"], item["question"])):
+            lines.append(f"- [{escape_md(row['sample_id'])}] {escape_md(row['question'])}")
+            lines.append(f"  - Expected: {escape_md(row['expected_answer'])}")
+            lines.append(f"  - Confidence: {row['confidence']:.2f}")
+            lines.append(f"  - Recalled: {row['recalled_count']}")
+            lines.append(f"  - Explanation: {escape_md(row['explanation'])}")
+        lines.append("")
+    if not category_counts:
+        lines.append("No failed questions.")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Analyze a LoCoMo benchmark results JSON file")
+    parser.add_argument("results", help="Path to results JSON")
+    parser.add_argument("--output", default=None, help="Optional path to save the markdown report")
+    args = parser.parse_args()
+
+    source_path = Path(args.results)
+    report = render_report(load_results(args.results), source_path)
+    if args.output:
+        Path(args.output).write_text(report)
+    print(report, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/test-locomo-benchmark.sh
+++ b/test-locomo-benchmark.sh
@@ -73,7 +73,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --live              Run against Railway deployment (default: local Docker)"
             echo "  --recall-limit N    Number of memories to recall per question (default: 10)"
             echo "  --conversations I,J Comma-separated conversation indices (e.g. 0,1 for mini mode)"
-            echo "  --judge             Enable category-5 LLM judge (defaults to gpt-5.1)"
+            echo "  --judge             Enable category-5 LLM judge (defaults to gpt-5.4-mini-2026-03-17)"
             echo "  --judge-model MODEL Set the category-5 judge model (also enables judge)"
             echo "  --no-cleanup        Don't cleanup test data after evaluation"
             echo "  --output FILE       Save results to JSON file"
@@ -204,8 +204,46 @@ if [ -n "$JUDGE_MODEL" ]; then
     PYTHON_CMD="$PYTHON_CMD --judge-model $JUDGE_MODEL"
 fi
 
+RESOLVED_JUDGE_MODEL=""
+if [ "$JUDGE" = true ]; then
+    if [ -n "$JUDGE_MODEL" ]; then
+        RESOLVED_JUDGE_MODEL="$JUDGE_MODEL"
+    elif [ -n "${BENCH_JUDGE_MODEL:-}" ]; then
+        RESOLVED_JUDGE_MODEL="$BENCH_JUDGE_MODEL"
+    else
+        RESOLVED_JUDGE_MODEL="gpt-5.4-mini-2026-03-17"
+    fi
+fi
+
 echo ""
 echo -e "${BLUE}🚀 Starting benchmark evaluation...${NC}"
+echo -e "${BLUE}Configuration:${NC}"
+if [ "$RUN_LIVE" = true ]; then
+    echo "  Target: Railway"
+else
+    echo "  Target: local Docker"
+fi
+if [ -n "$CONVERSATIONS" ]; then
+    echo "  Conversations: $CONVERSATIONS"
+else
+    echo "  Conversations: all"
+fi
+echo "  Recall limit: $RECALL_LIMIT"
+if [ "$NO_CLEANUP" = true ]; then
+    echo "  Cleanup: disabled"
+else
+    echo "  Cleanup: enabled"
+fi
+if [ "$JUDGE" = true ]; then
+    echo "  Judge: enabled ($RESOLVED_JUDGE_MODEL)"
+else
+    echo "  Judge: disabled"
+fi
+if [ -n "$OUTPUT_FILE" ]; then
+    echo "  Output: $OUTPUT_FILE"
+else
+    echo "  Output: none"
+fi
 echo ""
 
 # Run the benchmark

--- a/tests/benchmarks/core_adapter/evaluate.js
+++ b/tests/benchmarks/core_adapter/evaluate.js
@@ -35,7 +35,7 @@ const CONFIG = {
   // GPT-4.1: ~$2/1M input, ~$8/1M output (good balance)
   // gpt-4o-mini: cheapest but weaker reasoning
   model: process.env.EVAL_MODEL || "gpt-5.1",
-  evalModel: process.env.EVAL_JUDGE_MODEL || "gpt-5.1",
+  evalModel: process.env.EVAL_JUDGE_MODEL || "gpt-5.4-mini-2026-03-17",
 };
 
 // Initialize services

--- a/tests/benchmarks/judge_policy.py
+++ b/tests/benchmarks/judge_policy.py
@@ -1,0 +1,54 @@
+"""Shared benchmark judge policy for AutoMem internal evaluations."""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Dict, Optional
+
+CANONICAL_BENCHMARK_JUDGE_MODEL = "gpt-5.4-mini-2026-03-17"
+CANONICAL_BENCHMARK_JUDGE_PROFILE = "openai-gpt-5.4-mini-2026-03-17"
+DEFAULT_JUDGE_PROVIDER = "openai"
+
+_SNAPSHOT_SUFFIX_RE = re.compile(r".+-\d{4}-\d{2}-\d{2}$")
+
+
+def is_gpt5_family(model_name: Optional[str]) -> bool:
+    return bool(model_name and model_name.strip().lower().startswith("gpt-5"))
+
+
+def judge_snapshot_pinned(model_name: Optional[str]) -> bool:
+    return bool(model_name and _SNAPSHOT_SUFFIX_RE.match(model_name.strip()))
+
+
+def judge_profile_for(
+    model_name: Optional[str],
+    *,
+    profile: Optional[str] = None,
+    env_var: str = "BENCH_JUDGE_PROFILE",
+) -> Optional[str]:
+    if not model_name:
+        return None
+    if profile and profile.strip():
+        return profile.strip()
+    env_profile = os.getenv(env_var)
+    if env_profile and env_profile.strip():
+        return env_profile.strip()
+    if model_name == CANONICAL_BENCHMARK_JUDGE_MODEL:
+        return CANONICAL_BENCHMARK_JUDGE_PROFILE
+    return f"custom-{model_name}"
+
+
+def judge_metadata(
+    model_name: Optional[str],
+    *,
+    provider: Optional[str] = DEFAULT_JUDGE_PROVIDER,
+    profile: Optional[str] = None,
+    env_var: str = "BENCH_JUDGE_PROFILE",
+) -> Dict[str, Any]:
+    return {
+        "judge_model": model_name,
+        "judge_profile": judge_profile_for(model_name, profile=profile, env_var=env_var),
+        "judge_provider": provider if model_name else None,
+        "judge_snapshot_pinned": judge_snapshot_pinned(model_name),
+    }

--- a/tests/benchmarks/longmemeval/configs.py
+++ b/tests/benchmarks/longmemeval/configs.py
@@ -50,7 +50,7 @@ class LongMemEvalConfig:
     request_timeout: int = 30
 
     # Evaluation
-    use_llm_eval: bool = False  # Use GPT-4o for evaluation (costs money)
+    use_llm_eval: bool = False  # Use canonical OpenAI judge for evaluation (costs money)
     max_questions: int = 0  # 0 = all questions
 
     # Tag prefix for cleanup

--- a/tests/benchmarks/longmemeval/evaluator.py
+++ b/tests/benchmarks/longmemeval/evaluator.py
@@ -3,7 +3,7 @@ LongMemEval Evaluation Module
 
 Provides scoring utilities:
 - Quick local scoring (exact match, substring, F1 token overlap)
-- GPT-4o-based evaluation (matches LongMemEval paper's methodology)
+- LLM-based evaluation with the canonical AutoMem judge by default
 """
 
 import json
@@ -11,6 +11,8 @@ import os
 import re
 from collections import Counter
 from typing import Any, ClassVar, Dict, List, Optional, Tuple
+
+from tests.benchmarks.judge_policy import is_gpt5_family
 
 try:
     from openai import OpenAI
@@ -153,7 +155,7 @@ def llm_evaluate(
     client: Optional[Any] = None,
 ) -> Dict[str, Any]:
     """
-    GPT-4o-based evaluation matching LongMemEval paper methodology.
+    LLM-based evaluation matching the LongMemEval paper's judge style.
 
     The evaluator asks the LLM to judge whether the hypothesis correctly
     answers the question given the reference answer.
@@ -202,12 +204,35 @@ Respond with ONLY a JSON object:
 {{"correct": true/false, "confidence": 0.0-1.0, "explanation": "brief reason"}}"""
 
     try:
-        response = client.chat.completions.create(
-            model=model,
-            messages=[{"role": "user", "content": prompt}],
-            temperature=0,
-            max_tokens=200,
-        )
+        request_kwargs: Dict[str, Any] = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        if is_gpt5_family(model):
+            request_kwargs["max_completion_tokens"] = 200
+            request_kwargs["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "longmemeval_judge",
+                    "strict": True,
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "correct": {"type": "boolean"},
+                            "confidence": {"type": "number"},
+                            "explanation": {"type": "string"},
+                        },
+                        "required": ["correct", "confidence", "explanation"],
+                        "additionalProperties": False,
+                    },
+                },
+            }
+        else:
+            request_kwargs["temperature"] = 0
+            request_kwargs["max_tokens"] = 200
+            request_kwargs["response_format"] = {"type": "json_object"}
+
+        response = client.chat.completions.create(**request_kwargs)
         content = response.choices[0].message.content.strip()
 
         # Parse JSON response (handle fenced markdown like ```json ... ```)

--- a/tests/benchmarks/longmemeval/test_evaluator.py
+++ b/tests/benchmarks/longmemeval/test_evaluator.py
@@ -1,4 +1,6 @@
-from tests.benchmarks.longmemeval.evaluator import normalize_text, quick_score
+from types import SimpleNamespace
+
+from tests.benchmarks.longmemeval.evaluator import llm_evaluate, normalize_text, quick_score
 
 
 def test_normalize_text_coerces_non_string_inputs() -> None:
@@ -10,3 +12,63 @@ def test_quick_score_handles_numeric_reference() -> None:
     result = quick_score("The answer is 500.", 500, "q_1")
     assert isinstance(result, dict)
     assert result["is_correct"] is True
+
+
+def test_llm_evaluate_uses_gpt5_compatible_structured_request() -> None:
+    captured = {}
+
+    class _Completions:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            content = '{"correct": true, "confidence": 0.9, "explanation": "matches"}'
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+            )
+
+    client = SimpleNamespace(chat=SimpleNamespace(completions=_Completions()))
+
+    result = llm_evaluate(
+        question="What is the name?",
+        hypothesis="Ada",
+        reference="Ada",
+        question_id="q_1",
+        model="gpt-5.4-mini-2026-03-17",
+        client=client,
+    )
+
+    assert result["is_correct"] is True
+    assert captured["model"] == "gpt-5.4-mini-2026-03-17"
+    assert captured["max_completion_tokens"] == 200
+    assert "max_tokens" not in captured
+    assert "temperature" not in captured
+    assert captured["response_format"]["type"] == "json_schema"
+    assert captured["response_format"]["json_schema"]["strict"] is True
+
+
+def test_llm_evaluate_keeps_json_mode_for_non_gpt5_models() -> None:
+    captured = {}
+
+    class _Completions:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            content = '{"correct": false, "confidence": 0.2, "explanation": "miss"}'
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+            )
+
+    client = SimpleNamespace(chat=SimpleNamespace(completions=_Completions()))
+
+    result = llm_evaluate(
+        question="What is the name?",
+        hypothesis="Grace",
+        reference="Ada",
+        question_id="q_1",
+        model="gpt-4o-mini",
+        client=client,
+    )
+
+    assert result["is_correct"] is False
+    assert captured["max_tokens"] == 200
+    assert captured["temperature"] == 0
+    assert "max_completion_tokens" not in captured
+    assert captured["response_format"] == {"type": "json_object"}

--- a/tests/benchmarks/longmemeval/test_longmemeval.py
+++ b/tests/benchmarks/longmemeval/test_longmemeval.py
@@ -54,6 +54,11 @@ except ImportError:
     OpenAI = None
 
 from tests.benchmarks.backends import MemoryRecord, SearchRequest, create_backend
+from tests.benchmarks.judge_policy import (
+    CANONICAL_BENCHMARK_JUDGE_MODEL,
+    DEFAULT_JUDGE_PROVIDER,
+    judge_metadata,
+)
 from tests.benchmarks.longmemeval.configs import LongMemEvalConfig, get_config
 from tests.benchmarks.longmemeval.evaluator import (
     LongMemEvalScorer,
@@ -102,6 +107,11 @@ class LongMemEvalBenchmark:
         self.openai_client = None
         if OpenAI and os.getenv("OPENAI_API_KEY"):
             self.openai_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+    def effective_judge_model(self) -> Optional[str]:
+        if not self.config.use_llm_eval:
+            return None
+        return self.config.eval_llm_model or CANONICAL_BENCHMARK_JUDGE_MODEL
 
     def health_check(self) -> bool:
         """Verify the configured backend is accessible."""
@@ -492,7 +502,7 @@ Answer:"""
 
         # Score
         if self.config.use_llm_eval and self.openai_client:
-            eval_model = self.config.eval_llm_model or self.config.llm_model
+            eval_model = self.effective_judge_model()
             eval_result = llm_evaluate(
                 question=question,
                 hypothesis=hypothesis,
@@ -570,6 +580,8 @@ Answer:"""
         print(f"  Temporal hints: {self.config.use_temporal_hints}")
         print(f"  LLM model: {self.config.llm_model}")
         print(f"  LLM eval: {self.config.use_llm_eval}")
+        if self.config.use_llm_eval:
+            print(f"  Judge model: {self.effective_judge_model()}")
         has_llm = self.openai_client is not None
         print(f"  OpenAI available: {has_llm}")
         print()
@@ -613,6 +625,7 @@ Answer:"""
         scores = self.scorer.print_report(config_name=self.config.name, elapsed_time=elapsed_time)
         scores["backend"] = self.backend.name
         scores["elapsed_time"] = elapsed_time
+        effective_judge_model = self.effective_judge_model()
         scores["config"] = {
             "backend": self.config.backend,
             "name": self.config.name,
@@ -625,6 +638,7 @@ Answer:"""
             "llm_model": self.config.llm_model,
             "eval_llm_model": self.config.eval_llm_model,
             "use_llm_eval": self.config.use_llm_eval,
+            **judge_metadata(effective_judge_model, provider=DEFAULT_JUDGE_PROVIDER),
         }
         scores["memory_ingest_failures"] = self.memory_ingest_failures
         scores["details"] = all_results
@@ -728,7 +742,7 @@ def main() -> int:
     parser.add_argument(
         "--llm-eval",
         action="store_true",
-        help="Use GPT-4o for evaluation (costs money, more accurate)",
+        help="Use canonical OpenAI judge for evaluation (costs money, more accurate)",
     )
     parser.add_argument(
         "--no-cleanup",

--- a/tests/benchmarks/test_locomo.py
+++ b/tests/benchmarks/test_locomo.py
@@ -52,6 +52,18 @@ from tests.benchmarks.judge_policy import (
 )
 
 DEFAULT_CAT5_JUDGE_MODEL = CANONICAL_BENCHMARK_JUDGE_MODEL
+JUDGE_API_SURFACE = "chat.completions"
+LOCOMO_CAT5_JUDGE_PROMPT_VERSION = "locomo-cat5-v1"
+LOCOMO_CAT5_JUDGE_SCHEMA_VERSION = "locomo-cat5-json-v1"
+JUDGE_PRICING_USD_PER_1M = {
+    "gpt-5.4": {"input": 2.50, "output": 15.00},
+    "gpt-5.4-mini": {"input": 0.75, "output": 4.50},
+    "gpt-5.4-nano": {"input": 0.20, "output": 1.25},
+    "gpt-5.4-pro": {"input": 30.00, "output": 180.00},
+    "gpt-4o-mini": {"input": 0.15, "output": 0.60},
+    "gpt-4.1": {"input": 2.0, "output": 8.0},
+    "gpt-5.1": {"input": 1.25, "output": 10.0},
+}
 
 
 @dataclass
@@ -101,6 +113,15 @@ def _default_scope_prefix(backend: str, data_file: str) -> str:
     return f"locomo-{backend}-{digest}"
 
 
+def _pricing_model_key(model_name: Optional[str]) -> Optional[str]:
+    if not model_name:
+        return None
+    normalized = model_name.strip()
+    if re.match(r".+-\d{4}-\d{2}-\d{2}$", normalized):
+        return re.sub(r"-\d{4}-\d{2}-\d{2}$", "", normalized)
+    return normalized
+
+
 class LoCoMoEvaluator:
     """Evaluates AutoMem against the LoCoMo benchmark"""
 
@@ -136,6 +157,19 @@ class LoCoMoEvaluator:
         # Embedding-based answer checking (fast, handles semantic similarity)
         self.use_embedding_similarity = self.has_openai_api_key
         self.embedding_cache = {}  # text -> embedding vector
+        self.judge_stats = {
+            "questions_requiring_judge": 0,
+            "api_calls": 0,
+            "cache_hits": 0,
+            "errors": 0,
+            "skipped": 0,
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        }
+        self._judge_api_latencies_ms: List[float] = []
+        self._judge_estimated_cost_usd = 0.0
+        self._judge_cost_estimate_available = True
 
     def health_check(self) -> bool:
         """Verify the configured backend is accessible."""
@@ -1115,41 +1149,224 @@ Respond in JSON format:
     def _judge_metadata(self) -> Dict[str, Any]:
         return judge_metadata(self.config.judge_model, provider=DEFAULT_JUDGE_PROVIDER)
 
+    @staticmethod
+    def _hash_payload(payload: Any) -> str:
+        if isinstance(payload, (dict, list, tuple)):
+            text = json.dumps(payload, sort_keys=True)
+        else:
+            text = str(payload)
+        return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _usage_value(usage: Any, field: str) -> int:
+        if usage is None:
+            return 0
+        value = usage.get(field, 0) if isinstance(usage, dict) else getattr(usage, field, 0)
+        try:
+            return int(value or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _percentile(values: List[float], percentile: float) -> Optional[float]:
+        if not values:
+            return None
+        ordered = sorted(values)
+        if len(ordered) == 1:
+            return ordered[0]
+        rank = (len(ordered) - 1) * percentile
+        lower = int(rank)
+        upper = min(lower + 1, len(ordered) - 1)
+        weight = rank - lower
+        return ordered[lower] * (1 - weight) + ordered[upper] * weight
+
+    def _judge_pricing(self) -> Optional[Dict[str, float]]:
+        input_override = os.getenv("BENCH_JUDGE_INPUT_COST_PER_1M")
+        output_override = os.getenv("BENCH_JUDGE_OUTPUT_COST_PER_1M")
+        if input_override and output_override:
+            try:
+                return {
+                    "input": float(input_override),
+                    "output": float(output_override),
+                }
+            except ValueError:
+                return None
+        if not self.config.judge_model:
+            return None
+        return JUDGE_PRICING_USD_PER_1M.get(_pricing_model_key(self.config.judge_model))
+
+    def _estimate_judge_cost(self, prompt_tokens: int, completion_tokens: int) -> Optional[float]:
+        pricing = self._judge_pricing()
+        if not pricing:
+            return None
+        return (prompt_tokens / 1_000_000) * pricing["input"] + (
+            completion_tokens / 1_000_000
+        ) * pricing["output"]
+
+    def _record_judge_usage(self, usage: Any) -> None:
+        prompt_tokens = self._usage_value(usage, "prompt_tokens")
+        completion_tokens = self._usage_value(usage, "completion_tokens")
+        total_tokens = self._usage_value(usage, "total_tokens")
+        if total_tokens == 0 and (prompt_tokens or completion_tokens):
+            total_tokens = prompt_tokens + completion_tokens
+
+        self.judge_stats["prompt_tokens"] += prompt_tokens
+        self.judge_stats["completion_tokens"] += completion_tokens
+        self.judge_stats["total_tokens"] += total_tokens
+
+        estimated_cost = self._estimate_judge_cost(prompt_tokens, completion_tokens)
+        if estimated_cost is None:
+            if prompt_tokens or completion_tokens:
+                self._judge_cost_estimate_available = False
+            return
+        self._judge_estimated_cost_usd += estimated_cost
+
+    def _judge_system_prompt(self) -> str:
+        return (
+            "You are a strict benchmark judge. "
+            "Use recalled memories to draft the answer and evidence dialogs "
+            "only to verify correctness."
+        )
+
+    def _judge_prompt_template(self) -> str:
+        return """You are judging a LoCoMo category-5 complex reasoning answer.
+
+Question:
+{question}
+
+Adversarial answer (distractor; may be wrong, incomplete, or occasionally overlap with the evidence):
+{adversarial_answer}
+
+Recalled memories:
+{recalled_text}
+
+Evidence dialogs (ground truth):
+{evidence_text}
+
+Instructions:
+1. Draft the best answer you can using ONLY the recalled memories.
+2. If the recalled memories do not support a positive answer, it is valid to answer with:
+   - "I don't know"
+   - "The recalled memories do not say"
+   - "The question premise or person appears incorrect"
+3. Compare that drafted answer to the evidence dialogs, which are the only ground truth.
+4. Do NOT assume the adversarial answer is always false; use the evidence dialogs to decide.
+5. Mark the answer correct if the drafted answer materially agrees with the evidence dialogs, including when the correct outcome is abstaining, correcting the person/entity, or stating that the premise is unsupported.
+6. Mark the answer incorrect if the drafted answer asserts content contradicted by the evidence, misses clearly available support in the recalled memories, or simply repeats unsupported adversarial content.
+
+Respond with ONLY a JSON object:
+{{
+  "generated_answer": "answer drafted from recalled memories",
+  "verdict": "supported | abstain | contradiction | unsupported | incorrect",
+  "correct": true,
+  "confidence": 0.0,
+  "reasoning": "brief explanation grounded in the evidence dialogs"
+}}"""
+
+    def _judge_response_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "locomo_cat5_judge",
+            "strict": True,
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "generated_answer": {"type": "string"},
+                    "verdict": {
+                        "type": "string",
+                        "enum": [
+                            "supported",
+                            "abstain",
+                            "contradiction",
+                            "unsupported",
+                            "incorrect",
+                        ],
+                    },
+                    "correct": {"type": "boolean"},
+                    "confidence": {"type": "number"},
+                    "reasoning": {"type": "string"},
+                },
+                "required": [
+                    "generated_answer",
+                    "verdict",
+                    "correct",
+                    "confidence",
+                    "reasoning",
+                ],
+                "additionalProperties": False,
+            },
+        }
+
+    def _judge_config(self) -> Dict[str, Any]:
+        metadata = self._judge_metadata()
+        return {
+            "enabled": bool(self.config.judge_model),
+            "provider": metadata["judge_provider"],
+            "api": JUDGE_API_SURFACE if self.config.judge_model else None,
+            "model": metadata["judge_model"],
+            "profile": metadata["judge_profile"],
+            "snapshot_pinned": metadata["judge_snapshot_pinned"],
+            "prompt_version": (
+                LOCOMO_CAT5_JUDGE_PROMPT_VERSION if self.config.judge_model else None
+            ),
+            "prompt_sha256": (
+                self._hash_payload(
+                    {
+                        "system": self._judge_system_prompt(),
+                        "user_template": self._judge_prompt_template(),
+                    }
+                )
+                if self.config.judge_model
+                else None
+            ),
+            "response_schema_version": (
+                LOCOMO_CAT5_JUDGE_SCHEMA_VERSION if self.config.judge_model else None
+            ),
+            "response_schema_sha256": (
+                self._hash_payload(self._judge_response_schema())
+                if self.config.judge_model
+                else None
+            ),
+            "reasoning_effort": None,
+            "seed": None,
+            "temperature": (
+                (
+                    None
+                    if self._judge_model_uses_structured_outputs(self.config.judge_model)
+                    else 0.0
+                )
+                if self.config.judge_model
+                else None
+            ),
+            "max_completion_tokens_attempts": (
+                list(self._judge_token_attempts()) if self.config.judge_model else []
+            ),
+            "timeout_seconds": (
+                self.OPENAI_REQUEST_TIMEOUT_SECONDS if self.config.judge_model else None
+            ),
+        }
+
+    def _judge_stats_summary(self) -> Dict[str, Any]:
+        latencies = self._judge_api_latencies_ms
+        return {
+            **self.judge_stats,
+            "estimated_cost_usd": (
+                round(self._judge_estimated_cost_usd, 6)
+                if self._judge_cost_estimate_available and latencies
+                else None
+            ),
+            "latency_ms": {
+                "avg": round(sum(latencies) / len(latencies), 3) if latencies else None,
+                "p50": round(self._percentile(latencies, 0.50), 3) if latencies else None,
+                "p95": round(self._percentile(latencies, 0.95), 3) if latencies else None,
+                "max": round(max(latencies), 3) if latencies else None,
+            },
+        }
+
     def _judge_response_format(self) -> Dict[str, Any]:
         if self._judge_model_uses_structured_outputs(self.config.judge_model):
             return {
                 "type": "json_schema",
-                "json_schema": {
-                    "name": "locomo_cat5_judge",
-                    "strict": True,
-                    "schema": {
-                        "type": "object",
-                        "properties": {
-                            "generated_answer": {"type": "string"},
-                            "verdict": {
-                                "type": "string",
-                                "enum": [
-                                    "supported",
-                                    "abstain",
-                                    "contradiction",
-                                    "unsupported",
-                                    "incorrect",
-                                ],
-                            },
-                            "correct": {"type": "boolean"},
-                            "confidence": {"type": "number"},
-                            "reasoning": {"type": "string"},
-                        },
-                        "required": [
-                            "generated_answer",
-                            "verdict",
-                            "correct",
-                            "confidence",
-                            "reasoning",
-                        ],
-                        "additionalProperties": False,
-                    },
-                },
+                "json_schema": self._judge_response_schema(),
             }
         return {"type": "json_object"}
 
@@ -1197,6 +1414,8 @@ Respond in JSON format:
         evidence_text = self._format_memories_for_llm(evidence_memories, limit=8)
         cache_key = self._make_llm_cache_key(
             "judge_cat5",
+            LOCOMO_CAT5_JUDGE_PROMPT_VERSION,
+            LOCOMO_CAT5_JUDGE_SCHEMA_VERSION,
             self.config.judge_model,
             question,
             adversarial_answer,
@@ -1205,55 +1424,27 @@ Respond in JSON format:
             evidence_text,
         )
         if cache_key in self.llm_cache:
+            self.judge_stats["cache_hits"] += 1
             return self.llm_cache[cache_key]
 
-        prompt = f"""You are judging a LoCoMo category-5 complex reasoning answer.
-
-Question:
-{question}
-
-Adversarial answer (distractor; may be wrong, incomplete, or occasionally overlap with the evidence):
-{adversarial_answer or "None"}
-
-Recalled memories:
-{recalled_text}
-
-Evidence dialogs (ground truth):
-{evidence_text}
-
-Instructions:
-1. Draft the best answer you can using ONLY the recalled memories.
-2. If the recalled memories do not support a positive answer, it is valid to answer with:
-   - "I don't know"
-   - "The recalled memories do not say"
-   - "The question premise or person appears incorrect"
-3. Compare that drafted answer to the evidence dialogs, which are the only ground truth.
-4. Do NOT assume the adversarial answer is always false; use the evidence dialogs to decide.
-5. Mark the answer correct if the drafted answer materially agrees with the evidence dialogs, including when the correct outcome is abstaining, correcting the person/entity, or stating that the premise is unsupported.
-6. Mark the answer incorrect if the drafted answer asserts content contradicted by the evidence, misses clearly available support in the recalled memories, or simply repeats unsupported adversarial content.
-
-Respond with ONLY a JSON object:
-{{
-  "generated_answer": "answer drafted from recalled memories",
-  "verdict": "supported | abstain | contradiction | unsupported | incorrect",
-  "correct": true,
-  "confidence": 0.0,
-  "reasoning": "brief explanation grounded in the evidence dialogs"
-}}"""
+        prompt = self._judge_prompt_template().format(
+            question=question,
+            adversarial_answer=adversarial_answer or "None",
+            recalled_text=recalled_text,
+            evidence_text=evidence_text,
+        )
 
         last_error: Optional[Exception] = None
         for token_budget in self._judge_token_attempts():
+            request_started = time.perf_counter()
+            self.judge_stats["api_calls"] += 1
             try:
                 request_kwargs: Dict[str, Any] = {
                     "model": self.config.judge_model,
                     "messages": [
                         {
                             "role": "system",
-                            "content": (
-                                "You are a strict benchmark judge. "
-                                "Use recalled memories to draft the answer and evidence dialogs "
-                                "only to verify correctness."
-                            ),
+                            "content": self._judge_system_prompt(),
                         },
                         {"role": "user", "content": prompt},
                     ],
@@ -1267,6 +1458,8 @@ Respond with ONLY a JSON object:
                     request_kwargs["temperature"] = 0.0
 
                 response = self.openai_client.chat.completions.create(**request_kwargs)
+                self._judge_api_latencies_ms.append((time.perf_counter() - request_started) * 1000)
+                self._record_judge_usage(getattr(response, "usage", None))
                 result = self._parse_json_object_response(response.choices[0].message.content)
                 correct = result.get("correct")
                 if not isinstance(correct, bool):
@@ -1286,8 +1479,10 @@ Respond with ONLY a JSON object:
                 self.llm_cache[cache_key] = judge_result
                 return judge_result
             except Exception as e:
+                self._judge_api_latencies_ms.append((time.perf_counter() - request_started) * 1000)
                 last_error = e
 
+        self.judge_stats["errors"] += 1
         error_result = (
             None,
             0.0,
@@ -1586,6 +1781,7 @@ Respond with ONLY a JSON object:
         base_result["recalled_count"] = len(recalled_memories)
 
         if category == 5 and not answer:
+            self.judge_stats["questions_requiring_judge"] += 1
             (
                 is_correct,
                 confidence,
@@ -1608,6 +1804,8 @@ Respond with ONLY a JSON object:
                     "judge_reasoning": judge_reasoning,
                 }
             )
+            if is_correct is None:
+                self.judge_stats["skipped"] += 1
             return base_result
 
         is_correct, confidence, explanation = self.check_answer_in_memories(
@@ -1857,6 +2055,39 @@ Respond with ONLY a JSON object:
         print(f"\n🎯 Overall Accuracy: {overall_accuracy:.2%} ({total_correct}/{total_questions})")
         print(f"⏱️  Total Time: {elapsed_time:.1f}s")
         print(f"💾 Total Memories Stored: {sum(r['memory_count'] for r in conversation_results)}")
+        if self.config.judge_model:
+            judge_config = self._judge_config()
+            judge_stats = self._judge_stats_summary()
+            print("\n🧑‍⚖️ Judge Summary:")
+            print(f"  Model: {judge_config['model']}")
+            print(f"  Profile: {judge_config['profile']}")
+            print(
+                "  Questions/API calls/cache hits/skipped: "
+                f"{judge_stats['questions_requiring_judge']}/"
+                f"{judge_stats['api_calls']}/"
+                f"{judge_stats['cache_hits']}/"
+                f"{judge_stats['skipped']}"
+            )
+            if judge_stats["api_calls"]:
+                print(
+                    "  Tokens (prompt/completion/total): "
+                    f"{judge_stats['prompt_tokens']}/"
+                    f"{judge_stats['completion_tokens']}/"
+                    f"{judge_stats['total_tokens']}"
+                )
+                latency = judge_stats["latency_ms"]
+                print(
+                    "  API latency ms (avg/p50/p95/max): "
+                    f"{latency['avg']:.1f}/"
+                    f"{latency['p50']:.1f}/"
+                    f"{latency['p95']:.1f}/"
+                    f"{latency['max']:.1f}"
+                )
+                cost = judge_stats["estimated_cost_usd"]
+                if cost is None:
+                    print("  Estimated API cost: n/a")
+                else:
+                    print(f"  Estimated API cost: ${cost:.4f}")
 
         # Category breakdown
         print("\n📈 Category Breakdown:")
@@ -1917,14 +2148,8 @@ Respond with ONLY a JSON object:
                     f"  {cat5_name:25s}: {accuracy:6.2%} ({correct:3d}/{total:3d}, {cat5_skipped:3d} skipped)"
                 )
 
-        # Comparison with the published CORE reference.
-        # Treat 88.24% as a useful external reference point, not a strict
-        # apples-to-apples leaderboard, because public LoCoMo setups differ.
         core_sota = 0.8824
         improvement = overall_accuracy - core_sota
-        print("\n📊 Comparison with published CORE reference:")
-        print(f"  CORE: {core_sota:.2%}")
-        print(f"  AutoMem: {overall_accuracy:.2%}")
         if cat5_skipped:
             if self.config.judge_model:
                 print(
@@ -1934,12 +2159,6 @@ Respond with ONLY a JSON object:
                 print(
                     f"  ⚠️  AutoMem excludes {cat5_skipped} cat-5 Qs (needs LLM judge); treat comparison as directional only"
                 )
-        if improvement > 0:
-            print(f"  📈 AutoMem is {improvement:.2%} above that reference")
-        elif improvement < 0:
-            print(f"  📉 AutoMem is {abs(improvement):.2%} behind that reference")
-        else:
-            print("  🤝 AutoMem matches that reference")
 
         # Cleanup
         if cleanup_after:
@@ -1958,6 +2177,8 @@ Respond with ONLY a JSON object:
             "judge_requested": bool(self.config.judge_model),
             "judge_available": bool(self.config.judge_model and self.openai_client),
             **self._judge_metadata(),
+            "judge_config": self._judge_config(),
+            "judge_stats": self._judge_stats_summary(),
             "categories": category_results,
             "conversations": conversation_results,
             "comparison": {

--- a/tests/benchmarks/test_locomo.py
+++ b/tests/benchmarks/test_locomo.py
@@ -1479,7 +1479,10 @@ Respond with ONLY a JSON object:
                 self.llm_cache[cache_key] = judge_result
                 return judge_result
             except Exception as e:
-                self._judge_api_latencies_ms.append((time.perf_counter() - request_started) * 1000)
+                if len(self._judge_api_latencies_ms) < self.judge_stats["api_calls"]:
+                    self._judge_api_latencies_ms.append(
+                        (time.perf_counter() - request_started) * 1000
+                    )
                 last_error = e
 
         self.judge_stats["errors"] += 1

--- a/tests/benchmarks/test_locomo.py
+++ b/tests/benchmarks/test_locomo.py
@@ -44,8 +44,14 @@ load_dotenv()
 load_dotenv(Path.home() / ".config" / "automem" / ".env")
 
 from tests.benchmarks.backends import MemoryRecord, SearchRequest, create_backend
+from tests.benchmarks.judge_policy import (
+    CANONICAL_BENCHMARK_JUDGE_MODEL,
+    DEFAULT_JUDGE_PROVIDER,
+    is_gpt5_family,
+    judge_metadata,
+)
 
-DEFAULT_CAT5_JUDGE_MODEL = "gpt-5.1"
+DEFAULT_CAT5_JUDGE_MODEL = CANONICAL_BENCHMARK_JUDGE_MODEL
 
 
 @dataclass
@@ -1104,7 +1110,10 @@ Respond in JSON format:
     @staticmethod
     def _judge_model_uses_structured_outputs(model_name: Optional[str]) -> bool:
         """GPT-5 family models prefer strict json_schema over legacy json_object mode."""
-        return bool(model_name and model_name.strip().lower().startswith("gpt-5"))
+        return is_gpt5_family(model_name)
+
+    def _judge_metadata(self) -> Dict[str, Any]:
+        return judge_metadata(self.config.judge_model, provider=DEFAULT_JUDGE_PROVIDER)
 
     def _judge_response_format(self) -> Dict[str, Any]:
         if self._judge_model_uses_structured_outputs(self.config.judge_model):
@@ -1162,7 +1171,13 @@ Respond in JSON format:
             return None, 0.0, "Skipped: requires LLM judge", None, None
 
         if not self.openai_client:
-            return None, 0.0, "Skipped: OPENAI_API_KEY not set for LLM judge", None, None
+            return (
+                None,
+                0.0,
+                "Skipped: OPENAI_API_KEY not set for LLM judge",
+                None,
+                None,
+            )
 
         evidence_memories = self.fetch_evidence_memories(
             evidence_dialog_ids,
@@ -1942,7 +1957,7 @@ Respond with ONLY a JSON object:
             "backend": self.backend.name,
             "judge_requested": bool(self.config.judge_model),
             "judge_available": bool(self.config.judge_model and self.openai_client),
-            "judge_model": self.config.judge_model,
+            **self._judge_metadata(),
             "categories": category_results,
             "conversations": conversation_results,
             "comparison": {

--- a/tests/test_benchmark_env_loading.py
+++ b/tests/test_benchmark_env_loading.py
@@ -58,3 +58,17 @@ def test_longmemeval_benchmark_loads_openai_api_key_from_global_env(
     benchmark = module.LongMemEvalBenchmark(module.get_config("baseline"))
 
     assert benchmark.openai_client is not None
+
+
+def test_longmemeval_llm_eval_defaults_to_canonical_judge(monkeypatch) -> None:
+    monkeypatch.delenv("LONGMEMEVAL_EVAL_LLM_MODEL", raising=False)
+    module_path = (
+        Path(__file__).resolve().parent / "benchmarks" / "longmemeval" / "test_longmemeval.py"
+    )
+    module = _load_module("longmemeval_canonical_judge", module_path)
+    monkeypatch.setattr(module, "create_backend", lambda *args, **kwargs: _DummyBackend())
+
+    config = module.get_config("baseline", use_llm_eval=True)
+    benchmark = module.LongMemEvalBenchmark(config)
+
+    assert benchmark.effective_judge_model() == "gpt-5.4-mini-2026-03-17"

--- a/tests/test_benchmark_result_analyzer.py
+++ b/tests/test_benchmark_result_analyzer.py
@@ -1,0 +1,88 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "bench" / "analyze_locomo_results.py"
+
+
+def test_analyze_locomo_results_generates_markdown_report(tmp_path: Path) -> None:
+    input_path = tmp_path / "results.json"
+    output_path = tmp_path / "report.md"
+    input_path.write_text(
+        json.dumps(
+            {
+                "overall": {"accuracy": 0.5, "correct": 2, "total": 4},
+                "conversations": [
+                    {
+                        "sample_id": "conv-1",
+                        "qa_results": [
+                            {
+                                "question": "What is Alice's job?",
+                                "expected_answer": "Engineer",
+                                "category": 1,
+                                "is_correct": False,
+                                "confidence": 0.0,
+                                "recalled_count": 12,
+                                "explanation": "No good match (max: 0.00)",
+                            },
+                            {
+                                "question": "When did Alice move?",
+                                "expected_answer": "2023",
+                                "category": 2,
+                                "is_correct": True,
+                                "confidence": 1.0,
+                                "recalled_count": 10,
+                                "explanation": "Found in evidence dialog D1:2",
+                            },
+                        ],
+                    },
+                    {
+                        "sample_id": "conv-2",
+                        "qa_results": [
+                            {
+                                "question": "Why did Bob leave?",
+                                "expected_answer": "Family reasons",
+                                "category": 3,
+                                "is_correct": False,
+                                "confidence": 0.25,
+                                "recalled_count": 20,
+                                "explanation": "No good match (max: 0.25)",
+                            },
+                            {
+                                "question": "What did Bob buy?",
+                                "expected_answer": "A bike",
+                                "category": 1,
+                                "is_correct": False,
+                                "confidence": 0.0,
+                                "recalled_count": 8,
+                                "explanation": "No good match (max: 0.00)",
+                            },
+                        ],
+                    },
+                ],
+            }
+        )
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(input_path), "--output", str(output_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    stdout = result.stdout
+    assert "## Overview" in stdout
+    assert "Failed questions: 3" in stdout
+    assert "## Failures by Category" in stdout
+    assert "| 1 | Single-hop Recall | 2 |" in stdout
+    assert "## Failures by Conversation" in stdout
+    assert "| conv-2 | 2 |" in stdout
+    assert "## Top Failure Explanations" in stdout
+    assert "| No good match (max: 0.00) | 2 |" in stdout
+    assert "### Category 1: Single-hop Recall" in stdout
+    assert "What is Alice's job?" in stdout
+    assert output_path.read_text() == stdout

--- a/tests/test_locomo_benchmark_script.py
+++ b/tests/test_locomo_benchmark_script.py
@@ -1,0 +1,78 @@
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def test_runner_prints_resolved_judge_and_output_summary(tmp_path: Path) -> None:
+    sandbox = tmp_path / "repo"
+    (sandbox / "scripts" / "lib").mkdir(parents=True)
+    (sandbox / "tests" / "benchmarks" / "locomo" / "data").mkdir(parents=True)
+
+    (sandbox / "test-locomo-benchmark.sh").write_text(
+        (REPO_ROOT / "test-locomo-benchmark.sh").read_text()
+    )
+    (sandbox / "scripts" / "lib" / "common.sh").write_text(
+        (REPO_ROOT / "scripts" / "lib" / "common.sh").read_text()
+    )
+    (sandbox / "tests" / "benchmarks" / "locomo" / "data" / "locomo10.json").write_text("[]")
+    (sandbox / "test-locomo-benchmark.sh").chmod(0o755)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    python_args = tmp_path / "python-args.txt"
+
+    _write_executable(
+        bin_dir / "curl",
+        "#!/bin/sh\nexit 0\n",
+    )
+    _write_executable(
+        bin_dir / "docker",
+        "#!/bin/sh\n"
+        'if [ "$1" = "info" ]; then exit 0; fi\n'
+        'if [ "$1" = "compose" ]; then exit 0; fi\n'
+        "exit 0\n",
+    )
+    _write_executable(
+        bin_dir / "python3",
+        "#!/bin/sh\n" f"printf '%s\\n' \"$@\" > '{python_args}'\n" "exit 0\n",
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["BENCH_JUDGE_MODEL"] = "custom-judge-model"
+
+    result = subprocess.run(
+        [
+            str(sandbox / "test-locomo-benchmark.sh"),
+            "--conversations",
+            "0",
+            "--judge",
+            "--output",
+            "benchmarks/results/test.json",
+        ],
+        cwd=sandbox,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+    stdout = result.stdout + result.stderr
+
+    assert result.returncode == 0
+    assert "Judge:" in stdout
+    assert "enabled" in stdout
+    assert "custom-judge-model" in stdout
+    assert "Conversations:" in stdout
+    assert "0" in stdout
+    assert "Output:" in stdout
+    assert "benchmarks/results/test.json" in stdout
+    assert "--judge" in python_args.read_text()

--- a/tests/test_locomo_cat5_judge.py
+++ b/tests/test_locomo_cat5_judge.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
@@ -627,3 +628,116 @@ def test_locomo_judge_metadata_records_profile_and_snapshot(
         "judge_provider": "openai",
         "judge_snapshot_pinned": True,
     }
+
+
+def test_run_benchmark_records_judge_config_and_stats(
+    locomo_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    data_file = tmp_path / "locomo-mini.json"
+    data_file.write_text(
+        json.dumps(
+            [
+                {
+                    "sample_id": "conv-1",
+                    "qa": [_cat5_qa()],
+                }
+            ]
+        )
+    )
+
+    config = locomo_module.LoCoMoConfig(data_file=str(data_file))
+    config.judge_model = locomo_module.DEFAULT_CAT5_JUDGE_MODEL
+    evaluator = locomo_module.LoCoMoEvaluator(config)
+    evaluator.openai_client = None
+    evaluator.has_openai_api_key = True
+    evaluator.use_embedding_similarity = False
+
+    monkeypatch.setattr(evaluator, "health_check", lambda: True)
+    monkeypatch.setattr(evaluator, "cleanup_test_data", lambda sample_ids: True)
+    monkeypatch.setattr(
+        evaluator,
+        "load_conversation_into_automem",
+        lambda conversation, sample_id: {},
+    )
+    monkeypatch.setattr(
+        evaluator,
+        "_recall_memories_for_qa",
+        lambda question, sample_id, evidence: [
+            _fake_memory("D10:20", "Jolene is watching videos and planning beginner climbs.")
+        ],
+    )
+    monkeypatch.setattr(
+        evaluator,
+        "fetch_evidence_memories",
+        lambda evidence_dialog_ids, sample_id, use_local_cache=False: [
+            _fake_memory("D10:20", "Jolene is watching videos and planning beginner climbs.")
+        ],
+    )
+    monkeypatch.setattr(locomo_module.time, "sleep", lambda seconds: None)
+
+    perf_samples = iter([10.0, 10.25])
+    monkeypatch.setattr(locomo_module.time, "perf_counter", lambda: next(perf_samples))
+
+    class FakeCompletions:
+        def create(self, **kwargs: Any) -> Any:
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(
+                            content=(
+                                '{"generated_answer": "She plans to train and start with '
+                                'beginner climbs.", "verdict": "supported", '
+                                '"correct": true, "confidence": 0.91, '
+                                '"reasoning": "Matches the evidence dialog."}'
+                            )
+                        )
+                    )
+                ],
+                usage=SimpleNamespace(
+                    prompt_tokens=120,
+                    completion_tokens=30,
+                    total_tokens=150,
+                ),
+            )
+
+    evaluator.openai_client = SimpleNamespace(chat=SimpleNamespace(completions=FakeCompletions()))
+
+    results = evaluator.run_benchmark(cleanup_after=False)
+    captured = capsys.readouterr()
+
+    assert results["judge_config"]["enabled"] is True
+    assert results["judge_config"]["provider"] == "openai"
+    assert results["judge_config"]["api"] == "chat.completions"
+    assert results["judge_config"]["model"] == "gpt-5.4-mini-2026-03-17"
+    assert results["judge_config"]["profile"] == "openai-gpt-5.4-mini-2026-03-17"
+    assert results["judge_config"]["snapshot_pinned"] is True
+    assert results["judge_config"]["prompt_version"] == "locomo-cat5-v1"
+    assert len(results["judge_config"]["prompt_sha256"]) == 64
+    assert results["judge_config"]["response_schema_version"] == "locomo-cat5-json-v1"
+    assert len(results["judge_config"]["response_schema_sha256"]) == 64
+    assert results["judge_config"]["reasoning_effort"] is None
+    assert results["judge_config"]["seed"] is None
+    assert results["judge_config"]["temperature"] is None
+    assert results["judge_config"]["max_completion_tokens_attempts"] == [250, 400, 600]
+    assert results["judge_config"]["timeout_seconds"] == 90.0
+    assert results["judge_stats"] == {
+        "questions_requiring_judge": 1,
+        "api_calls": 1,
+        "cache_hits": 0,
+        "errors": 0,
+        "skipped": 0,
+        "prompt_tokens": 120,
+        "completion_tokens": 30,
+        "total_tokens": 150,
+        "estimated_cost_usd": 0.000225,
+        "latency_ms": {
+            "avg": 250.0,
+            "p50": 250.0,
+            "p95": 250.0,
+            "max": 250.0,
+        },
+    }
+    assert "Comparison with published CORE reference" not in captured.out

--- a/tests/test_locomo_cat5_judge.py
+++ b/tests/test_locomo_cat5_judge.py
@@ -568,7 +568,7 @@ def test_cat5_with_canonical_answer_stays_deterministic(
     assert result["explanation"].startswith("Deterministic cat-5 scoring:")
 
 
-def test_main_defaults_judge_to_gpt_5_1_when_env_unset(
+def test_main_defaults_judge_to_canonical_snapshot_when_env_unset(
     locomo_module: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.delenv("BENCH_JUDGE_MODEL", raising=False)
@@ -587,6 +587,7 @@ def test_main_defaults_judge_to_gpt_5_1_when_env_unset(
 
     assert locomo_module.main() == 0
     assert captured["config"].judge_model == locomo_module.DEFAULT_CAT5_JUDGE_MODEL
+    assert captured["config"].judge_model == "gpt-5.4-mini-2026-03-17"
 
 
 def test_main_prefers_bench_judge_model_env_override(
@@ -608,3 +609,21 @@ def test_main_prefers_bench_judge_model_env_override(
 
     assert locomo_module.main() == 0
     assert captured["config"].judge_model == "custom-judge-model"
+
+
+def test_locomo_judge_metadata_records_profile_and_snapshot(
+    locomo_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("BENCH_JUDGE_PROFILE", raising=False)
+    config = locomo_module.LoCoMoConfig()
+    config.judge_model = locomo_module.DEFAULT_CAT5_JUDGE_MODEL
+    evaluator = locomo_module.LoCoMoEvaluator(config)
+
+    metadata = evaluator._judge_metadata()
+
+    assert metadata == {
+        "judge_model": "gpt-5.4-mini-2026-03-17",
+        "judge_profile": "openai-gpt-5.4-mini-2026-03-17",
+        "judge_provider": "openai",
+        "judge_snapshot_pinned": True,
+    }


### PR DESCRIPTION
## Summary
- pin the canonical benchmark judge configuration around `gpt-5.4-mini-2026-03-17` and propagate that policy across LoCoMo, LongMemEval, env loading, and supporting docs/tests
- make LoCoMo runs easier to trust by surfacing resolved runner config, recording judge provenance/token/latency/cost metadata in result JSON, and trimming stale CORE-heavy framing from runtime output/docs
- add a small `analyze_locomo_results.py` helper plus tests so failed benchmark questions can be reviewed without hand-parsing raw result JSON

## Test plan
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest tests/test_locomo_cat5_judge.py tests/test_locomo_benchmark_script.py tests/test_benchmark_result_analyzer.py -q`
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest tests/test_locomo_cat5_judge.py tests/test_locomo_benchmark_script.py -q`
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest tests/test_locomo_cat5_judge.py -k \"run_benchmark_records_judge_config_and_stats\" -q`