### PR TITLE
[codex] Fix LongMemEval harness resume and stratified mini

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ help:
 	@echo ""
 	@echo "Benchmarks:"
 	@echo "  make bench-mini-locomo    - Mini LoCoMo (2 conversations, <5 min)"
-	@echo "  make bench-mini-longmemeval - Mini LongMemEval (20 questions)"
+	@echo "  make bench-mini-longmemeval - Mini LongMemEval (stratified 30 questions)"
 	@echo "  make bench-mini           - Both mini benchmarks"
 	@echo "  make bench-ingest BENCH=locomo - Ingest + snapshot (run once)"
 	@echo "  make bench-eval BENCH=locomo CONFIG=baseline - Eval from snapshot (~2 min)"
@@ -143,7 +143,7 @@ bench-mini-locomo:
 	@./test-locomo-benchmark.sh --conversations 0,1
 
 bench-mini-longmemeval:
-	@./test-longmemeval-benchmark.sh --max-questions 20
+	@./test-longmemeval-benchmark.sh --llm-eval --per-type 5 --llm-model gpt-5-mini
 
 bench-mini: bench-mini-locomo bench-mini-longmemeval
 

--- a/benchmarks/EXPERIMENT_LOG.md
+++ b/benchmarks/EXPERIMENT_LOG.md
@@ -12,7 +12,7 @@ on the snapshot-based bench infrastructure (PR #97, merged 2026-03-02).
 | 0 | `make test` (unit) | 30s | free | Every change |
 | 1 | `locomo-mini` (2 convos, 304 Qs) | 2-3 min | free / ~$0.20 with judge | Rapid iteration |
 | 2 | `locomo` (10 convos, 1986 Qs) | 5-10 min | free / ~$1-3 with judge | Before merge |
-| 3 | `longmemeval-mini` (20 Qs) | 15 min | ~$1 | Scoring/entity changes |
+| 3 | `longmemeval-mini` (stratified 30 Qs) | 15 min | ~$1 | Scoring/entity changes |
 | 4 | `longmemeval` (500 Qs) | 1-2 hr | ~$10 | Milestones only |
 
 ## Results
@@ -74,7 +74,9 @@ claims belong in this repo once they become durable enough to cite.
 |------|-----------|-------|-------|-----------|-------|
 | 2026-04-22 | BEAM 100K V1 raw-dialogue shim | 20 conversations, 400 questions | **76.25% (305/400)**, avg 0.677 | top-k 200 | `gpt-5-mini` answerer/judge, zero errors. Diagnostic result only: BEAM 100K is easier than mem0's published 1M/10M settings, and the V1 shim stores raw dialogue rather than mem0-style extracted facts. |
 | 2026-04-22 | BEAM 100K V2 fact-extraction shim | 20 conversations, 400 questions | **73.75% (295/400)**, avg 0.653 | top-k 200 | -2.50pp vs V1 overall, within the estimated noise floor. Category signal was useful: abstention +15pp and knowledge_update +7.5pp; event_ordering -20pp and information_extraction -12.5pp. |
-| 2026-04-24 | LongMemEval partial (50q) | 50 questions, single-session-user type | **82.0% (41/50)** | recall@5 **92.0% (46/50)** | Provisional partial run; recall_limit=10, no entity/relation expansion. Not reproduced by the current `bench-mini-longmemeval` target and not directly comparable to the older 35.6% / 500-question setup or to a full LongMemEval claim. |
+| 2026-04-24 | LongMemEval partial legacy prefix (50q) | 50 questions, single-session-user type | **82.0% (41/50)** | recall@5 **92.0% (46/50)** | Provisional prefix run with legacy `gpt-4o` answerer; recall_limit=10, no entity/relation expansion. Not reproduced by the current stratified `bench-mini-longmemeval` target and not directly comparable to the older 35.6% / 500-question setup or to a full LongMemEval claim. |
+| 2026-04-25 | LongMemEval representative mini | 30 questions, stratified 5 per type | **60.0% (18/30)** | recall@5 **96.67% (29/30)** | Canonical run: `gpt-5-mini` answerer, `gpt-5.4-mini-2026-03-17` judge, `judge_errors=0`, `memory_ingest_failures=0`. Result artifact: `benchmarks/results/longmemeval_mini_stratified_gpt5mini_20260425_225854.json`. |
+| 2026-04-26 | LongMemEval full | 500 questions | **86.20% (431/500)** | recall@5 **97.20% (486/500)** | Canonical run: `gpt-5-mini` answerer, `gpt-5.4-mini-2026-03-17` judge, `judge_errors=0`, `memory_ingest_failures=0`. Result artifact: `benchmarks/results/longmemeval_full_gpt5mini_20260425_231308.json`. |
 
 ## How to add an entry
 

--- a/benchmarks/EXPERIMENT_LOG.md
+++ b/benchmarks/EXPERIMENT_LOG.md
@@ -17,29 +17,40 @@ on the snapshot-based bench infrastructure (PR #97, merged 2026-03-02).
 
 ## Results
 
-| Date | Issue/PR | Branch | LoCoMo-mini | LoCoMo-full | LME-mini | Notes |
-|------|----------|--------|-------------|-------------|----------|-------|
-| 2026-03-02 | baseline | main | 76.97% (234/304) | 80.06% (1590/1986) | -- | Voyage 4, 1024d. Health: DEGRADED (low score variance) |
-| 2026-03-02 | #73 | exp/73-min-score-threshold | 76.97% (+0.0) | -- | -- | min_score + adaptive floor. No regression. Needs #78 for impact |
-| 2026-03-02 | PR #80 | jescalan/feat/enhanced-recall | BLOCKED | -- | -- | Merge conflicts with main (recall.py), needs rebase before eval |
-| 2026-03-02 | PR #87 | jescalan/feat/write-time-dedup | 76.97% (+0.0) | -- | -- | Write-time dedup gate. Neutral on recall (expected) |
-| 2026-03-02 | #78 | exp/78-decay-fix | 76.97% (+0.0) | 79.51% (-0.55) | -- | Decay rate 0.1→0.01, importance floor, archive filter. Within variance. Impact is on production (rehabilitated via rescore) |
-| 2026-03-10 | pre-refactor | main (@ 795368a) | 76.97% (+0.0) | -- | -- | Baseline re-confirmed after #73, #78, #115, #116 merged. Stable. Pre-relation-tier-refactor checkpoint. |
-| 2026-03-10 | eval-fix | docs/benchmark-agent-guidelines | **89.27% (208/233)** | -- | -- | Fix temporal matching (answer vs memory dates) + skip cat5 (no ground truth). Honest corrected baseline after evaluator fixes. |
-| 2026-03-10 | cat5-judge | feat/bench-cat5-judge | **89.80% (273/304)** | **87.56% (1739/1986)** | -- | Opt-in GPT-4o judge for cat5. Full run scored cat5 at 95.74% (427/446) with 0 judge skips/errors; added 90s OpenAI request timeout to prevent stuck full runs. |
-| 2026-03-10 | main-refresh (no judge) | main | **89.36% (210/235)** | -- | -- | Fresh current-main rerun before PR #80 experiment. Comparison anchor for judge-off. |
-| 2026-03-10 | main-refresh (judge) | main | **90.13% (274/304)** | -- | -- | Fresh current-main rerun with `BENCH_JUDGE_MODEL=gpt-4o`. Comparison anchor for judge-on. |
-| 2026-03-11 | PR #80 port (no judge) | exp/pr80-enhanced-recall-v2 | 85.53% (201/235) | -- | -- | BM25 + query expansion + rerank port. Regressed **-3.83pp** vs fresh main. Open-domain -11.4pp. Runtime 7.4x. → [postmortem](postmortems/2026-03-11_pr80_enhanced_recall.md) |
-| 2026-03-11 | PR #80 port (judge) | exp/pr80-enhanced-recall-v2 | 88.16% (268/304) | -- | -- | Same branch with GPT-4o cat5 judge. Regressed **-1.97pp** vs fresh main. Runtime 10.2x. → [postmortem](postmortems/2026-03-11_pr80_enhanced_recall.md) |
-| 2026-03-11 | PR #80 BM25-only f10 | exp/pr80-bm25-only-f10 | 88.09% (-1.28) | -- | -- | Best config variant, still regressed. → [postmortem](postmortems/2026-03-11_pr80_enhanced_recall.md) |
-| 2026-03-11 | PR #80 BM25-only f20 | exp/pr80-bm25-only-f20 | 87.66% (-1.70) | -- | -- | More BM25 results = more dilution. → [postmortem](postmortems/2026-03-11_pr80_enhanced_recall.md) |
-| 2026-03-11 | PR #80 BM25+rerank top5 | exp/pr80-bm25-rerank-top5 | 87.23% (-2.13) | -- | -- | Reranking didn't recover regression. → [postmortem](postmortems/2026-03-11_pr80_enhanced_recall.md) |
-| 2026-03-11 | PR #80 BM25+rerank top10 | exp/pr80-bm25-rerank-top10 | 86.81% (-2.55) | -- | -- | Wider rerank window = worse. → [postmortem](postmortems/2026-03-11_pr80_enhanced_recall.md) |
-| 2026-03-11 | #74 entity expansion | exp/74-entity-expansion-precision-v1 | 89.36% (+0.0) | -- | -- | Hub-node detection. Zero delta — benchmark doesn't exercise graph expansion. → [postmortem](postmortems/2026-03-11_issue74_entity_expansion_precision.md) |
-| 2026-03-12 | #79 (PR #125) | exp/79-priority-ids-fetch-v1 | 89.36% (+0.0) | -- | -- | Bug fix: priority_ids now fetches by ID. Merged. → [postmortem](postmortems/2026-03-12_issue79_priority_ids_fetch.md) |
-| 2026-04-23 | #128 | fix/128-recall-keyword-scoring-dead-for-vector-results-adaptive-floor-too-aggressive | **85.53% (201/235)** | -- | -- | Content keyword fallback + gentler adaptive floor. Improved **+3.40pp** vs the same-day baseline (`82.13%`, `193/235`) with no sampled question-level regressions across conv-26/conv-30. |
-| 2026-04-23 | #128 full judge | fix/128-recall-keyword-scoring-dead-for-vector-results-adaptive-floor-too-aggressive | -- | **83.99% (1668/1986)** | -- | Full judge-on rerun after harness fixes. Judge preflight passed and cat-5 scored **92.83% (414/446)** with **0 skips**. Improves **+3.93pp** vs full baseline (`80.06%`, `1590/1986`), so #128 is strong enough to move forward to broader validation. |
-| 2026-04-23 | #142 | fix/142-expansion-tag-filter | -- | 77.30% (-0.07) | -- | Expansion tag-filter bypass. Effectively flat vs pre-fix `77.37%` — canonical configs don't exercise `expand_relations`. Validated via scoped repro + helper/API tests. |
+Current headline results:
+
+| Benchmark | Scope | Score | Retrieval | Notes |
+|-----------|-------|-------|-----------|-------|
+| LongMemEval full | 500 questions | **86.20% (431/500)** | recall@5 **97.20% (486/500)** | Canonical `gpt-5-mini` answerer + `gpt-5.4-mini-2026-03-17` judge; `judge_errors=0`, `memory_ingest_failures=0`. |
+| LongMemEval mini | 30 questions, stratified 5 per type | **60.0% (18/30)** | recall@5 **96.67% (29/30)** | Representative canary; do not compare to legacy prefix slices. |
+| LoCoMo full | 10 conversations, 1986 questions | **83.99% (1668/1986)** | -- | Latest recorded full judge-on run from #128; cat5 scored 92.83% with 0 skips. |
+
+Detailed experiment history:
+
+| Date | Issue/PR | Branch | LoCoMo-mini | LoCoMo-full | LME-mini | LME-full | Notes |
+|------|----------|--------|-------------|-------------|----------|----------|-------|
+| 2026-03-02 | baseline | main | 76.97% (234/304) | 80.06% (1590/1986) | -- | -- | Voyage 4, 1024d. Health: DEGRADED (low score variance) |
+| 2026-03-02 | #73 | exp/73-min-score-threshold | 76.97% (+0.0) | -- | -- | -- | min_score + adaptive floor. No regression. Needs #78 for impact |
+| 2026-03-02 | PR #80 | jescalan/feat/enhanced-recall | BLOCKED | -- | -- | -- | Merge conflicts with main (recall.py), needs rebase before eval |
+| 2026-03-02 | PR #87 | jescalan/feat/write-time-dedup | 76.97% (+0.0) | -- | -- | -- | Write-time dedup gate. Neutral on recall (expected) |
+| 2026-03-02 | #78 | exp/78-decay-fix | 76.97% (+0.0) | 79.51% (-0.55) | -- | -- | Decay rate 0.1→0.01, importance floor, archive filter. Within variance. Impact is on production (rehabilitated via rescore) |
+| 2026-03-10 | pre-refactor | main (@ 795368a) | 76.97% (+0.0) | -- | -- | -- | Baseline re-confirmed after #73, #78, #115, #116 merged. Stable. Pre-relation-tier-refactor checkpoint. |
+| 2026-03-10 | eval-fix | docs/benchmark-agent-guidelines | **89.27% (208/233)** | -- | -- | -- | Fix temporal matching (answer vs memory dates) + skip cat5 (no ground truth). Honest corrected baseline after evaluator fixes. |
+| 2026-03-10 | cat5-judge | feat/bench-cat5-judge | **89.80% (273/304)** | **87.56% (1739/1986)** | -- | -- | Opt-in GPT-4o judge for cat5. Full run scored cat5 at 95.74% (427/446) with 0 judge skips/errors; added 90s OpenAI request timeout to prevent stuck full runs. |
+| 2026-03-10 | main-refresh (no judge) | main | **89.36% (210/235)** | -- | -- | -- | Fresh current-main rerun before PR #80 experiment. Comparison anchor for judge-off. |
+| 2026-03-10 | main-refresh (judge) | main | **90.13% (274/304)** | -- | -- | -- | Fresh current-main rerun with `BENCH_JUDGE_MODEL=gpt-4o`. Comparison anchor for judge-on. |
+| 2026-03-11 | PR #80 port (no judge) | exp/pr80-enhanced-recall-v2 | 85.53% (201/235) | -- | -- | -- | BM25 + query expansion + rerank port. Regressed **-3.83pp** vs fresh main. Open-domain -11.4pp. Runtime 7.4x. → [postmortem](postmortems/2026-03-11_pr80_enhanced_recall.md) |
+| 2026-03-11 | PR #80 port (judge) | exp/pr80-enhanced-recall-v2 | 88.16% (268/304) | -- | -- | -- | Same branch with GPT-4o cat5 judge. Regressed **-1.97pp** vs fresh main. Runtime 10.2x. → [postmortem](postmortems/2026-03-11_pr80_enhanced_recall.md) |
+| 2026-03-11 | PR #80 BM25-only f10 | exp/pr80-bm25-only-f10 | 88.09% (-1.28) | -- | -- | -- | Best config variant, still regressed. → [postmortem](postmortems/2026-03-11_pr80_enhanced_recall.md) |
+| 2026-03-11 | PR #80 BM25-only f20 | exp/pr80-bm25-only-f20 | 87.66% (-1.70) | -- | -- | -- | More BM25 results = more dilution. → [postmortem](postmortems/2026-03-11_pr80_enhanced_recall.md) |
+| 2026-03-11 | PR #80 BM25+rerank top5 | exp/pr80-bm25-rerank-top5 | 87.23% (-2.13) | -- | -- | -- | Reranking didn't recover regression. → [postmortem](postmortems/2026-03-11_pr80_enhanced_recall.md) |
+| 2026-03-11 | PR #80 BM25+rerank top10 | exp/pr80-bm25-rerank-top10 | 86.81% (-2.55) | -- | -- | -- | Wider rerank window = worse. → [postmortem](postmortems/2026-03-11_pr80_enhanced_recall.md) |
+| 2026-03-11 | #74 entity expansion | exp/74-entity-expansion-precision-v1 | 89.36% (+0.0) | -- | -- | -- | Hub-node detection. Zero delta — benchmark doesn't exercise graph expansion. → [postmortem](postmortems/2026-03-11_issue74_entity_expansion_precision.md) |
+| 2026-03-12 | #79 (PR #125) | exp/79-priority-ids-fetch-v1 | 89.36% (+0.0) | -- | -- | -- | Bug fix: priority_ids now fetches by ID. Merged. → [postmortem](postmortems/2026-03-12_issue79_priority_ids_fetch.md) |
+| 2026-04-23 | #128 | fix/128-recall-keyword-scoring-dead-for-vector-results-adaptive-floor-too-aggressive | **85.53% (201/235)** | -- | -- | -- | Content keyword fallback + gentler adaptive floor. Improved **+3.40pp** vs the same-day baseline (`82.13%`, `193/235`) with no sampled question-level regressions across conv-26/conv-30. |
+| 2026-04-23 | #128 full judge | fix/128-recall-keyword-scoring-dead-for-vector-results-adaptive-floor-too-aggressive | -- | **83.99% (1668/1986)** | -- | -- | Full judge-on rerun after harness fixes. Judge preflight passed and cat-5 scored **92.83% (414/446)** with **0 skips**. Improves **+3.93pp** vs full baseline (`80.06%`, `1590/1986`), so #128 is strong enough to move forward to broader validation. |
+| 2026-04-23 | #142 | fix/142-expansion-tag-filter | -- | 77.30% (-0.07) | -- | -- | Expansion tag-filter bypass. Effectively flat vs pre-fix `77.37%` — canonical configs don't exercise `expand_relations`. Validated via scoped repro + helper/API tests. |
+| 2026-04-26 | LongMemEval harness | fix/longmemeval-harness-resume-and-stratified-mini | -- | -- | **60.0% (18/30)** | **86.20% (431/500)** | Representative stratified mini and full canonical run. Full recall@5 **97.20% (486/500)**; `judge_errors=0`, `memory_ingest_failures=0`. |
 
 ### Category Breakdown (LoCoMo-mini)
 
@@ -63,26 +74,41 @@ Categories 1-4 are scored by word-overlap/date matching. Category 5 uses an opt-
 \* Temporal was artificially low: evaluator compared question dates (empty) vs memory dates instead of answer dates.
 \*\* Complex was artificially 100%: dataset has no `answer` field for cat5 → empty string → `"" in content` always True.
 
-## Additional Benchmarks
+### Category Breakdown (LongMemEval full)
 
-These results are useful validation signals, but they are not README headline claims yet.
-LongMemEval entries marked mini/provisional are partial runs. BEAM entries came from
-`automem-evals` exploratory runners and are included here because official benchmark
-claims belong in this repo once they become durable enough to cite.
+Canonical run: `benchmarks/results/longmemeval_full_gpt5mini_20260425_231308.json`.
+Answerer `gpt-5-mini`; judge `gpt-5.4-mini-2026-03-17`.
+
+| Question type | Accuracy | Recall@5 |
+|---------------|----------|----------|
+| knowledge-update | 88.46% (69/78) | 100.00% (78/78) |
+| multi-session | 81.20% (108/133) | 98.50% (131/133) |
+| single-session-assistant | 98.21% (55/56) | 100.00% (56/56) |
+| single-session-preference | 60.00% (18/30) | 90.00% (27/30) |
+| single-session-user | 91.43% (64/70) | 92.86% (65/70) |
+| temporal-reasoning | 87.97% (117/133) | 96.99% (129/133) |
+
+Failure split from the result-analysis helper: 58 wrong answers had the answer
+session retrieved at recall@5; 11 were retrieval misses. This is the basis for
+follow-up issues #158 and #159.
+
+## Exploratory and Historical Benchmarks
+
+These results are useful validation signals, but they are not current headline
+claims. BEAM entries came from `automem-evals` exploratory runners. LongMemEval
+prefix entries are legacy/provisional because dataset prefixes are biased.
 
 | Date | Benchmark | Scope | Score | Retrieval | Notes |
 |------|-----------|-------|-------|-----------|-------|
 | 2026-04-22 | BEAM 100K V1 raw-dialogue shim | 20 conversations, 400 questions | **76.25% (305/400)**, avg 0.677 | top-k 200 | `gpt-5-mini` answerer/judge, zero errors. Diagnostic result only: BEAM 100K is easier than mem0's published 1M/10M settings, and the V1 shim stores raw dialogue rather than mem0-style extracted facts. |
 | 2026-04-22 | BEAM 100K V2 fact-extraction shim | 20 conversations, 400 questions | **73.75% (295/400)**, avg 0.653 | top-k 200 | -2.50pp vs V1 overall, within the estimated noise floor. Category signal was useful: abstention +15pp and knowledge_update +7.5pp; event_ordering -20pp and information_extraction -12.5pp. |
 | 2026-04-24 | LongMemEval partial legacy prefix (50q) | 50 questions, single-session-user type | **82.0% (41/50)** | recall@5 **92.0% (46/50)** | Provisional prefix run with legacy `gpt-4o` answerer; recall_limit=10, no entity/relation expansion. Not reproduced by the current stratified `bench-mini-longmemeval` target and not directly comparable to the older 35.6% / 500-question setup or to a full LongMemEval claim. |
-| 2026-04-25 | LongMemEval representative mini | 30 questions, stratified 5 per type | **60.0% (18/30)** | recall@5 **96.67% (29/30)** | Canonical run: `gpt-5-mini` answerer, `gpt-5.4-mini-2026-03-17` judge, `judge_errors=0`, `memory_ingest_failures=0`. Result artifact: `benchmarks/results/longmemeval_mini_stratified_gpt5mini_20260425_225854.json`. |
-| 2026-04-26 | LongMemEval full | 500 questions | **86.20% (431/500)** | recall@5 **97.20% (486/500)** | Canonical run: `gpt-5-mini` answerer, `gpt-5.4-mini-2026-03-17` judge, `judge_errors=0`, `memory_ingest_failures=0`. Result artifact: `benchmarks/results/longmemeval_full_gpt5mini_20260425_231308.json`. |
 
 ## How to add an entry
 
 1. Run the benchmark: `make bench-eval BENCH=locomo-mini CONFIG=baseline`
 2. Record the overall accuracy from the output JSON
-3. Add a row to the Results table with the date, issue/PR, branch, and scores
+3. Add a row to the detailed experiment history with the date, issue/PR, branch, and scores
 4. Add a row to the Category Breakdown table with per-category scores
 5. For deltas, show as `XX.X% (+Y.Y)` relative to the baseline row
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -323,11 +323,14 @@ Current baselines and methodology notes live in `benchmarks/EXPERIMENT_LOG.md`.
 
 ## LongMemEval Benchmark
 
-AutoMem also includes a LongMemEval harness for milestone validation against the ICLR 2025 long-term memory dataset. Treat the current published number as a provisional partial result, not a full benchmark claim.
+AutoMem also includes a LongMemEval harness for milestone validation against the ICLR 2025 long-term memory dataset. Treat prefix slices as smoke tests only; cite the canonical full run or the stratified representative mini for current results.
 
 ```bash
-# Current mini target: prefix slice smoke test, not the 50-question result below
+# Representative judged mini: stratified 5 questions per question type (30 total)
 make bench-mini-longmemeval
+
+# Prefix smoke only; biased by dataset order
+./test-longmemeval-benchmark.sh --max-questions 20
 
 # Full local run
 make test-longmemeval
@@ -336,13 +339,15 @@ make test-longmemeval
 make test-longmemeval-live
 ```
 
-Current provisional result:
+Current LongMemEval results:
 
 | Setup | Scope | Score | Retrieval | Notes |
 |------|-------|-------|-----------|-------|
-| `longmemeval` partial (50q) | 50 questions, single-session-user type | **82.0% (41/50)** | recall@5 **92.0% (46/50)** | Provisional partial run; recall_limit=10, no entity/relation expansion. Not reproduced by the current `bench-mini-longmemeval` target and not directly comparable to the older 35.6% / 500-question setup. |
+| `longmemeval-mini` representative | 30 questions, stratified 5 per question type | **60.0% (18/30)** | recall@5 **96.67% (29/30)** | Canonical run: `gpt-5-mini` answerer, `gpt-5.4-mini-2026-03-17` judge, `judge_errors=0`, `memory_ingest_failures=0`. |
+| `longmemeval` full canonical | 500 questions | **86.20% (431/500)** | recall@5 **97.20% (486/500)** | Canonical run: `gpt-5-mini` answerer, `gpt-5.4-mini-2026-03-17` judge, `judge_errors=0`, `memory_ingest_failures=0`. |
+| `longmemeval` partial legacy prefix (50q) | 50 questions, single-session-user type | **82.0% (41/50)** | recall@5 **92.0% (46/50)** | Provisional prefix run with legacy `gpt-4o` answerer; recall_limit=10, no entity/relation expansion. Not reproduced by the current stratified `bench-mini-longmemeval` target and not directly comparable to the older 35.6% / 500-question setup. |
 
-For future published LongMemEval results, use the pinned judge policy in [`docs/BENCHMARK_JUDGE_POLICY.md`](BENCHMARK_JUDGE_POLICY.md) so runs remain comparable over time. Result metadata should distinguish the answer model (`llm_model`, currently `gpt-4o`) from the judge model (`judge_model`, currently `gpt-5.4-mini-2026-03-17` when `--llm-eval` is enabled).
+For future published LongMemEval results, use the pinned judge policy in [`docs/BENCHMARK_JUDGE_POLICY.md`](BENCHMARK_JUDGE_POLICY.md) so runs remain comparable over time. The primary answerer is `gpt-5-mini`; `gpt-4o` is legacy continuity only and should be labeled as such. Result metadata distinguishes the answer model (`answerer_model` / `llm_model`) from the judge model (`judge_model`, currently `gpt-5.4-mini-2026-03-17` when `--llm-eval` is enabled).
 
 ## BEAM Benchmark
 

--- a/scripts/bench/ingest_and_snapshot.sh
+++ b/scripts/bench/ingest_and_snapshot.sh
@@ -44,7 +44,7 @@ elif [[ "$BENCH_NAME" == "longmemeval-mini" ]]; then
     python3 tests/benchmarks/longmemeval/test_longmemeval.py \
         --base-url "$AUTOMEM_TEST_BASE_URL" \
         --api-token "$AUTOMEM_TEST_API_TOKEN" \
-        --max-questions 20 --no-cleanup
+        --per-type 5 --no-cleanup
 else
     echo -e "${RED}Unknown benchmark: ${BENCH_NAME}${NC}"
     echo "Supported: locomo, locomo-mini, longmemeval-mini"

--- a/scripts/bench/restore_and_eval.sh
+++ b/scripts/bench/restore_and_eval.sh
@@ -99,9 +99,9 @@ if [[ "$BENCH_NAME" == locomo* ]]; then
         --api-token "$AUTOMEM_TEST_API_TOKEN" \
         ${EVAL_ARGS}
 elif [[ "$BENCH_NAME" == longmemeval* ]]; then
-    LONGMEM_ARGS=(--config "$CONFIG" --no-cleanup --output "${OUTPUT}")
+    LONGMEM_ARGS=(--config "$CONFIG" --no-cleanup --output "${OUTPUT%.json}")
     if [[ "$BENCH_NAME" == "longmemeval-mini" ]]; then
-        LONGMEM_ARGS+=(--max-questions 20)
+        LONGMEM_ARGS+=(--per-type 5)
     fi
     "$PYTHON_BIN" tests/benchmarks/longmemeval/test_longmemeval.py \
         --base-url "$AUTOMEM_TEST_BASE_URL" \

--- a/test-longmemeval-benchmark.sh
+++ b/test-longmemeval-benchmark.sh
@@ -29,8 +29,11 @@ RECALL_LIMIT=""
 NO_CLEANUP=false
 OUTPUT_FILE=""
 MAX_QUESTIONS=""
+PER_TYPE=""
 LLM_MODEL=""
+EVAL_LLM_MODEL=""
 LLM_EVAL=false
+RESUME=false
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -59,12 +62,24 @@ while [[ $# -gt 0 ]]; do
             MAX_QUESTIONS="$2"
             shift 2
             ;;
+        --per-type)
+            PER_TYPE="$2"
+            shift 2
+            ;;
         --llm-model)
             LLM_MODEL="$2"
             shift 2
             ;;
+        --eval-llm-model)
+            EVAL_LLM_MODEL="$2"
+            shift 2
+            ;;
         --llm-eval)
             LLM_EVAL=true
