### PR TITLE
docs(runtime): align Docker viewer paths and setup guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ source .venv/bin/activate
 
 # Development
 make dev             # Start full stack (FalkorDB + Qdrant + API) via Docker
+make stop            # Stop local containers (keep volumes)
 make test            # Run pytest test suite (unit tests only)
 make test-integration # Run all tests including integration tests (starts Docker)
 make test-live       # Run integration tests against live Railway server
@@ -81,7 +82,7 @@ The `automem/api` module provides **28 endpoints** (admin: 2, memory: 10, recall
 2. **FalkorDB** (port 6379) - Graph storage for Memory nodes and relationship edges
 3. **Qdrant** (optional, port 6333) - Vector search for semantic similarity (dimension depends on embedding provider; see `VECTOR_SIZE`)
 4. **Consolidation Engine** - Background processing for memory maintenance
-5. **FalkorDB Browser** (optional, port 3001) - Web UI for graph visualization (start with `docker compose --profile browser up`)
+5. **FalkorDB Browser** (local, port 3000) - FalkorDB built-in Web UI for local graph inspection
 
 ### Memory Consolidation Engine
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -50,6 +50,9 @@ make dev
 - API: `http://localhost:8001`
 - FalkorDB: `localhost:6379`
 - Qdrant: `localhost:6333`
+- FalkorDB Browser (official local graph UI): `http://localhost:3000`
+
+`/viewer` is not the local FalkorDB browser. It redirects/bootstraps to a standalone graph viewer only when `GRAPH_VIEWER_URL` is configured.
 
 **Optional Enhancement:**
 
@@ -193,7 +196,7 @@ Reference these in AutoMem config via `${{service.<name>.internalHost}}`
 
 #### Get Your AutoMem URL
 
-1. Click on your **automem-api** service (the API, not FalkorDB)
+1. Click on your **memory-service** service (the API, not FalkorDB)
 2. Go to **"Settings"** tab
 3. Scroll to **"Networking"** → **"Public Networking"**
 4. Click **"Generate Domain"** (if not already generated)
@@ -298,8 +301,8 @@ Run complete stack locally:
 # Start all services
 make dev
 
-# Or manually with docker-compose
-docker-compose up -d
+# Or manually with docker compose
+docker compose up -d
 ```
 
 **docker-compose.yml** includes:
@@ -307,12 +310,13 @@ docker-compose up -d
 - AutoMem Flask API (port 8001)
 - FalkorDB (port 6379)
 - Qdrant (port 6333)
+- FalkorDB Browser via FalkorDB built-in UI (port 3000)
 
 Stop services:
 
 ```bash
 make stop
-# Or: docker-compose down
+# Or: docker compose down
 ```
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Makefile - Development commands
-.PHONY: help install dev test fmt lint test-integration test-live test-locomo test-locomo-live test-longmemeval test-longmemeval-live test-longmemeval-watch clean logs deploy deploy-check bench-health
+.PHONY: help install dev stop test fmt lint test-integration test-live test-locomo test-locomo-live test-longmemeval test-longmemeval-live test-longmemeval-watch clean logs deploy deploy-check bench-health
 
 VENV_DIR := $(if $(wildcard .venv/bin/python),.venv,venv)
 VENV_BIN := $(VENV_DIR)/bin
@@ -16,6 +16,7 @@ help:
 	@echo "  make test       - Run unit tests only"
 	@echo "  make fmt        - Format code (black + isort)"
 	@echo "  make lint       - Lint code (flake8)"
+	@echo "  make stop       - Stop local containers (keep volumes)"
 	@echo "  make test-integration - Run all tests including integration tests"
 	@echo "  make test-live  - Run integration tests against live Railway server"
 	@echo "  make logs       - Show development logs"
@@ -51,6 +52,11 @@ install:
 dev:
 	@echo "🚀 Starting local development environment..."
 	docker compose up --build
+
+# Stop local development containers (preserve volumes)
+stop:
+	@echo "⏹️  Stopping local development environment..."
+	docker compose down
 
 # Run tests
 test:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ railway up
 ## Graph Viewer (Standalone)
 
 The visualizer now runs as a separate service/repository (`automem-graph-viewer`).
-AutoMem keeps `/viewer` as a compatibility entrypoint and forwards users to the standalone app.
+AutoMem keeps `/viewer` as the public entrypoint and forwards it to the standalone app when `GRAPH_VIEWER_URL` is configured.
+
+For local Docker graph inspection, use FalkorDB's built-in browser at `http://localhost:3000`.
+`/viewer` is not the local FalkorDB browser and requires `GRAPH_VIEWER_URL`.
 
 Set these variables on the AutoMem API service:
 
@@ -384,7 +387,19 @@ make dev
 # API: http://localhost:8001
 # FalkorDB: localhost:6379
 # Qdrant: localhost:6333
+# FalkorDB Browser (official local graph UI): http://localhost:3000
 ```
+
+Local Docker runtime surface:
+
+| Service | URL / Port | Purpose |
+|---|---|---|
+| AutoMem API | `http://localhost:8001` | Memory API and `/viewer` compatibility redirect route |
+| FalkorDB | `localhost:6379` | Graph database |
+| Qdrant | `localhost:6333` | Vector database |
+| FalkorDB Browser | `http://localhost:3000` | Official local graph inspection UI |
+
+`/viewer` is not the local FalkorDB browser. It redirects to standalone `automem-graph-viewer` when `GRAPH_VIEWER_URL` is configured.
 
 ### Option 3: Development Mode
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: falkordb/falkordb:latest
     ports:
       - "6379:6379" # Redis/FalkorDB
-      - "3000:3000" # Browser UI
+      - "3000:3000" # Official local graph browser UI (FalkorDB built-in)
     volumes:
       - falkordb_data:/data # Persistent data
       - ./backups/falkordb:/backups # Local backups
@@ -18,7 +18,7 @@ services:
       - FALKORDB_DATA_PATH=/data
       - REDIS_PASSWORD=${FALKORDB_PASSWORD:-}
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: [ "CMD", "redis-cli", "ping" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -51,10 +51,10 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       VOYAGE_API_KEY: ${VOYAGE_API_KEY:-}
       VECTOR_SIZE: ${VECTOR_SIZE:-1024}
-      EMBEDDING_PROVIDER: ${EMBEDDING_PROVIDER:-auto}  # auto|voyage|openai|local|placeholder
+      EMBEDDING_PROVIDER: ${EMBEDDING_PROVIDER:-auto} # auto|voyage|openai|local|placeholder
       MEMORY_CONTENT_HARD_LIMIT: ${MEMORY_CONTENT_HARD_LIMIT:-2000}
       MEMORY_AUTO_SUMMARIZE: ${MEMORY_AUTO_SUMMARIZE:-true}
-      AUTOMEM_MODELS_DIR: /root/.config/automem/models  # Keep in sync with volume mount
+      AUTOMEM_MODELS_DIR: /root/.config/automem/models # Keep in sync with volume mount
     depends_on:
       falkordb:
         condition: service_healthy
@@ -62,22 +62,10 @@ services:
         condition: service_started
     volumes:
       - .:/app
-      - fastembed_models:/root/.config/automem/models  # Persist embedding models
+      - fastembed_models:/root/.config/automem/models # Persist embedding models
     restart: unless-stopped
-
-  # Optional: FalkorDB Browser for visualization
-  falkordb-browser:
-    image: falkordb/falkordb-browser:latest
-    ports:
-      - "3001:3000" # Browser UI on different port
-    environment:
-      - FALKORDB_URL=redis://${FALKORDB_PASSWORD:+:${FALKORDB_PASSWORD}@}falkordb:6379
-    depends_on:
-      - falkordb
-    restart: unless-stopped
-    profiles: ["browser"] # Only start with: docker-compose --profile browser up
 
 volumes:
   falkordb_data:
   qdrant_data:
-  fastembed_models:  # Persistent cache for local embedding models
+  fastembed_models: # Persistent cache for local embedding models

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - FALKORDB_DATA_PATH=/data
       - REDIS_PASSWORD=${FALKORDB_PASSWORD:-}
     healthcheck:
-      test: [ "CMD", "redis-cli", "ping" ]
+      test: [ "CMD-SHELL", "if [ -n \"$REDIS_PASSWORD\" ]; then redis-cli -a \"$REDIS_PASSWORD\" ping; else redis-cli ping; fi" ]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -131,7 +131,7 @@ VECTOR_SIZE=768                                  # must match the model's output
 ## Hosting Considerations (Railway vs Self-Hosted)
 
 - **Railway / managed PaaS:** Voyage and OpenAI are the simplest choices (no local model downloads). FastEmbed works but increases image size and cold-start time; use a persistent volume for `AUTOMEM_MODELS_DIR` if supported. Ollama typically requires a **separate service** (Railway does not ship Ollama by default), so you'll need to deploy Ollama elsewhere and set `OLLAMA_BASE_URL` to that service.
-- **Self-hosted Docker/VPS:** FastEmbed and Ollama are straightforward and avoid API costs. Ollama benefits from GPU acceleration if available; otherwise expect higher latency on CPU. Ensure the Ollama base URL is reachable from the AutoMem container (`OLLAMA_BASE_URL=http://ollama:11434` in docker-compose setups).
+- **Self-hosted Docker/VPS:** FastEmbed and Ollama are straightforward and avoid API costs. Ollama benefits from GPU acceleration if available; otherwise expect higher latency on CPU. Ensure the Ollama base URL is reachable from the AutoMem container (`OLLAMA_BASE_URL=http://ollama:11434` in docker compose setups).
 - **Dimension consistency:** Regardless of host, make sure `VECTOR_SIZE` matches the embedding model output. Changing models requires re-embedding existing memories.
 
 ## Optional Variables

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -184,6 +184,7 @@ When running Qdrant as a Railway service (instead of Qdrant Cloud), set `QDRANT_
 - AutoMem no longer serves built viewer assets in-process.
 - `/viewer` now redirects/bootstraps to `GRAPH_VIEWER_URL` and forwards `server=<automem-origin>`.
 - URL hash tokens (for example `#token=...`) stay client-side and are preserved during redirect.
+- Local Docker graph inspection uses FalkorDB's built-in browser at `http://localhost:3000` (not `/viewer`).
 
 ### Scripts Only
 

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -141,7 +141,7 @@ If migration fails or results are poor:
 
 ```bash
 # 1. Stop application
-docker-compose down  # or however you run AutoMem
+docker compose down  # or however you run AutoMem
 
 # 2. Restore from backup
 python scripts/restore_from_backup.py backups/qdrant/qdrant_snapshot_YYYYMMDD_HHMMSS.tar.gz
@@ -152,7 +152,7 @@ export VECTOR_SIZE=768
 export EMBEDDING_MODEL=text-embedding-3-small
 
 # 4. Restart
-docker-compose up -d
+docker compose up -d
 ```
 
 ---

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -127,7 +127,10 @@ Verify results are returned and scores look reasonable.
 #### 6. Restart Application
 ```bash
 # If using Docker
-make restart
+docker compose up -d
+
+# Or rerun the foreground dev stack
+make dev
 
 # If using systemd
 sudo systemctl restart automem

--- a/docs/RAILWAY_DEPLOYMENT.md
+++ b/docs/RAILWAY_DEPLOYMENT.md
@@ -38,7 +38,7 @@ flowchart TB
         subgraph db [falkordb Service]
             FalkorDB[(FalkorDB<br/>Port 6379)]
             Volume[Persistent Volume<br/>/var/lib/falkordb/data]
-            TCPProxy[TCP Proxy<br/>Public access]
+            TCPProxy[TCP Proxy<br/>Optional admin access]
         end
 
         subgraph qdrantsvc [qdrant Service — Option B]
@@ -74,7 +74,7 @@ flowchart TB
     FalkorDB --> Volume
     Qdrant --> QdrantVolume
 
-    TCPProxy -.->|Optional<br/>External access| FalkorDB
+    TCPProxy -.->|Optional<br/>Admin-only TCP access| FalkorDB
 ```
 
 ---
@@ -148,6 +148,7 @@ Deploy `automem-graph-viewer` as a separate Railway service, then configure thes
 | `VIEWER_ALLOWED_ORIGINS` | `https://<your-viewer-domain>` |
 
 AutoMem keeps `/viewer` for compatibility and redirects/bootstraps users to the standalone viewer.
+Use `/viewer` on `memory-service` as the public entrypoint; the standalone viewer is the backing service behind that route. Keep FalkorDB internal and avoid using direct public DB access as a viewer transport.
 
 ### Get Your API Tokens
 
@@ -428,9 +429,9 @@ python scripts/recover_from_qdrant.py
 
 ---
 
-## Optional: FalkorDB Browser
+## Optional: FalkorDB Browser (Admin / Debug)
 
-For visual graph exploration:
+For low-level graph debugging by operators (separate from the public standalone graph-viewer):
 
 1. **Create new service**:
 
@@ -444,8 +445,8 @@ For visual graph exploration:
    ```
 
 3. **Access**:
-   - Generate public domain
-   - Open in browser
+   - Prefer private networking / access-controlled exposure (for example Cloudflare Access)
+   - Avoid treating this as the public product viewer path
    - Visual query builder included
 
 ---
@@ -639,7 +640,8 @@ REDIS_ARGS=--maxmemory 512mb --maxmemory-policy allkeys-lru
 - [ ] Set up monitoring alerts (see [MONITORING_AND_BACKUPS.md](MONITORING_AND_BACKUPS.md))
 - [ ] Configure automated backups (see [MONITORING_AND_BACKUPS.md](MONITORING_AND_BACKUPS.md))
 - [x] Add Remote MCP server integration — see docs/MCP_SSE.md
-- [ ] Deploy FalkorDB Browser
+- [ ] Deploy standalone graph-viewer (public UI) if needed
+- [ ] Deploy FalkorDB Browser only for admin/debug workflows
 - [ ] Set up staging environment
 
 **Questions?** Open an issue: https://github.com/verygoodplugins/automem/issues

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -62,7 +62,7 @@ flowchart TD
     PreDeploy -->|No| LocalIntegration
 
     LiveCheck -->|Yes| LiveIntegration
-    LiveCheck -->|No| SetupDocker[Set up Docker first<br/>docker-compose up]
+    LiveCheck -->|No| SetupDocker[Set up Docker first<br/>docker compose up]
 
     SetupDocker --> LocalIntegration
 


### PR DESCRIPTION
## Summary
- make local Docker graph inspection explicitly use FalkorDB's built-in browser on `http://localhost:3000` and remove the extra local `falkordb-browser` service path
- clarify that production/public viewer access stays behind `/viewer` on `memory-service`, backed by the standalone `automem-graph-viewer`
- align Docker docs and commands across README, installation, migrations, testing, Railway deployment, env var docs, and agent docs, including adding `make stop`

## Test plan
- [x] `make help >/dev/null`
- [x] `docker compose config --quiet`
- [x] `ReadLints` on edited files returned no issues
- [x] reviewed final diff against `origin/main`