+            shift
+            ;;
+        --resume)
+            RESUME=true
             shift
             ;;
         --help|-h)
@@ -76,16 +91,21 @@ while [[ $# -gt 0 ]]; do
             echo "                      expand-relations, high-k, temporal, full-graph"
             echo "                      (default: baseline)"
             echo "  --recall-limit N    Override recall limit from config"
-            echo "  --llm-model MODEL   LLM for answer generation (default: gpt-4o)"
-            echo "  --llm-eval          Use GPT-4o for evaluation (costs more, more accurate)"
-            echo "  --max-questions N   Limit questions for quick testing (default: all 500)"
+            echo "  --llm-model MODEL   LLM for answer generation (default: gpt-5-mini)"
+            echo "  --eval-llm-model MODEL"
+            echo "                      LLM judge override (default: canonical pinned judge)"
+            echo "  --llm-eval          Use canonical OpenAI judge for evaluation"
+            echo "  --max-questions N   Prefix-limit questions for debug smoke only"
+            echo "  --per-type N        Select up to N questions per question_type"
+            echo "  --resume            Resume from <output>.partial.jsonl (requires --output)"
             echo "  --no-cleanup        Don't cleanup test data after evaluation"
             echo "  --output FILE       Save results to specified path (without extension)"
             echo "  --help, -h          Show this help message"
             echo ""
             echo "Examples:"
             echo "  $0                                        # Baseline, local, all 500"
-            echo "  $0 --max-questions 10                     # Quick test with 10 questions"
+            echo "  $0 --per-type 5 --llm-eval                # Representative stratified mini"
+            echo "  $0 --max-questions 10                     # Prefix debug smoke"
             echo "  $0 --config full-graph --llm-eval         # Full config with LLM eval"
             echo "  $0 --live --config temporal               # Temporal config on Railway"
             echo "  $0 --config high-k --recall-limit 30      # Custom recall limit"
@@ -181,39 +201,67 @@ else
     fi
 
     export AUTOMEM_TEST_BASE_URL="http://localhost:8001"
-    export AUTOMEM_TEST_API_TOKEN="test-token"
+    if [ -z "${AUTOMEM_TEST_API_TOKEN:-}" ]; then
+        env_api_token=""
+        if [ -f "$SCRIPT_DIR/.env" ]; then
+            env_api_token="$(awk -F= '/^AUTOMEM_API_TOKEN=/ {print substr($0, index($0, "=") + 1); exit}' "$SCRIPT_DIR/.env")"
+            env_api_token="${env_api_token%\"}"
+            env_api_token="${env_api_token#\"}"
+            env_api_token="${env_api_token%\'}"
+            env_api_token="${env_api_token#\'}"
+        fi
+        export AUTOMEM_TEST_API_TOKEN="${env_api_token:-test-token}"
+    else
+        export AUTOMEM_TEST_API_TOKEN
+    fi
 
     echo -e "${GREEN}Docker services ready${NC}"
 fi
 
 # Build python command
-PYTHON_CMD="python3 $SCRIPT_DIR/tests/benchmarks/longmemeval/test_longmemeval.py"
-PYTHON_CMD="$PYTHON_CMD --base-url $AUTOMEM_TEST_BASE_URL"
-PYTHON_CMD="$PYTHON_CMD --api-token $AUTOMEM_TEST_API_TOKEN"
-PYTHON_CMD="$PYTHON_CMD --config $CONFIG"
+PYTHON_BIN="$SCRIPT_DIR/.venv/bin/python"
+if [ ! -x "$PYTHON_BIN" ]; then
+    PYTHON_BIN="python3"
+fi
+PYTHON_CMD=("$PYTHON_BIN" "$SCRIPT_DIR/tests/benchmarks/longmemeval/test_longmemeval.py")
+PYTHON_CMD+=(--base-url "$AUTOMEM_TEST_BASE_URL")
+PYTHON_CMD+=(--api-token "$AUTOMEM_TEST_API_TOKEN")
+PYTHON_CMD+=(--config "$CONFIG")
 
 if [ -n "$RECALL_LIMIT" ]; then
-    PYTHON_CMD="$PYTHON_CMD --recall-limit $RECALL_LIMIT"
+    PYTHON_CMD+=(--recall-limit "$RECALL_LIMIT")
 fi
 
 if [ "$NO_CLEANUP" = true ]; then
-    PYTHON_CMD="$PYTHON_CMD --no-cleanup"
+    PYTHON_CMD+=(--no-cleanup)
 fi
 
 if [ -n "$OUTPUT_FILE" ]; then
-    PYTHON_CMD="$PYTHON_CMD --output $OUTPUT_FILE"
+    PYTHON_CMD+=(--output "$OUTPUT_FILE")
 fi
 
 if [ -n "$MAX_QUESTIONS" ]; then
-    PYTHON_CMD="$PYTHON_CMD --max-questions $MAX_QUESTIONS"
+    PYTHON_CMD+=(--max-questions "$MAX_QUESTIONS")
+fi
+
+if [ -n "$PER_TYPE" ]; then
+    PYTHON_CMD+=(--per-type "$PER_TYPE")
 fi
 
 if [ -n "$LLM_MODEL" ]; then
-    PYTHON_CMD="$PYTHON_CMD --llm-model $LLM_MODEL"
+    PYTHON_CMD+=(--llm-model "$LLM_MODEL")
+fi
+
+if [ -n "$EVAL_LLM_MODEL" ]; then
+    PYTHON_CMD+=(--eval-llm-model "$EVAL_LLM_MODEL")
 fi
 
 if [ "$LLM_EVAL" = true ]; then
-    PYTHON_CMD="$PYTHON_CMD --llm-eval"
+    PYTHON_CMD+=(--llm-eval)
+fi
+
+if [ "$RESUME" = true ]; then
+    PYTHON_CMD+=(--resume)
 fi
 
 echo ""
@@ -222,7 +270,7 @@ echo -e "${BLUE}Starting benchmark evaluation...${NC}"
 echo ""
 
 # Run the benchmark
-if $PYTHON_CMD; then
+if "${PYTHON_CMD[@]}"; then
     echo ""
     echo -e "${GREEN}============================================${NC}"
     echo -e "${GREEN}Benchmark completed successfully!${NC}"

--- a/tests/benchmarks/longmemeval/analyze_results.py
+++ b/tests/benchmarks/longmemeval/analyze_results.py
@@ -1,0 +1,220 @@
+"""Analyze LongMemEval result JSON artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+
+def _pct(correct: int, total: int) -> Optional[float]:
+    if total <= 0:
+        return None
+    return correct / total
+
+
+def _result_details(results: Dict[str, Any]) -> List[Dict[str, Any]]:
+    details = results.get("details")
+    if isinstance(details, list):
+        return details
+    legacy_results = results.get("results")
+    if isinstance(legacy_results, list):
+        return legacy_results
+    return []
+
+
+def _status_counts(rows: Iterable[Dict[str, Any]]) -> Dict[str, int]:
+    counts = {"hit": 0, "miss": 0, "unknown": 0}
+    for row in rows:
+        recall_hit = row.get("recall_hit_at_5")
+        if recall_hit is True:
+            counts["hit"] += 1
+        elif recall_hit is False:
+            counts["miss"] += 1
+        else:
+            counts["unknown"] += 1
+    return counts
+
+
+def analyze_results(results: Dict[str, Any]) -> Dict[str, Any]:
+    """Return compact diagnostics for a LongMemEval result artifact."""
+    details = _result_details(results)
+    total = len(details)
+    correct = sum(1 for row in details if row.get("is_correct") is True)
+    recall_total = sum(1 for row in details if row.get("recall_hit_at_5") is not None)
+    recall_hits = sum(1 for row in details if row.get("recall_hit_at_5") is True)
+    failures = [row for row in details if row.get("is_correct") is not True]
+
+    by_type: Dict[str, Dict[str, Any]] = {}
+    grouped: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for row in details:
+        grouped[str(row.get("question_type", "unknown"))].append(row)
+
+    for question_type in sorted(grouped):
+        rows = grouped[question_type]
+        type_total = len(rows)
+        type_correct = sum(1 for row in rows if row.get("is_correct") is True)
+        type_recall_total = sum(1 for row in rows if row.get("recall_hit_at_5") is not None)
+        type_recall_hits = sum(1 for row in rows if row.get("recall_hit_at_5") is True)
+        by_type[question_type] = {
+            "total": type_total,
+            "correct": type_correct,
+            "accuracy": _pct(type_correct, type_total),
+            "recall_hits": type_recall_hits,
+            "recall_total": type_recall_total,
+            "recall_at_5": _pct(type_recall_hits, type_recall_total),
+        }
+
+    failure_rows = []
+    for row in failures:
+        failure_rows.append(
+            {
+                "question_id": row.get("question_id"),
+                "question_type": row.get("question_type"),
+                "question": row.get("question"),
+                "reference": row.get("reference"),
+                "hypothesis": row.get("hypothesis"),
+                "recall_hit_at_5": row.get("recall_hit_at_5"),
+                "retrieved_session_ids": row.get("retrieved_session_ids", []),
+                "answer_session_ids": row.get("answer_session_ids", []),
+                "judge_error": row.get("judge_error"),
+                "error": row.get("error"),
+            }
+        )
+
+    judge_errors = results.get("judge_errors")
+    if judge_errors is None:
+        judge_errors = sum(1 for row in details if row.get("judge_error"))
+
+    memory_ingest_failures = results.get("memory_ingest_failures")
+    if memory_ingest_failures is None:
+        memory_ingest_failures = sum(1 for row in details if row.get("error_type"))
+
+    empty_hypotheses = sum(1 for row in details if not row.get("hypothesis"))
+    publishable = results.get("publishable")
+    if publishable is None:
+        publishable = judge_errors == 0
+
+    return {
+        "overall": {
+            "total": total,
+            "correct": correct,
+            "accuracy": _pct(correct, total),
+            "recall_hits": recall_hits,
+            "recall_total": recall_total,
+            "recall_at_5": _pct(recall_hits, recall_total),
+        },
+        "by_type": by_type,
+        "failures_by_recall": _status_counts(failures),
+        "judge_errors": judge_errors,
+        "memory_ingest_failures": memory_ingest_failures,
+        "empty_hypotheses": empty_hypotheses,
+        "publishable": publishable,
+        "failure_rows": failure_rows,
+    }
+
+
+def load_results(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _format_rate(value: Optional[float]) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value * 100:.2f}%"
+
+
+def _truncate(value: Any, limit: int = 96) -> str:
+    text = "" if value is None else str(value).replace("\n", " ")
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "..."
+
+
+def format_analysis(analysis: Dict[str, Any], max_failures: int = 20) -> str:
+    """Format diagnostics as compact Markdown."""
+    overall = analysis["overall"]
+    lines = [
+        "# LongMemEval Result Analysis",
+        "",
+        "## Overall",
+        "",
+        f"- Accuracy: {_format_rate(overall['accuracy'])} "
+        f"({overall['correct']}/{overall['total']})",
+        f"- Recall@5: {_format_rate(overall['recall_at_5'])} "
+        f"({overall['recall_hits']}/{overall['recall_total']})",
+        f"- Judge errors: {analysis['judge_errors']}",
+        f"- Memory ingest failures: {analysis['memory_ingest_failures']}",
+        f"- Empty hypotheses: {analysis['empty_hypotheses']}",
+        f"- Publishable: {analysis['publishable']}",
+        "",
+        "## By Type",
+        "",
+        "| Question type | Accuracy | Recall@5 |",
+        "|---|---:|---:|",
+    ]
+
+    for question_type, stats in analysis["by_type"].items():
+        lines.append(
+            f"| {question_type} | {_format_rate(stats['accuracy'])} "
+            f"({stats['correct']}/{stats['total']}) | "
+            f"{_format_rate(stats['recall_at_5'])} "
+            f"({stats['recall_hits']}/{stats['recall_total']}) |"
+        )
+
+    failure_counts = analysis["failures_by_recall"]
+    lines.extend(
+        [
+            "",
+            "## Failures By Recall",
+            "",
+            f"- Retrieved answer session at @5: {failure_counts['hit']}",
+            f"- Retrieval miss at @5: {failure_counts['miss']}",
+            f"- Unknown recall status: {failure_counts['unknown']}",
+            "",
+            f"## Failure Rows (first {max_failures})",
+            "",
+            "| ID | Type | Recall@5 | Reference | Hypothesis |",
+            "|---|---|---:|---|---|",
+        ]
+    )
+
+    for row in analysis["failure_rows"][:max_failures]:
+        lines.append(
+            f"| {row.get('question_id')} | {row.get('question_type')} | "
+            f"{row.get('recall_hit_at_5')} | {_truncate(row.get('reference'))} | "
+            f"{_truncate(row.get('hypothesis'))} |"
+        )
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("result_json", type=Path, help="LongMemEval result JSON path")
+    parser.add_argument(
+        "--max-failures",
+        type=int,
+        default=20,
+        help="Maximum failure rows to print in text mode",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable analysis JSON",
+    )
+    args = parser.parse_args()
+
+    analysis = analyze_results(load_results(args.result_json))
+    if args.json:
+        print(json.dumps(analysis, indent=2, ensure_ascii=False))
+    else:
+        print(format_analysis(analysis, max_failures=args.max_failures))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmarks/longmemeval/configs.py
+++ b/tests/benchmarks/longmemeval/configs.py
@@ -40,7 +40,7 @@ class LongMemEvalConfig:
     importance: float = 0.5
 
     # Answer generation
-    llm_model: str = os.getenv("LONGMEMEVAL_LLM_MODEL", "gpt-4o")
+    llm_model: str = os.getenv("LONGMEMEVAL_LLM_MODEL", "gpt-5-mini")
     eval_llm_model: Optional[str] = os.getenv("LONGMEMEVAL_EVAL_LLM_MODEL")
     use_chain_of_note: bool = True
 
@@ -52,6 +52,7 @@ class LongMemEvalConfig:
     # Evaluation
     use_llm_eval: bool = False  # Use canonical OpenAI judge for evaluation (costs money)
     max_questions: int = 0  # 0 = all questions
+    per_type: int = 0  # 0 = no stratified selection; otherwise questions per type
 
     # Tag prefix for cleanup
     tag_prefix: str = "longmemeval"

--- a/tests/benchmarks/longmemeval/evaluator.py
+++ b/tests/benchmarks/longmemeval/evaluator.py
@@ -12,7 +12,7 @@ import re
 from collections import Counter
 from typing import Any, ClassVar, Dict, List, Optional, Tuple
 
-from tests.benchmarks.judge_policy import is_gpt5_family
+from tests.benchmarks.judge_policy import CANONICAL_BENCHMARK_JUDGE_MODEL, is_gpt5_family
 
 try:
     from openai import OpenAI
@@ -151,8 +151,9 @@ def llm_evaluate(
     hypothesis: str,
     reference: str,
     question_id: str,
-    model: str = "gpt-4o",
+    model: str = CANONICAL_BENCHMARK_JUDGE_MODEL,
     client: Optional[Any] = None,
+    fallback_on_error: bool = True,
 ) -> Dict[str, Any]:
     """
     LLM-based evaluation matching the LongMemEval paper's judge style.
@@ -248,6 +249,8 @@ Respond with ONLY a JSON object:
         }
 
     except (json.JSONDecodeError, KeyError, IndexError, TypeError, ValueError) as e:
+        if not fallback_on_error:
+            raise
         # Fall back to quick scoring on LLM failure
         qs = quick_score(hypothesis, reference, question_id)
         return {

--- a/tests/benchmarks/longmemeval/test_analysis.py
+++ b/tests/benchmarks/longmemeval/test_analysis.py
@@ -1,0 +1,100 @@
+from tests.benchmarks.longmemeval.analyze_results import analyze_results, format_analysis
+
+
+def test_analyze_results_reports_type_recall_failures_and_publishability() -> None:
+    analysis = analyze_results(
+        {
+            "judge_errors": 1,
+            "memory_ingest_failures": 0,
+            "publishable": False,
+            "details": [
+                {
+                    "question_id": "q1",
+                    "question_type": "single-session-preference",
+                    "reference": "tea",
+                    "hypothesis": "tea",
+                    "is_correct": True,
+                    "recall_hit_at_5": True,
+                    "retrieved_session_ids": ["s1"],
+                    "answer_session_ids": ["s1"],
+                },
+                {
+                    "question_id": "q2",
+                    "question_type": "single-session-preference",
+                    "reference": "coffee",
+                    "hypothesis": "",
+                    "is_correct": False,
+                    "recall_hit_at_5": False,
+                    "judge_error": "timeout",
+                    "retrieved_session_ids": ["s2"],
+                    "answer_session_ids": ["s3"],
+                },
+                {
+                    "question_id": "q3",
+                    "question_type": "multi-session",
+                    "reference": "Paris",
+                    "hypothesis": "Lyon",
+                    "is_correct": False,
+                    "recall_hit_at_5": True,
+                    "retrieved_session_ids": ["s4"],
+                    "answer_session_ids": ["s4"],
+                },
+            ],
+        }
+    )
+
+    assert analysis["overall"]["correct"] == 1
+    assert analysis["overall"]["total"] == 3
+    assert analysis["overall"]["recall_hits"] == 2
+    assert analysis["by_type"]["single-session-preference"]["correct"] == 1
+    assert analysis["by_type"]["single-session-preference"]["recall_hits"] == 1
+    assert analysis["failures_by_recall"] == {"hit": 1, "miss": 1, "unknown": 0}
+    assert analysis["judge_errors"] == 1
+    assert analysis["memory_ingest_failures"] == 0
+    assert analysis["empty_hypotheses"] == 1
+    assert analysis["publishable"] is False
+    assert analysis["failure_rows"][0]["question_id"] == "q2"
+
+
+def test_format_analysis_includes_compact_failure_rows() -> None:
+    text = format_analysis(
+        {
+            "overall": {
+                "total": 1,
+                "correct": 0,
+                "accuracy": 0.0,
+                "recall_hits": 1,
+                "recall_total": 1,
+                "recall_at_5": 1.0,
+            },
+            "by_type": {
+                "multi-session": {
+                    "total": 1,
+                    "correct": 0,
+                    "accuracy": 0.0,
+                    "recall_hits": 1,
+                    "recall_total": 1,
+                    "recall_at_5": 1.0,
+                }
+            },
+            "failures_by_recall": {"hit": 1, "miss": 0, "unknown": 0},
+            "judge_errors": 0,
+            "memory_ingest_failures": 0,
+            "empty_hypotheses": 0,
+            "publishable": True,
+            "failure_rows": [
+                {
+                    "question_id": "q1",
+                    "question_type": "multi-session",
+                    "reference": "Paris",
+                    "hypothesis": "Lyon",
+                    "recall_hit_at_5": True,
+                }
+            ],
+        },
+        max_failures=1,
+    )
+
+    assert "Accuracy: 0.00% (0/1)" in text
+    assert "| multi-session | 0.00% (0/1) | 100.00% (1/1) |" in text
+    assert "| q1 | multi-session | True | Paris | Lyon |" in text

--- a/tests/benchmarks/longmemeval/test_evaluator.py
+++ b/tests/benchmarks/longmemeval/test_evaluator.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 
 import tests.benchmarks.longmemeval.test_longmemeval as harness
@@ -191,3 +192,148 @@ def test_judge_failure_records_error_after_retries(monkeypatch) -> None:
     assert result["is_correct"] is False
     assert result["judge_attempts"] == 3
     assert "RuntimeError: judge unavailable" in result["judge_error"]
+
+
+def _sample_item(question_id: str = "q1") -> dict:
+    return {
+        "question_id": question_id,
+        "question_type": "multi-session",
+        "question": "Where did I go?",
+        "answer": "Paris",
+        "question_date": "2023/05/30 (Tue) 20:42",
+        "answer_session_ids": ["s1"],
+        "haystack_sessions": [[{"role": "user", "content": "I went to Paris."}]],
+        "haystack_session_ids": ["s1"],
+        "haystack_dates": ["2023/05/30 (Tue) 20:42"],
+    }
+
+
+def _result(question_id: str, *, judge_error=None, is_correct=True) -> dict:
+    return {
+        "question_id": question_id,
+        "question_type": "multi-session",
+        "question": "Where did I go?",
+        "reference": "Paris",
+        "hypothesis": "Paris" if is_correct else "Lyon",
+        "is_correct": is_correct,
+        "confidence": 1.0 if is_correct else 0.0,
+        "explanation": "test result",
+        "recalled_count": 1,
+        "memories_stored": 1,
+        "is_abstention": False,
+        "question_date": "2023/05/30 (Tue) 20:42",
+        "answer_session_ids": ["s1"],
+        "retrieved_session_ids": ["s1"],
+        "recall_hit_at_5": True,
+        "judge_attempts": 1,
+        "judge_error": judge_error,
+    }
+
+
+def _benchmark(monkeypatch, tmp_path):
+    monkeypatch.setattr(harness, "create_backend", lambda *args, **kwargs: _DummyBackend())
+    config = harness.get_config(
+        "baseline",
+        results_dir=str(tmp_path),
+        data_file=str(tmp_path / "unused.json"),
+    )
+    return harness.LongMemEvalBenchmark(config)
+
+
+def test_resume_loads_completed_partial_rows_and_skips_completed_question(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    benchmark = _benchmark(monkeypatch, tmp_path)
+    output_base = str(tmp_path / "resume-run")
+    partial_path = benchmark.artifact_paths(output_base)["partial"]
+    completed = _result("q1")
+    with open(partial_path, "w", encoding="utf-8") as f:
+        f.write(json.dumps(completed) + "\n")
+
+    monkeypatch.setattr(benchmark, "load_dataset", lambda: [_sample_item("q1"), _sample_item("q2")])
+    monkeypatch.setattr(benchmark, "ingest_sessions", lambda item: 1)
+    monkeypatch.setattr(
+        benchmark,
+        "evaluate_question",
+        lambda item, stored: _result(item["question_id"]),
+    )
+    cleaned = []
+    monkeypatch.setattr(
+        benchmark,
+        "cleanup_test_data",
+        lambda question_id=None: cleaned.append(question_id),
+    )
+
+    scores = benchmark.run_benchmark(output_path=output_base, resume=True)
+
+    assert [row["question_id"] for row in scores["details"]] == ["q1", "q2"]
+    assert cleaned == ["q2"]
+    assert scores["overall"]["total"] == 2
+    assert len(open(partial_path, encoding="utf-8").read().splitlines()) == 2
+
+
+def test_load_partial_results_ignores_malformed_trailing_jsonl_line(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    benchmark = _benchmark(monkeypatch, tmp_path)
+    output_base = str(tmp_path / "partial-run")
+    partial_path = benchmark.artifact_paths(output_base)["partial"]
+    with open(partial_path, "w", encoding="utf-8") as f:
+        f.write(json.dumps(_result("q1")) + "\n")
+        f.write("{not-json")
+
+    results = benchmark._load_partial_results(output_base)
+
+    assert [row["question_id"] for row in results] == ["q1"]
+
+
+def test_status_json_records_progress_and_artifact_metadata(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    benchmark = _benchmark(monkeypatch, tmp_path)
+    output_base = str(tmp_path / "status-run")
+    monkeypatch.setattr(benchmark, "load_dataset", lambda: [_sample_item("q1")])
+    monkeypatch.setattr(benchmark, "ingest_sessions", lambda item: 1)
+    monkeypatch.setattr(
+        benchmark,
+        "evaluate_question",
+        lambda item, stored: _result(item["question_id"]),
+    )
+    monkeypatch.setattr(benchmark, "cleanup_test_data", lambda question_id=None: None)
+
+    benchmark.run_benchmark(output_path=output_base)
+    status_path = benchmark.artifact_paths(output_base)["status"]
+
+    with open(status_path, encoding="utf-8") as f:
+        status = json.load(f)
+
+    assert status["status"] == "completed"
+    assert status["completed"] == 1
+    assert status["remaining"] == 0
+    assert status["artifacts"]["partial"].endswith(".partial.jsonl")
+    assert status["config"]["answerer_model"] == "gpt-5-mini"
+
+
+def test_publishable_false_when_any_judge_errors_are_recorded(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    benchmark = _benchmark(monkeypatch, tmp_path)
+    output_base = str(tmp_path / "judge-error-run")
+    monkeypatch.setattr(benchmark, "load_dataset", lambda: [_sample_item("q1")])
+    monkeypatch.setattr(benchmark, "ingest_sessions", lambda item: 1)
+    monkeypatch.setattr(
+        benchmark,
+        "evaluate_question",
+        lambda item, stored: _result(item["question_id"], judge_error="timeout", is_correct=False),
+    )
+    monkeypatch.setattr(benchmark, "cleanup_test_data", lambda question_id=None: None)
+
+    scores = benchmark.run_benchmark(output_path=output_base)
+
+    assert scores["judge_errors"] == 1
+    assert scores["publishable"] is False
+    assert scores["publishable_reason"] == "judge_errors_present"

--- a/tests/benchmarks/longmemeval/test_evaluator.py
+++ b/tests/benchmarks/longmemeval/test_evaluator.py
@@ -1,6 +1,23 @@
 from types import SimpleNamespace
 
+import tests.benchmarks.longmemeval.test_longmemeval as harness
 from tests.benchmarks.longmemeval.evaluator import llm_evaluate, normalize_text, quick_score
+
+
+class _DummyBackend:
+    name = "automem"
+
+    def health_check(self) -> bool:
+        return True
+
+    def cleanup_scope(self, scope_id: str) -> int:
+        return 0
+
+    def ingest_memories(self, *args, **kwargs):
+        return {}
+
+    def search(self, request):
+        return []
 
 
 def test_normalize_text_coerces_non_string_inputs() -> None:
@@ -72,3 +89,105 @@ def test_llm_evaluate_keeps_json_mode_for_non_gpt5_models() -> None:
     assert captured["temperature"] == 0
     assert "max_completion_tokens" not in captured
     assert captured["response_format"] == {"type": "json_object"}
+
+
+def test_stratified_selection_preserves_dataset_order_and_limits_per_type(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(harness, "create_backend", lambda *args, **kwargs: _DummyBackend())
+    benchmark = harness.LongMemEvalBenchmark(harness.get_config("baseline", per_type=1))
+    dataset = [
+        {"question_id": "u1", "question_type": "single-session-user"},
+        {"question_id": "u2", "question_type": "single-session-user"},
+        {"question_id": "m1", "question_type": "multi-session"},
+        {"question_id": "t1", "question_type": "temporal-reasoning"},
+    ]
+
+    selected, metadata = benchmark.select_dataset(dataset)
+
+    assert [item["question_id"] for item in selected] == ["u1", "m1", "t1"]
+    assert metadata["strategy"] == "stratified_per_type"
+    assert metadata["per_type"] == 1
+    assert metadata["selected_type_distribution"] == {
+        "multi-session": 1,
+        "single-session-user": 1,
+        "temporal-reasoning": 1,
+    }
+
+
+def test_generate_answer_uses_gpt5_compatible_chat_completion_args(monkeypatch) -> None:
+    monkeypatch.setattr(harness, "create_backend", lambda *args, **kwargs: _DummyBackend())
+    benchmark = harness.LongMemEvalBenchmark(harness.get_config("baseline", llm_model="gpt-5-mini"))
+    captured = {}
+
+    class _Completions:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="Step 3 - Answer: Ada"))]
+            )
+
+    benchmark.openai_client = SimpleNamespace(chat=SimpleNamespace(completions=_Completions()))
+
+    answer = benchmark.generate_answer(
+        "What is the name?",
+        [{"content": "User: Her name is Ada.", "metadata": {}}],
+        "2023/05/30 (Tue) 20:42",
+    )
+
+    assert answer == "Ada"
+    assert captured["model"] == "gpt-5-mini"
+    assert captured["max_completion_tokens"] == benchmark.GPT5_ANSWER_MAX_COMPLETION_TOKENS[0]
+    assert "max_tokens" not in captured
+    assert "temperature" not in captured
+
+
+def test_generate_answer_retries_empty_gpt5_content_with_larger_budget(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(harness, "create_backend", lambda *args, **kwargs: _DummyBackend())
+    benchmark = harness.LongMemEvalBenchmark(harness.get_config("baseline", llm_model="gpt-5-mini"))
+    budgets = []
+
+    class _Completions:
+        def create(self, **kwargs):
+            budgets.append(kwargs["max_completion_tokens"])
+            content = "" if len(budgets) == 1 else "Step 3 - Answer: Ada"
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+            )
+
+    benchmark.openai_client = SimpleNamespace(chat=SimpleNamespace(completions=_Completions()))
+
+    answer = benchmark.generate_answer(
+        "What is the name?",
+        [{"content": "User: Her name is Ada.", "metadata": {}}],
+        "2023/05/30 (Tue) 20:42",
+    )
+
+    assert answer == "Ada"
+    assert budgets == list(benchmark.GPT5_ANSWER_MAX_COMPLETION_TOKENS)
+
+
+def test_judge_failure_records_error_after_retries(monkeypatch) -> None:
+    monkeypatch.setattr(harness, "create_backend", lambda *args, **kwargs: _DummyBackend())
+    monkeypatch.setattr(harness.time, "sleep", lambda seconds: None)
+    benchmark = harness.LongMemEvalBenchmark(harness.get_config("baseline", use_llm_eval=True))
+
+    class _Completions:
+        def create(self, **kwargs):
+            raise RuntimeError("judge unavailable")
+
+    benchmark.openai_client = SimpleNamespace(chat=SimpleNamespace(completions=_Completions()))
+
+    result = benchmark._llm_evaluate_with_retries(
+        question="What is the name?",
+        hypothesis="Ada",
+        reference="Ada",
+        question_id="q_1",
+        model="gpt-5.4-mini-2026-03-17",
+    )
+
+    assert result["is_correct"] is False
+    assert result["judge_attempts"] == 3
+    assert "RuntimeError: judge unavailable" in result["judge_error"]

--- a/tests/benchmarks/longmemeval/test_longmemeval.py
+++ b/tests/benchmarks/longmemeval/test_longmemeval.py
@@ -839,6 +839,14 @@ Answer:"""
             print(f"{self.backend.name} backend is not accessible. Aborting benchmark.")
             return {"overall": {"accuracy": 0.0, "correct": 0, "total": 0}}
 
+        # Fail fast if LLM eval is requested but no OpenAI client is available.
+        if self.config.use_llm_eval and not self.openai_client:
+            raise RuntimeError(
+                "--llm-eval requires OPENAI_API_KEY to be set, but no OpenAI client is "
+                "configured. Set OPENAI_API_KEY and retry, or omit --llm-eval to use "
+                "quick_score instead."
+            )
+
         # Load dataset
         full_dataset = self.load_dataset()
         dataset, selection_metadata = self.select_dataset(full_dataset)
@@ -846,12 +854,20 @@ Answer:"""
         resumed_results: List[Dict[str, Any]] = []
         completed_ids = set()
         if resume:
-            resumed_results = self._load_partial_results(output_base)
+            raw_results = self._load_partial_results(output_base)
+            # De-duplicate by question_id (last occurrence wins, preserving order).
+            seen: Dict[str, Dict[str, Any]] = {}
+            for result in raw_results:
+                qid = result.get("question_id")
+                if qid:
+                    seen[qid] = result
+                else:
+                    print(
+                        f"WARNING: resumed result missing question_id; skipping: {result!r:.200}"
+                    )
+            resumed_results = list(seen.values())
             for result in resumed_results:
-                question_id = result.get("question_id")
-                if not question_id or question_id in completed_ids:
-                    continue
-                completed_ids.add(question_id)
+                completed_ids.add(result["question_id"])
                 self.scorer.add_result(result)
 
         print("\nRunning LongMemEval benchmark:")

--- a/tests/benchmarks/longmemeval/test_longmemeval.py
+++ b/tests/benchmarks/longmemeval/test_longmemeval.py
@@ -33,7 +33,7 @@ import os
 import re
 import sys
 import time
-from collections import defaultdict
+from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, TypedDict
@@ -57,6 +57,7 @@ from tests.benchmarks.backends import MemoryRecord, SearchRequest, create_backen
 from tests.benchmarks.judge_policy import (
     CANONICAL_BENCHMARK_JUDGE_MODEL,
     DEFAULT_JUDGE_PROVIDER,
+    is_gpt5_family,
     judge_metadata,
 )
 from tests.benchmarks.longmemeval.configs import LongMemEvalConfig, get_config
@@ -71,7 +72,7 @@ from tests.benchmarks.longmemeval.evaluator import (
 logger = logging.getLogger(__name__)
 
 
-class LongMemEvalResult(TypedDict):
+class LongMemEvalResult(TypedDict, total=False):
     question_id: str
     question_type: str
     question: str
@@ -87,10 +88,19 @@ class LongMemEvalResult(TypedDict):
     answer_session_ids: List[str]
     retrieved_session_ids: List[str]
     recall_hit_at_5: bool
+    judge_attempts: int
+    judge_error: Optional[str]
+    error: Optional[str]
+    error_type: Optional[str]
 
 
 class LongMemEvalBenchmark:
     """Evaluates AutoMem against the LongMemEval benchmark."""
+
+    JUDGE_MAX_ATTEMPTS = 3
+    JUDGE_RETRY_BASE_SECONDS = 0.5
+    GPT5_ANSWER_MAX_COMPLETION_TOKENS = (2000, 4000)
+    LEGACY_ANSWER_MAX_TOKENS = 500
 
     def __init__(self, config: LongMemEvalConfig) -> None:
         self.config = config
@@ -107,6 +117,7 @@ class LongMemEvalBenchmark:
         self.openai_client = None
         if OpenAI and os.getenv("OPENAI_API_KEY"):
             self.openai_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        self._last_output_base: Optional[str] = None
 
     def effective_judge_model(self) -> Optional[str]:
         if not self.config.use_llm_eval:
@@ -143,6 +154,52 @@ class LongMemEvalBenchmark:
         print(f"Loaded {len(data)} questions from {Path(data_file).name}")
         return data
 
+    @staticmethod
+    def question_type_distribution(dataset: List[Dict[str, Any]]) -> Dict[str, int]:
+        """Return a stable question-type distribution for result metadata."""
+        return dict(
+            sorted(Counter(item.get("question_type", "unknown") for item in dataset).items())
+        )
+
+    def select_dataset(
+        self, dataset: List[Dict[str, Any]]
+    ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+        """Apply configured question selection and return metadata about the slice."""
+        full_distribution = self.question_type_distribution(dataset)
+
+        if self.config.per_type > 0:
+            selected: List[Dict[str, Any]] = []
+            selected_counts: Counter[str] = Counter()
+            for item in dataset:
+                question_type = item.get("question_type", "unknown")
+                if selected_counts[question_type] >= self.config.per_type:
+                    continue
+                selected.append(item)
+                selected_counts[question_type] += 1
+            strategy = "stratified_per_type"
+            strategy_params: Dict[str, Any] = {"per_type": self.config.per_type}
+        elif self.config.max_questions > 0:
+            selected = dataset[: self.config.max_questions]
+            strategy = "prefix"
+            strategy_params = {
+                "max_questions": self.config.max_questions,
+                "debug_prefix": True,
+            }
+        else:
+            selected = list(dataset)
+            strategy = "all"
+            strategy_params = {}
+
+        selected_distribution = self.question_type_distribution(selected)
+        return selected, {
+            "strategy": strategy,
+            **strategy_params,
+            "full_total": len(dataset),
+            "selected_total": len(selected),
+            "full_type_distribution": full_distribution,
+            "selected_type_distribution": selected_distribution,
+        }
+
     def cleanup_test_data(self, question_id: Optional[str] = None) -> None:
         """Remove test memories from AutoMem."""
         if self.config.backend == "automem" and question_id:
@@ -160,6 +217,103 @@ class LongMemEvalBenchmark:
 
         if total_deleted > 0:
             print(f"  Cleaned up {total_deleted} memories")
+
+    def resolve_output_base(self, output_path: Optional[str] = None) -> str:
+        """Resolve the output base used for final, partial, and status artifacts."""
+        if output_path is None:
+            timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+            output_path = os.path.join(
+                self.config.results_dir,
+                f"{self.config.name}_{timestamp}",
+            )
+
+        for suffix in (".partial.jsonl", ".status.json", ".jsonl", ".json"):
+            if output_path.endswith(suffix):
+                output_path = output_path[: -len(suffix)]
+                break
+        self._last_output_base = output_path
+        return output_path
+
+    @staticmethod
+    def artifact_paths(output_base: str) -> Dict[str, str]:
+        return {
+            "json": f"{output_base}.json",
+            "jsonl": f"{output_base}.jsonl",
+            "partial": f"{output_base}.partial.jsonl",
+            "status": f"{output_base}.status.json",
+        }
+
+    def _append_partial_result(self, output_base: str, result: Dict[str, Any]) -> None:
+        paths = self.artifact_paths(output_base)
+        os.makedirs(os.path.dirname(paths["partial"]) or ".", exist_ok=True)
+        with open(paths["partial"], "a", encoding="utf-8") as f:
+            f.write(json.dumps(result, ensure_ascii=False) + "\n")
+            f.flush()
+
+    def _write_status(
+        self,
+        output_base: str,
+        *,
+        started_at: str,
+        selection: Dict[str, Any],
+        completed: int,
+        total: int,
+        skipped: int,
+        elapsed_time: float,
+        status: str,
+        judge_errors: int,
+    ) -> None:
+        paths = self.artifact_paths(output_base)
+        os.makedirs(os.path.dirname(paths["status"]) or ".", exist_ok=True)
+        payload = {
+            "status": status,
+            "started_at": started_at,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+            "elapsed_time": elapsed_time,
+            "output_base": output_base,
+            "artifacts": paths,
+            "completed": completed,
+            "total": total,
+            "skipped": skipped,
+            "remaining": max(total - completed, 0),
+            "memory_ingest_failures": self.memory_ingest_failures,
+            "judge_errors": judge_errors,
+            "selection": selection,
+            "config": {
+                "backend": self.config.backend,
+                "name": self.config.name,
+                "answerer_model": self.config.llm_model,
+                "llm_model": self.config.llm_model,
+                "use_llm_eval": self.config.use_llm_eval,
+                "judge_model": self.effective_judge_model(),
+            },
+        }
+        with open(paths["status"], "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+
+    def _load_partial_results(self, output_base: str) -> List[Dict[str, Any]]:
+        paths = self.artifact_paths(output_base)
+        partial_path = paths["partial"]
+        if not os.path.exists(partial_path):
+            return []
+
+        with open(partial_path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+
+        results: List[Dict[str, Any]] = []
+        for index, line in enumerate(lines):
+            if not line.strip():
+                continue
+            try:
+                result = json.loads(line)
+            except json.JSONDecodeError:
+                if index == len(lines) - 1:
+                    print(f"Warning: ignoring malformed trailing line in {partial_path}")
+                    break
+                raise
+            if result.get("question_id"):
+                results.append(result)
+        return results
 
     def _parse_session_date(self, date_str: str) -> Optional[str]:
         """Parse LongMemEval date format to ISO format.
@@ -435,13 +589,34 @@ Question: {question}
 Answer:"""
 
         try:
-            response = self.openai_client.chat.completions.create(
-                model=self.config.llm_model,
-                messages=[{"role": "user", "content": prompt}],
-                temperature=0,
-                max_tokens=500,
-            )
-            full_answer = response.choices[0].message.content.strip()
+            if is_gpt5_family(self.config.llm_model):
+                token_budgets = self.GPT5_ANSWER_MAX_COMPLETION_TOKENS
+            else:
+                token_budgets = (self.LEGACY_ANSWER_MAX_TOKENS,)
+
+            full_answer = ""
+            for token_budget in token_budgets:
+                request_kwargs: Dict[str, Any] = {
+                    "model": self.config.llm_model,
+                    "messages": [{"role": "user", "content": prompt}],
+                }
+                if is_gpt5_family(self.config.llm_model):
+                    request_kwargs["max_completion_tokens"] = token_budget
+                else:
+                    request_kwargs["temperature"] = 0
+                    request_kwargs["max_tokens"] = token_budget
+
+                response = self.openai_client.chat.completions.create(**request_kwargs)
+                full_answer = response.choices[0].message.content.strip()
+                if full_answer:
+                    break
+                logger.warning(
+                    "LLM answer generation returned empty content for %s at token budget %s",
+                    self.config.llm_model,
+                    token_budget,
+                )
+            if not full_answer:
+                raise ValueError("LLM answer generation returned empty content")
 
             # Extract final answer from chain-of-note format
             if self.config.use_chain_of_note:
@@ -477,6 +652,53 @@ Answer:"""
                 return memories[0].get("content", "I don't know.")
             return "I don't know."
 
+    def _llm_evaluate_with_retries(
+        self,
+        *,
+        question: str,
+        hypothesis: str,
+        reference: str,
+        question_id: str,
+        model: str,
+    ) -> Dict[str, Any]:
+        """Run the judge with retries and return a non-crashing error result on failure."""
+        last_error: Optional[Exception] = None
+        for attempt in range(1, self.JUDGE_MAX_ATTEMPTS + 1):
+            try:
+                result = llm_evaluate(
+                    question=question,
+                    hypothesis=hypothesis,
+                    reference=reference,
+                    question_id=question_id,
+                    model=model,
+                    client=self.openai_client,
+                    fallback_on_error=False,
+                )
+                result["judge_attempts"] = attempt
+                result["judge_error"] = None
+                return result
+            except Exception as exc:
+                last_error = exc
+                if attempt < self.JUDGE_MAX_ATTEMPTS:
+                    sleep_seconds = self.JUDGE_RETRY_BASE_SECONDS * (2 ** (attempt - 1))
+                    logger.warning(
+                        "Judge attempt %s/%s failed for %s: %s",
+                        attempt,
+                        self.JUDGE_MAX_ATTEMPTS,
+                        question_id,
+                        exc,
+                    )
+                    time.sleep(sleep_seconds)
+
+        error = f"{type(last_error).__name__}: {last_error}" if last_error else "unknown error"
+        return {
+            "is_correct": False,
+            "confidence": 0.0,
+            "explanation": f"Judge failed after {self.JUDGE_MAX_ATTEMPTS} attempts: {error}",
+            "judge_attempts": self.JUDGE_MAX_ATTEMPTS,
+            "judge_error": error,
+        }
+
     def evaluate_question(self, item: Dict[str, Any], memories_stored: int) -> LongMemEvalResult:
         """
         Evaluate a single question: recall, generate answer, score.
@@ -501,19 +723,31 @@ Answer:"""
         hypothesis = self.generate_answer(question, memories, question_date)
 
         # Score
-        if self.config.use_llm_eval and self.openai_client:
+        judge_attempts = 0
+        judge_error = None
+        if self.config.use_llm_eval:
             eval_model = self.effective_judge_model()
-            eval_result = llm_evaluate(
-                question=question,
-                hypothesis=hypothesis,
-                reference=reference,
-                question_id=question_id,
-                model=eval_model,
-                client=self.openai_client,
-            )
+            if self.openai_client and eval_model:
+                eval_result = self._llm_evaluate_with_retries(
+                    question=question,
+                    hypothesis=hypothesis,
+                    reference=reference,
+                    question_id=question_id,
+                    model=eval_model,
+                )
+            else:
+                eval_result = {
+                    "is_correct": False,
+                    "confidence": 0.0,
+                    "explanation": "LLM eval unavailable: OPENAI_API_KEY required",
+                    "judge_attempts": 0,
+                    "judge_error": "OPENAI_API_KEY required",
+                }
             is_correct = eval_result["is_correct"]
             confidence = eval_result["confidence"]
             explanation = eval_result["explanation"]
+            judge_attempts = int(eval_result.get("judge_attempts") or 0)
+            judge_error = eval_result.get("judge_error")
         else:
             qs = quick_score(hypothesis, reference, question_id)
             is_correct = qs["is_correct"]
@@ -538,11 +772,46 @@ Answer:"""
             "answer_session_ids": answer_session_ids,
             "retrieved_session_ids": retrieved_session_ids,
             "recall_hit_at_5": recall_hit_at_5,
+            "judge_attempts": judge_attempts,
+            "judge_error": judge_error,
         }
 
         return result
 
-    def run_benchmark(self, cleanup_after: bool = True) -> Dict[str, Any]:
+    def _build_error_result(
+        self, item: Dict[str, Any], memories_stored: int, exc: Exception
+    ) -> LongMemEvalResult:
+        """Build a persisted result for unexpected per-question failures."""
+        question_id = item.get("question_id", "unknown")
+        error = f"{type(exc).__name__}: {exc}"
+        return {
+            "question_id": question_id,
+            "question_type": item.get("question_type", "unknown"),
+            "question": item.get("question", ""),
+            "reference": item.get("answer", ""),
+            "hypothesis": "",
+            "is_correct": False,
+            "confidence": 0.0,
+            "explanation": f"Benchmark question failed: {error}",
+            "recalled_count": 0,
+            "memories_stored": memories_stored,
+            "is_abstention": is_abstention_question(question_id),
+            "question_date": item.get("question_date", ""),
+            "answer_session_ids": list(item.get("answer_session_ids") or []),
+            "retrieved_session_ids": [],
+            "recall_hit_at_5": False,
+            "judge_attempts": 0,
+            "judge_error": None,
+            "error": error,
+            "error_type": type(exc).__name__,
+        }
+
+    def run_benchmark(
+        self,
+        cleanup_after: bool = True,
+        output_path: Optional[str] = None,
+        resume: bool = False,
+    ) -> Dict[str, Any]:
         """
         Run the full LongMemEval benchmark.
 
@@ -556,6 +825,14 @@ Answer:"""
         Returns comprehensive results dict.
         """
         self.memory_ingest_failures = 0
+        self.scorer = LongMemEvalScorer()
+        output_base = self.resolve_output_base(output_path)
+        paths = self.artifact_paths(output_base)
+        os.makedirs(os.path.dirname(paths["partial"]) or ".", exist_ok=True)
+
+        if not resume:
+            with open(paths["partial"], "w", encoding="utf-8"):
+                pass
 
         # Health check
         if not self.health_check():
@@ -563,50 +840,85 @@ Answer:"""
             return {"overall": {"accuracy": 0.0, "correct": 0, "total": 0}}
 
         # Load dataset
-        dataset = self.load_dataset()
+        full_dataset = self.load_dataset()
+        dataset, selection_metadata = self.select_dataset(full_dataset)
 
-        # Apply question limit
-        if self.config.max_questions > 0:
-            dataset = dataset[: self.config.max_questions]
+        resumed_results: List[Dict[str, Any]] = []
+        completed_ids = set()
+        if resume:
+            resumed_results = self._load_partial_results(output_base)
+            for result in resumed_results:
+                question_id = result.get("question_id")
+                if not question_id or question_id in completed_ids:
+                    continue
+                completed_ids.add(question_id)
+                self.scorer.add_result(result)
 
         print("\nRunning LongMemEval benchmark:")
         print(f"  Backend: {self.backend.name}")
         print(f"  Config: {self.config.name}")
         print(f"  Questions: {len(dataset)}")
+        print(f"  Selection: {selection_metadata['strategy']}")
+        if self.config.per_type > 0:
+            print(f"  Per type: {self.config.per_type}")
         print(f"  Storage: {self.config.storage_strategy}")
         print(f"  Recall limit: {self.config.recall_limit}")
         print(f"  Expand entities: {self.config.expand_entities}")
         print(f"  Expand relations: {self.config.expand_relations}")
         print(f"  Temporal hints: {self.config.use_temporal_hints}")
-        print(f"  LLM model: {self.config.llm_model}")
+        print(f"  Answerer model: {self.config.llm_model}")
         print(f"  LLM eval: {self.config.use_llm_eval}")
         if self.config.use_llm_eval:
             print(f"  Judge model: {self.effective_judge_model()}")
         has_llm = self.openai_client is not None
         print(f"  OpenAI available: {has_llm}")
+        print(f"  Output base: {output_base}")
+        if resume:
+            print(f"  Resumed completed questions: {len(completed_ids)}")
         print()
 
         start_time = time.time()
-        all_results = []
+        started_at = datetime.now(timezone.utc).isoformat()
+        all_results = resumed_results[:]
+        skipped = 0
 
         for idx, item in enumerate(dataset):
             question_id = item["question_id"]
             question_type = item["question_type"]
             num_sessions = len(item.get("haystack_sessions", []))
 
+            if question_id in completed_ids:
+                skipped += 1
+                print(f"[{idx + 1}/{len(dataset)}] SKIP completed {question_id}")
+                continue
+
             print(f"[{idx + 1}/{len(dataset)}] {question_type}: " f"{item['question'][:60]}...")
 
-            # 1. Ingest sessions
-            stored = self.ingest_sessions(item)
-            print(f"  Ingested {stored} memories from {num_sessions} sessions")
+            stored = 0
+            try:
+                # 1. Ingest sessions
+                stored = self.ingest_sessions(item)
+                print(f"  Ingested {stored} memories from {num_sessions} sessions")
 
-            # 2. Evaluate (recall + generate + score)
-            result = self.evaluate_question(item, stored)
+                # 2. Evaluate (recall + generate + score)
+                result = self.evaluate_question(item, stored)
+            except Exception as exc:
+                logger.exception("Question failed for %s: %s", question_id, exc)
+                result = self._build_error_result(item, stored, exc)
+            finally:
+                # 3. Clean up this question's data even when recall/generation/judge fails
+                if cleanup_after:
+                    self.cleanup_test_data(question_id)
+
             all_results.append(result)
             self.scorer.add_result(result)
+            completed_ids.add(question_id)
+            self._append_partial_result(output_base, result)
 
             status = "CORRECT" if result["is_correct"] else "WRONG"
             print(f"  {status} | recalled={result['recalled_count']} | " f"{result['explanation']}")
+            if result.get("judge_error"):
+                print(f"    Judge error: {result['judge_error']}")
             if not result["is_correct"]:
                 expected = result.get("reference")
                 hypothesis = result.get("hypothesis")
@@ -615,9 +927,18 @@ Answer:"""
                 print(f"    Expected: {expected_preview}")
                 print(f"    Got:      {hypothesis_preview}")
 
-            # 3. Clean up this question's data
-            if cleanup_after:
-                self.cleanup_test_data(question_id)
+            elapsed_so_far = time.time() - start_time
+            self._write_status(
+                output_base,
+                started_at=started_at,
+                selection=selection_metadata,
+                completed=len(completed_ids),
+                total=len(dataset),
+                skipped=skipped,
+                elapsed_time=elapsed_so_far,
+                status="running",
+                judge_errors=sum(1 for row in all_results if row.get("judge_error")),
+            )
 
         elapsed_time = time.time() - start_time
 
@@ -625,6 +946,7 @@ Answer:"""
         scores = self.scorer.print_report(config_name=self.config.name, elapsed_time=elapsed_time)
         scores["backend"] = self.backend.name
         scores["elapsed_time"] = elapsed_time
+        scores["selection"] = selection_metadata
         effective_judge_model = self.effective_judge_model()
         scores["config"] = {
             "backend": self.config.backend,
@@ -635,13 +957,32 @@ Answer:"""
             "expand_relations": self.config.expand_relations,
             "auto_decompose": self.config.auto_decompose,
             "use_temporal_hints": self.config.use_temporal_hints,
+            "answerer_model": self.config.llm_model,
             "llm_model": self.config.llm_model,
             "eval_llm_model": self.config.eval_llm_model,
             "use_llm_eval": self.config.use_llm_eval,
+            "max_questions": self.config.max_questions,
+            "per_type": self.config.per_type,
             **judge_metadata(effective_judge_model, provider=DEFAULT_JUDGE_PROVIDER),
         }
+        judge_errors = sum(1 for row in all_results if row.get("judge_error"))
         scores["memory_ingest_failures"] = self.memory_ingest_failures
+        scores["judge_errors"] = judge_errors
+        scores["publishable"] = judge_errors == 0
+        scores["publishable_reason"] = None if judge_errors == 0 else "judge_errors_present"
+        scores["artifacts"] = paths
         scores["details"] = all_results
+        self._write_status(
+            output_base,
+            started_at=started_at,
+            selection=selection_metadata,
+            completed=len(completed_ids),
+            total=len(dataset),
+            skipped=skipped,
+            elapsed_time=elapsed_time,
+            status="completed",
+            judge_errors=judge_errors,
+        )
 
         return scores
 
@@ -649,30 +990,28 @@ Answer:"""
         self, scores: Dict[str, Any], output_path: Optional[str] = None
     ) -> Tuple[str, str]:
         """Save benchmark results to JSONL and JSON files."""
-        if output_path is None:
-            timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-            output_path = os.path.join(
-                self.config.results_dir,
-                f"{self.config.name}_{timestamp}",
-            )
+        if output_path is None and self._last_output_base:
+            output_path = self._last_output_base
+        output_path = self.resolve_output_base(output_path)
+        paths = self.artifact_paths(output_path)
 
         os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
 
         # Save full results as JSON
-        json_path = f"{output_path}.json"
-        with open(json_path, "w") as f:
+        json_path = paths["json"]
+        with open(json_path, "w", encoding="utf-8") as f:
             json.dump(scores, f, indent=2)
         print(f"\nResults saved to: {json_path}")
 
         # Save hypotheses as JSONL (for LongMemEval's evaluator)
-        jsonl_path = f"{output_path}.jsonl"
-        with open(jsonl_path, "w") as f:
+        jsonl_path = paths["jsonl"]
+        with open(jsonl_path, "w", encoding="utf-8") as f:
             for detail in scores.get("details", []):
                 line = {
                     "question_id": detail["question_id"],
                     "hypothesis": detail["hypothesis"],
                 }
-                f.write(json.dumps(line) + "\n")
+                f.write(json.dumps(line, ensure_ascii=False) + "\n")
         print(f"Hypotheses saved to: {jsonl_path}")
 
         return json_path, jsonl_path
@@ -732,12 +1071,12 @@ def main() -> int:
     parser.add_argument(
         "--llm-model",
         default=None,
-        help="LLM model for answer generation (default: gpt-4o)",
+        help="LLM model for answer generation (default: gpt-5-mini)",
     )
     parser.add_argument(
         "--eval-llm-model",
         default=None,
-        help="LLM model for evaluation (default: same as --llm-model)",
+        help=f"LLM model for evaluation (default: {CANONICAL_BENCHMARK_JUDGE_MODEL})",
     )
     parser.add_argument(
         "--llm-eval",
@@ -753,15 +1092,30 @@ def main() -> int:
         "--max-questions",
         type=int,
         default=0,
-        help="Limit number of questions (0 = all, useful for debugging)",
+        help="Prefix-limit questions (0 = all; debug smoke only, biased by dataset order)",
+    )
+    parser.add_argument(
+        "--per-type",
+        type=int,
+        default=0,
+        help="Select up to N questions per LongMemEval question_type",
     )
     parser.add_argument(
         "--output",
         default=None,
         help="Output file path (without extension)",
     )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume from <output>.partial.jsonl; requires --output",
+    )
 
     args = parser.parse_args()
+    if args.max_questions > 0 and args.per_type > 0:
+        parser.error("--max-questions and --per-type are mutually exclusive")
+    if args.resume and not args.output:
+        parser.error("--resume requires --output so the partial artifact is explicit")
 
     # Build config from preset + overrides
     overrides = {
@@ -782,15 +1136,22 @@ def main() -> int:
         overrides["use_llm_eval"] = True
     if args.max_questions > 0:
         overrides["max_questions"] = args.max_questions
+    if args.per_type > 0:
+        overrides["per_type"] = args.per_type
 
     config = get_config(args.config, **overrides)
 
     # Run benchmark
     benchmark = LongMemEvalBenchmark(config)
-    scores = benchmark.run_benchmark(cleanup_after=not args.no_cleanup)
+    output_base = benchmark.resolve_output_base(args.output)
+    scores = benchmark.run_benchmark(
+        cleanup_after=not args.no_cleanup,
+        output_path=output_base,
+        resume=args.resume,
+    )
 
     # Save results
-    benchmark.save_results(scores, args.output)
+    benchmark.save_results(scores, output_base)
 
     # Return exit code
     return 0 if scores.get("overall", {}).get("total", 0) > 0 else 1

--- a/tests/benchmarks/longmemeval/test_longmemeval.py
+++ b/tests/benchmarks/longmemeval/test_longmemeval.py
@@ -862,9 +862,7 @@ Answer:"""
                 if qid:
                     seen[qid] = result
                 else:
-                    print(
-                        f"WARNING: resumed result missing question_id; skipping: {result!r:.200}"
-                    )
+                    print(f"WARNING: resumed result missing question_id; skipping: {result!r:.200}")
             resumed_results = list(seen.values())
             for result in resumed_results:
                 completed_ids.add(result["question_id"])

--- a/tests/benchmarks/results/longmemeval_baseline_5_4mini_20260425_223943.json
+++ b/tests/benchmarks/results/longmemeval_baseline_5_4mini_20260425_223943.json
@@ -1,0 +1,555 @@
+{
+  "overall": {
+    "accuracy": 0.75,
+    "correct": 15,
+    "total": 20
+  },
+  "retrieval": {
+    "recall_any_at_5": 0.85,
+    "hits": 17,
+    "total": 20
+  },
+  "by_type": {
+    "single-session-user": {
+      "correct": 15,
+      "total": 20,
+      "accuracy": 0.75,
+      "name": "Single-Session (User)"
+    }
+  },
+  "retrieval_by_type": {
+    "single-session-user": {
+      "hits": 17,
+      "total": 20,
+      "recall_any_at_5": 0.85,
+      "name": "Single-Session (User)"
+    }
+  },
+  "abstention": {
+    "total": 0,
+    "correct": 0,
+    "accuracy": 0.0
+  },
+  "backend": "automem",
+  "elapsed_time": 228.66235494613647,
+  "config": {
+    "backend": "automem",
+    "name": "baseline",
+    "storage_strategy": "per-session",
+    "recall_limit": 10,
+    "expand_entities": false,
+    "expand_relations": false,
+    "auto_decompose": false,
+    "use_temporal_hints": false,
+    "llm_model": "gpt-4o",
+    "eval_llm_model": null,
+    "use_llm_eval": true,
+    "judge_model": "gpt-5.4-mini-2026-03-17",
+    "judge_profile": "openai-gpt-5.4-mini-2026-03-17",
+    "judge_provider": "openai",
+    "judge_snapshot_pinned": true
+  },
+  "memory_ingest_failures": 0,
+  "details": [
+    {
+      "question_id": "e47becba",
+      "question_type": "single-session-user",
+      "question": "What degree did I graduate with?",
+      "reference": "Business Administration",
+      "hypothesis": "I don't know.",
+      "is_correct": false,
+      "confidence": 0.99,
+      "explanation": "The assistant did not provide the degree; it \u067e\u0627\u0633\u062e 'I don't know' instead of 'Business Administration'.",
+      "recalled_count": 10,
+      "memories_stored": 53,
+      "is_abstention": false,
+      "question_date": "2023/05/30 (Tue) 23:40",
+      "answer_session_ids": [
+        "answer_280352e9"
+      ],
+      "retrieved_session_ids": [
+        "f6859b48_2",
+        "d414cac5_4",
+        "e348269f_1",
+        "d94b721b",
+        "7045db85_1"
+      ],
+      "recall_hit_at_5": false
+    },
+    {
+      "question_id": "118b2229",
+      "question_type": "single-session-user",
+      "question": "How long is my daily commute to work?",
+      "reference": "45 minutes each way",
+      "hypothesis": "Your daily commute to work is 45 minutes each way.",
+      "is_correct": true,
+      "confidence": 0.99,
+      "explanation": "The assistant\u2019s answer matches the reference answer exactly in meaning: the commute is 45 minutes each way.",
+      "recalled_count": 10,
+      "memories_stored": 45,
+      "is_abstention": false,
+      "question_date": "2023/05/30 (Tue) 20:36",
+      "answer_session_ids": [
+        "answer_40a90d51"
+      ],
+      "retrieved_session_ids": [
+        "answer_40a90d51",
+        "db50c0f6",
+        "afe04238_1",
+        "5209e813_2",
+        "7d8b5834_1"
+      ],
+      "recall_hit_at_5": true
+    },
+    {
+      "question_id": "51a45a95",
+      "question_type": "single-session-user",
+      "question": "Where did I redeem a $5 coupon on coffee creamer?",
+      "reference": "Target",
+      "hypothesis": "You redeemed a $5 coupon on coffee creamer at Target.",
+      "is_correct": true,
+      "confidence": 0.99,
+      "explanation": "The assistant\u2019s answer matches the reference answer by identifying Target as the place where the $5 coupon on coffee creamer was redeemed.",
+      "recalled_count": 10,
+      "memories_stored": 50,
+      "is_abstention": false,
+      "question_date": "2023/05/30 (Tue) 20:42",
+      "answer_session_ids": [
+        "answer_d61669c7"
+      ],
+      "retrieved_session_ids": [
+        "answer_d61669c7",
+        "98c198fb",
+        "217debf7",
+        "07d1915d_1",
+        "f32d1ccf_1"
+      ],
+      "recall_hit_at_5": true
+    },
+    {
+      "question_id": "58bf7951",
+      "question_type": "single-session-user",
+      "question": "What play did I attend at the local community theater?",
+      "reference": "The Glass Menagerie",
+      "hypothesis": "You attended a production of \"The Glass Menagerie\" at the local community theater.",
+      "is_correct": true,
+      "confidence": 0.99,
+      "explanation": "The assistant identifies the play as \"The Glass Menagerie,\" which matches the reference answer.",
+      "recalled_count": 10,
+      "memories_stored": 56,
+      "is_abstention": false,
+      "question_date": "2023/05/30 (Tue) 22:53",
+      "answer_session_ids": [
+        "answer_355c48bb"
+      ],
+      "retrieved_session_ids": [
+        "answer_355c48bb",
+        "ultrachat_268434",
+        "ultrachat_155546",
+        "ultrachat_221066",
+        "ultrachat_71618"
+      ],
+      "recall_hit_at_5": true
+    },
+    {
+      "question_id": "1e043500",
+      "question_type": "single-session-user",
+      "question": "What is the name of the playlist I created on Spotify?",
+      "reference": "Summer Vibes",
+      "hypothesis": "The name of the playlist you created on Spotify is \"Summer Vibes.\"",
+      "is_correct": true,
+      "confidence": 0.99,
+      "explanation": "The assistant gave the same playlist name as the reference answer: \"Summer Vibes.\"",
+      "recalled_count": 10,
+      "memories_stored": 49,
+      "is_abstention": false,
+      "question_date": "2023/05/30 (Tue) 19:19",
+      "answer_session_ids": [
+        "answer_3e012175"
+      ],
+      "retrieved_session_ids": [
+        "answer_3e012175",
+        "01bd9def",
+        "8020d945_2",
+        "sharegpt_Clr6oyu_0",
+        "2d0d0004"
+      ],
+      "recall_hit_at_5": true
+    },
+    {
+      "question_id": "c5e8278d",
+      "question_type": "single-session-user",
+      "question": "What was my last name before I changed it?",
+      "reference": "Johnson",
+      "hypothesis": "Your last name before you changed it was Johnson.",
+      "is_correct": true,
+      "confidence": 0.99,
+      "explanation": "The assistant\u2019s answer matches the reference answer exactly in meaning: the last name before the change was Johnson.",
+      "recalled_count": 10,
+      "memories_stored": 44,
+      "is_abstention": false,
+      "question_date": "2023/05/30 (Tue) 22:36",
+      "answer_session_ids": [
+        "answer_f6168136"
+      ],
+      "retrieved_session_ids": [
+        "answer_f6168136",
+        "89b1028d_1",
+        "aaf71ce2_2",
+        "f58317c6",
+        "d777e7da_1"
+      ],
+      "recall_hit_at_5": true
+    },
+    {
+      "question_id": "6ade9755",
+      "question_type": "single-session-user",
+      "question": "Where do I take yoga classes?",
+      "reference": "Serenity Yoga",
+      "hypothesis": "You take yoga classes at Serenity Yoga and also practice at home using the Down Dog app.",
+      "is_correct": true,
+      "confidence": 0.98,
+      "explanation": "The assistant correctly identifies Serenity Yoga as the place to take yoga classes. The extra mention of the Down Dog app is additional context and does not change the core answer.",
+      "recalled_count": 10,
+      "memories_stored": 51,
+      "is_abstention": false,
+      "question_date": "2023/05/30 (Tue) 21:04",
+      "answer_session_ids": [
+        "answer_9398da02"
+      ],
+      "retrieved_session_ids": [
+        "answer_9398da02",
+        "7c5ab02a_2",
+        "ultrachat_462",
+        "ultrachat_270925",
+        "e49a0b52_1"
+      ],
+      "recall_hit_at_5": true
+    },
+    {
+      "question_id": "6f9b354f",
+      "question_type": "single-session-user",
+      "question": "What color did I repaint my bedroom walls?",
+      "reference": "a lighter shade of gray",
+      "hypothesis": "You repainted your bedroom walls a lighter shade of gray.",
+      "is_correct": true,
+      "confidence": 0.99,
+      "explanation": "The assistant's answer matches the reference answer by stating the walls were repainted a lighter shade of gray.",
+      "recalled_count": 10,
+      "memories_stored": 50,
+      "is_abstention": false,
+      "question_date": "2023/05/30 (Tue) 22:42",
+      "answer_session_ids": [
+        "answer_feb5200f"
+      ],
+      "retrieved_session_ids": [
+        "answer_feb5200f",
+        "0c0f2449_2",
+        "sharegpt_VAELSB3_0",
+        "de877349",
+        "sharegpt_BYHT3Xz_0"
+      ],
+      "recall_hit_at_5": true
+    },
+    {
+      "question_id": "58ef2f1c",
+      "question_type": "single-session-user",
+      "question": "When did I volunteer at the local animal shelter's fundraising dinner?",
+      "reference": "February 14th",
+      "hypothesis": "You volunteered at the local animal shelter's fundraising dinner, \"Love is in the Air,\" in February.",
+      "is_correct": false,
+      "confidence": 0.88,
+      "explanation": "The assistant only states the month (February) and does not provide the specific date February 14th, so it misses key information from the reference answer.",
+      "recalled_count": 10,
+      "memories_stored": 50,
+      "is_abstention": false,
+      "question_date": "2023/04/02 (Sun) 23:49",
+      "answer_session_ids": [
+        "answer_59547700"
+      ],
+      "retrieved_session_ids": [
+        "answer_59547700",
+        "e6ab6a7b_2",
+        "ultrachat_5212",
+        "ultrachat_246324",
+        "e82ce7cd_1"
+      ],
+      "recall_hit_at_5": true
+    },
+    {
+      "question_id": "f8c5f88b",
+      "question_type": "single-session-user",
+      "question": "Where did I buy my new tennis racket from?",
+      "reference": "the sports store downtown",
+      "hypothesis": "You bought your new tennis racket from a sports store downtown.",
+      "is_correct": true,
+      "confidence": 0.98,
+      "explanation": "The assistant\u2019s answer matches the reference answer in meaning: it says the tennis racket was bought from a sports store downtown.",
+      "recalled_count": 10,
+      "memories_stored": 46,
+      "is_abstention": false,
+      "question_date": "2023/05/30 (Tue) 23:39",
+      "answer_session_ids": [
+        "answer_c3567066"
+      ],
+      "retrieved_session_ids": [
+        "answer_c3567066",
+        "91880423",
+        "68ace657_1",
+        "sharegpt_TKj3yO8_0",
+        "54e9197a"
+      ],
+      "recall_hit_at_5": true
+    },
+    {
+      "question_id": "5d3d2817",
+      "question_type": "single-session-user",
+      "question": "What was my previous occupation?",
+      "reference": "Marketing specialist at a small startup",
+      "hypothesis": "I don't know.",
+      "is_correct": false,
+      "confidence": 0.99,
+      "explanation": "The assistant did not identify the previous occupation; it replied that it didn't know instead of stating 'marketing specialist at a small startup'.",
+      "recalled_count": 10,
+      "memories_stored": 53,
+      "is_abstention": false,
+      "question_date": "2023/05/30 (Tue) 20:08",
+      "answer_session_ids": [
+        "answer_235eb6fb"
+      ],
+      "retrieved_session_ids": [
+        "sharegpt_BKl952A_23",
+        "sharegpt_8zsFRKh_0",
+        "e00298a6_1",
+        "ultrachat_371333",
+        "sharegpt_P6UZzFA_9"
+      ],
+      "recall_hit_at_5": false
+    },
+    {
+      "question_id": "7527f7e2",
+      "question_type": "single-session-user",
+      "question": "How much did I spend on a designer handbag?",
+      "reference": "$800",
+      "hypothesis": "You spent $800 on a designer handbag.",
+      "is_correct": true,
+      "confidence": 0.99,
+      "explanation": "The assistant states the same amount as the reference answer: $800.",
+      "recalled_count": 10,
+      "memories_stored": 45,
+      "is_abstention": false,
+      "question_date": "2023/05/30 (Tue) 23:20",
+      "answer_session_ids": [
+        "answer_7cb94507"
+      ],
+      "retrieved_session_ids": [
+        "answer_7cb94507",
+        "44bbd8cd_2",
+        "1cafd864_3",
+        "c7c4cf1e_2",
+        "4e2acecc"
+      ],
+      "recall_hit_at_5": true
+    },
+    {
+      "question_id": "c960da58",
+      "question_type": "single-session-user",
+      "question": "How many playlists do I have on Spotify?",
+      "reference": "20",
+      "hypothesis": "You have 20 playlists on Spotify.",
+      "is_correct": true,
+      "confidence": 0.99,
+      "explanation": "The assistant states the same number of playlists as the reference answer: 20.",
+      "recalled_count": 10,
+      "memories_stored": 46,
+      "is_abstention": false,
+      "question_date": "2023/05/30 (Tue) 18:45",
+      "answer_session_ids": [
+        "answer_e05e4612"
+      ],
+      "retrieved_session_ids": [
+        "answer_e05e4612",
+        "89d3053f",
+        "b65f51fb_5",
+        "f7ffddbc",
+        "ultrachat_198948"
+      ],
+      "recall_hit_at_5": true
+    },
+    {
+      "question_id": "3b6f954b",
+      "question_type": "single-session-user",
+      "question": "Where did I attend for my study abroad program?",
+      "reference": "University of Melbourne in Australia",
+      "hypothesis": "You attended your study abroad program at the University of Melbourne.",
+      "is_correct": true,
+      "confidence": 0.98,
+      "explanation": "The assistant correctly identified the study abroad institution as the University of Melbourne, matching the reference answer. It omitted the country, but the core information is correct.",
+      "recalled_count": 10,
+      "memories_stored": 50,
+      "is_abstention": false,
+      "question_date": "2023/05/30 (Tue) 16:24",
+      "answer_session_ids": [
+        "answer_94030872"
+      ],
+      "retrieved_session_ids": [
+        "answer_94030872",
+        "c271c071",
+        "f5f4b6f6_2",
+        "4ed9cd1b_1",
+        "ultrachat_294369"
+      ],
+      "recall_hit_at_5": true
+    },
+    {
+      "question_id": "726462e0",
+      "question_type": "single-session-user",
+      "question": "What was the discount I got on my first purchase from the new clothing brand?",
+      "reference": "10%",
+      "hypothesis": "I don't know.",
+      "is_correct": false,
+      "confidence": 0.99,
+      "explanation": "The assistant did not provide the discount amount. The reference answer is 10%, but the assistant said it doesn't know.",
+      "recalled_count": 10,
+      "memories_stored": 48,
+      "is_abstention": false,
+      "question_date": "2023/05/30 (Tue) 23:15",
+      "answer_session_ids": [
+        "answer_f38f679b"
+      ],
+      "retrieved_session_ids": [
+        "741c6781_1",
+        "6ef99651_2",
+        "9c05acfe_2",
+        "cdd9704d_1",
+        "7e4dab66_1"
+      ],
+      "recall_hit_at_5": false
+    },
+    {
+      "question_id": "94f70d80",
+      "question_type": "single-session-user",
+      "question": "How long did it take me to assemble the IKEA bookshelf?",
+      "reference": "4 hours",
+      "hypothesis": "It took you 4 hours to assemble the IKEA bookshelf.",
+      "is_correct": true,
+      "confidence": 0.99,
+      "explanation": "The assistant states the assembly time was 4 hours, which matches the reference answer.",
+      "recalled_count": 10,
+      "memories_stored": 49,
+      "is_abstention": false,
+      "question_date": "2023/05/30 (Tue) 23:11",
+      "answer_session_ids": [
+        "answer_c63c0458"
+      ],
+      "retrieved_session_ids": [
+        "answer_c63c0458",
+        "sharegpt_6fTnCnw_76",
+        "67045503",
+        "b015c3c3_1",
+        "43df393f"
+      ],
+      "recall_hit_at_5": true
+    },
+    {
+      "question_id": "66f24dbb",
+      "question_type": "single-session-user",
+      "question": "What did I buy for my sister's birthday gift?",
+      "reference": "a yellow dress",
+      "hypothesis": "You bought a yellow dress and a pair of earrings to match for your sister's birthday gift.",
+      "is_correct": false,
+      "confidence": 0.98,
+      "explanation": "The reference answer says the gift was only a yellow dress. The assistant added a pair of earrings, which changes the content and is not supported by the reference.",
+      "recalled_count": 10,
+      "memories_stored": 50,
+      "is_abstention": false,
+      "question_date": "2023/05/30 (Tue) 17:09",
+      "answer_session_ids": [
+        "answer_fea2e4d3"
+      ],
+      "retrieved_session_ids": [
+        "answer_fea2e4d3",
+        "89452526_2",
+        "798e4ba3_2",
+        "21c6c41d",
+        "8d46b8fa_1"
+      ],
+      "recall_hit_at_5": true
+    },
+    {
+      "question_id": "ad7109d1",
+      "question_type": "single-session-user",
+      "question": "What speed is my new internet plan?",
+      "reference": "500 Mbps",
+      "hypothesis": "Your new internet plan speed is 500 Mbps.",
+      "is_correct": true,
+      "confidence": 0.99,
+      "explanation": "The assistant states the plan speed is 500 Mbps, matching the reference answer exactly.",
+      "recalled_count": 10,
+      "memories_stored": 44,
+      "is_abstention": false,
+      "question_date": "2023/05/30 (Tue) 21:56",
+      "answer_session_ids": [
+        "answer_679840f8"
+      ],
+      "retrieved_session_ids": [
+        "answer_679840f8",
+        "3dc02d26_2",
+        "22aa7cca_3",
+        "3030efec_2",
+        "f2939479_1"
+      ],
+      "recall_hit_at_5": true
+    },
+    {
+      "question_id": "af8d2e46",
+      "question_type": "single-session-user",
+      "question": "How many shirts did I pack for my 5-day trip to Costa Rica?",
+      "reference": "7",
+      "hypothesis": "You packed 7 shirts for your 5-day trip to Costa Rica.",
+      "is_correct": true,
+      "confidence": 0.99,
+      "explanation": "The assistant states the same number of shirts as the reference answer: 7.",
+      "recalled_count": 10,
+      "memories_stored": 50,
+      "is_abstention": false,
+      "question_date": "2023/05/30 (Tue) 14:18",
+      "answer_session_ids": [
+        "answer_82a04f59"
+      ],
+      "retrieved_session_ids": [
+        "answer_82a04f59",
+        "73d5f10c",
+        "33c3b457",
+        "ultrachat_164840",
+        "ced213c6"
+      ],
+      "recall_hit_at_5": true
+    },
+    {
+      "question_id": "dccbc061",
+      "question_type": "single-session-user",
+      "question": "What was my previous stance on spirituality?",
+      "reference": "A staunch atheist",
+      "hypothesis": "Your previous stance on spirituality was that of a staunch atheist.",
+      "is_correct": true,
+      "confidence": 0.99,
+      "explanation": "The assistant conveys the same meaning as the reference answer by stating the previous stance was a staunch atheist.",
+      "recalled_count": 10,
+      "memories_stored": 49,
+      "is_abstention": false,
+      "question_date": "2023/05/30 (Tue) 19:10",
+      "answer_session_ids": [
+        "answer_8f276838"
+      ],
+      "retrieved_session_ids": [
+        "answer_8f276838",
+        "0f417163",
+        "ultrachat_519037",
+        "ultrachat_343",
+        "sharegpt_sZKME3y_0"
+      ],
+      "recall_hit_at_5": true
+    }
+  ]
+}

--- a/tests/benchmarks/results/longmemeval_baseline_5_4mini_20260425_223943.jsonl
+++ b/tests/benchmarks/results/longmemeval_baseline_5_4mini_20260425_223943.jsonl
@@ -1,0 +1,20 @@
+{"question_id": "e47becba", "hypothesis": "I don't know."}
+{"question_id": "118b2229", "hypothesis": "Your daily commute to work is 45 minutes each way."}
+{"question_id": "51a45a95", "hypothesis": "You redeemed a $5 coupon on coffee creamer at Target."}
+{"question_id": "58bf7951", "hypothesis": "You attended a production of \"The Glass Menagerie\" at the local community theater."}
+{"question_id": "1e043500", "hypothesis": "The name of the playlist you created on Spotify is \"Summer Vibes.\""}
+{"question_id": "c5e8278d", "hypothesis": "Your last name before you changed it was Johnson."}
+{"question_id": "6ade9755", "hypothesis": "You take yoga classes at Serenity Yoga and also practice at home using the Down Dog app."}
+{"question_id": "6f9b354f", "hypothesis": "You repainted your bedroom walls a lighter shade of gray."}
+{"question_id": "58ef2f1c", "hypothesis": "You volunteered at the local animal shelter's fundraising dinner, \"Love is in the Air,\" in February."}
+{"question_id": "f8c5f88b", "hypothesis": "You bought your new tennis racket from a sports store downtown."}
+{"question_id": "5d3d2817", "hypothesis": "I don't know."}
+{"question_id": "7527f7e2", "hypothesis": "You spent $800 on a designer handbag."}
+{"question_id": "c960da58", "hypothesis": "You have 20 playlists on Spotify."}
+{"question_id": "3b6f954b", "hypothesis": "You attended your study abroad program at the University of Melbourne."}
+{"question_id": "726462e0", "hypothesis": "I don't know."}
+{"question_id": "94f70d80", "hypothesis": "It took you 4 hours to assemble the IKEA bookshelf."}
+{"question_id": "66f24dbb", "hypothesis": "You bought a yellow dress and a pair of earrings to match for your sister's birthday gift."}
+{"question_id": "ad7109d1", "hypothesis": "Your new internet plan speed is 500 Mbps."}
+{"question_id": "af8d2e46", "hypothesis": "You packed 7 shirts for your 5-day trip to Costa Rica."}
+{"question_id": "dccbc061", "hypothesis": "Your previous stance on spirituality was that of a staunch atheist."}

--- a/tests/test_benchmark_env_loading.py
+++ b/tests/test_benchmark_env_loading.py
@@ -72,3 +72,14 @@ def test_longmemeval_llm_eval_defaults_to_canonical_judge(monkeypatch) -> None:
     benchmark = module.LongMemEvalBenchmark(config)
 
     assert benchmark.effective_judge_model() == "gpt-5.4-mini-2026-03-17"
+
+
+def test_longmemeval_answerer_defaults_to_gpt5_mini(monkeypatch) -> None:
+    monkeypatch.delenv("LONGMEMEVAL_LLM_MODEL", raising=False)
+    monkeypatch.delitem(sys.modules, "tests.benchmarks.longmemeval.configs", raising=False)
+    module_path = (
+        Path(__file__).resolve().parent / "benchmarks" / "longmemeval" / "test_longmemeval.py"
+    )
+    module = _load_module("longmemeval_default_answerer", module_path)
+
+    assert module.get_config("baseline").llm_model == "gpt-5-mini"

--- a/tests/test_longmemeval_benchmark_script.py
+++ b/tests/test_longmemeval_benchmark_script.py
@@ -1,0 +1,139 @@
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def test_runner_forwards_stratified_resume_judge_and_existing_token(
+    tmp_path: Path,
+) -> None:
+    sandbox = tmp_path / "repo"
+    (sandbox / "scripts" / "lib").mkdir(parents=True)
+    (sandbox / "tests" / "benchmarks" / "longmemeval" / "data").mkdir(parents=True)
+
+    (sandbox / "test-longmemeval-benchmark.sh").write_text(
+        (REPO_ROOT / "test-longmemeval-benchmark.sh").read_text()
+    )
+    (sandbox / "scripts" / "lib" / "common.sh").write_text(
+        (REPO_ROOT / "scripts" / "lib" / "common.sh").read_text()
+    )
+    (
+        sandbox / "tests" / "benchmarks" / "longmemeval" / "data" / "longmemeval_s_cleaned.json"
+    ).write_text("[]")
+    (sandbox / ".env").write_text("AUTOMEM_API_TOKEN=env-token\n")
+    (sandbox / "test-longmemeval-benchmark.sh").chmod(0o755)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    python_args = tmp_path / "python-args.txt"
+
+    _write_executable(bin_dir / "curl", "#!/bin/sh\nexit 0\n")
+    _write_executable(
+        bin_dir / "docker",
+        "#!/bin/sh\n"
+        'if [ "$1" = "info" ]; then exit 0; fi\n'
+        'if [ "$1" = "compose" ]; then exit 0; fi\n'
+        "exit 0\n",
+    )
+    _write_executable(
+        bin_dir / "python3",
+        "#!/bin/sh\n" f"printf '%s\\n' \"$@\" > '{python_args}'\n" "exit 0\n",
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["AUTOMEM_TEST_API_TOKEN"] = "existing-token"
+
+    result = subprocess.run(
+        [
+            str(sandbox / "test-longmemeval-benchmark.sh"),
+            "--per-type",
+            "5",
+            "--llm-eval",
+            "--llm-model",
+            "gpt-5-mini",
+            "--eval-llm-model",
+            "custom-judge",
+            "--output",
+            "benchmarks/results/run-base",
+            "--resume",
+        ],
+        cwd=sandbox,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+    args = python_args.read_text().splitlines()
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "--api-token" in args
+    assert args[args.index("--api-token") + 1] == "existing-token"
+    assert "--per-type" in args
+    assert args[args.index("--per-type") + 1] == "5"
+    assert "--llm-eval" in args
+    assert args[args.index("--llm-model") + 1] == "gpt-5-mini"
+    assert args[args.index("--eval-llm-model") + 1] == "custom-judge"
+    assert args[args.index("--output") + 1] == "benchmarks/results/run-base"
+    assert "--resume" in args
+
+
+def test_runner_uses_env_file_token_when_test_token_missing(tmp_path: Path) -> None:
+    sandbox = tmp_path / "repo"
+    (sandbox / "scripts" / "lib").mkdir(parents=True)
+    (sandbox / "tests" / "benchmarks" / "longmemeval" / "data").mkdir(parents=True)
+
+    (sandbox / "test-longmemeval-benchmark.sh").write_text(
+        (REPO_ROOT / "test-longmemeval-benchmark.sh").read_text()
+    )
+    (sandbox / "scripts" / "lib" / "common.sh").write_text(
+        (REPO_ROOT / "scripts" / "lib" / "common.sh").read_text()
+    )
+    (
+        sandbox / "tests" / "benchmarks" / "longmemeval" / "data" / "longmemeval_s_cleaned.json"
+    ).write_text("[]")
+    (sandbox / ".env").write_text("AUTOMEM_API_TOKEN=env-token\n")
+    (sandbox / "test-longmemeval-benchmark.sh").chmod(0o755)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    python_args = tmp_path / "python-args-env.txt"
+
+    _write_executable(bin_dir / "curl", "#!/bin/sh\nexit 0\n")
+    _write_executable(
+        bin_dir / "docker",
+        "#!/bin/sh\n"
+        'if [ "$1" = "info" ]; then exit 0; fi\n'
+        'if [ "$1" = "compose" ]; then exit 0; fi\n'
+        "exit 0\n",
+    )
+    _write_executable(
+        bin_dir / "python3",
+        "#!/bin/sh\n" f"printf '%s\\n' \"$@\" > '{python_args}'\n" "exit 0\n",
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env.pop("AUTOMEM_TEST_API_TOKEN", None)
+
+    result = subprocess.run(
+        [str(sandbox / "test-longmemeval-benchmark.sh"), "--max-questions", "1"],
+        cwd=sandbox,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+    args = python_args.read_text().splitlines()
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert args[args.index("--api-token") + 1] == "env-token"


### PR DESCRIPTION
## Summary

- Adds deterministic stratified LongMemEval mini selection with `--per-type`, preserving prefix `--max-questions` only for debug smoke runs.
- Updates LongMemEval model defaults and metadata so the answerer is `gpt-5-mini` and the canonical judge remains `gpt-5.4-mini-2026-03-17`.
- Makes LongMemEval runs resumable and crash-tolerant with per-question partial JSONL/status artifacts, judge retries, cleanup in `finally`, and publishability metadata.
- Adds a result-analysis helper for LongMemEval artifacts and refreshes `benchmarks/EXPERIMENT_LOG.md` so full LongMemEval is a headline result.

## Benchmark Results

Canonical full LongMemEval run:

- Accuracy: **86.20% (431/500)**
- Retrieval recall@5: **97.20% (486/500)**
- `judge_errors=0`
- `memory_ingest_failures=0`
- `publishable=true`

Representative stratified mini:

- Accuracy: **60.0% (18/30)**
- Retrieval recall@5: **96.67% (29/30)**
- 5 questions per question type

Follow-up server work is tracked separately in #158 and #159.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest tests/test_benchmark_env_loading.py tests/benchmarks/longmemeval/test_analysis.py tests/benchmarks/longmemeval/test_evaluator.py tests/test_locomo_benchmark_script.py tests/test_longmemeval_benchmark_script.py -q`
- `make test`
- `./test-longmemeval-benchmark.sh --per-type 5 --llm-eval --llm-model gpt-5-mini`
- `./test-longmemeval-benchmark.sh --llm-eval --llm-model gpt-5-mini --output benchmarks/results/longmemeval_full_gpt5mini_20260425_231308`