### PR TITLE
ci: enforce semantic PR titles

### DIFF
--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -1,0 +1,33 @@
+name: Semantic PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            refactor
+            test
+            ci
+            build
+            chore
+            perf
+            revert
+          requireScope: false
+          subjectPattern: ^(?!\[).+
+          subjectPatternError: |
+            PR titles must not start with bracketed agent/status prefixes like [codex], [claude], [copilot], or [wip].
+            Use a Conventional Commit title such as "feat(api): add memory-by-tag pagination" and put agent/status context in the PR body.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,9 @@ The benchmark system uses **snapshot-based evaluation**: ingest once, eval many 
 
 ## Commit & Pull Requests
 
-- Use Conventional Commits style: `feat`, `fix`, `docs`, `refactor`, `test`, `chore` (e.g., `feat(api): add /analyze endpoint`).
+- PR titles must use Conventional Commit format because squash merges use the PR title as the release commit title. Do not prefix titles with `[codex]`, `[claude]`, `[copilot]`, `[wip]`, or similar labels; put agent/status context in the PR body.
+- Use Conventional Commit types: `feat`, `fix`, `docs`, `refactor`, `test`, `ci`, `build`, `chore`, `perf`, `revert` (e.g., `feat(api): add /analyze endpoint`).
+- For public API changes, use `feat(api): ...` unless the change is strictly a bug fix with no new public surface. For docs-only changes, use `docs: ...`; for release automation, use `ci(release): ...` or `chore(release): ...`.
 - PRs must include: clear description and scope, linked issues, test plan/output, and notes on API or config changes. Update relevant docs under `docs/`.
 - CI must pass; formatting/lint clean.
 

--- a/docs/AGENT_TEMPLATE.md
+++ b/docs/AGENT_TEMPLATE.md
@@ -16,11 +16,12 @@ Reusable playbook for long-running coding sessions with GitHub PRs and CodeRabit
 1) Read context (recent commits, open PRs, failing checks) and make a short plan.
 2) Implement minimal scoped changes; add/adjust tests.
 3) Run targeted tests first (`<targeted test cmd>`), then format/lint (`<fmt/lint cmd>`).
-4) Commit with Conventional Commits; keep diffs tight. Push and open a draft PR early for CI.
+4) Commit and title PRs with Conventional Commits; the PR title becomes the squash-merge release commit title. Push and open a draft PR early for CI.
 5) While CI runs, pick up the next queued item or address feedback.
 
 ## PR & CodeRabit Reviews
 - PR body must include: Goal; Scope; Tests (commands + results); Risks/Rollback; Follow-ups; Screenshots if UI.
+- Do not prefix PR titles with `[codex]`, `[claude]`, `[copilot]`, `[wip]`, or similar labels; put agent/status context in the PR body.
 - Rebase/merge main regularly (e.g., every 60–90 minutes or after each issue).
 - Request CodeRabit review when ready; re-request after changes; summarize deltas in PR comments to speed review.
 


### PR DESCRIPTION
## Summary
- add a GitHub PR-title workflow that requires Conventional Commit PR titles
- reject bracket-prefixed subjects such as `feat: [codex] ...`
- document that PR titles become squash-merge release commit titles

## Test Plan
- `git diff --cached --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/semantic-pr-title.yml"); puts "workflow yaml ok"'`
- dry-run title examples for allowed and rejected PR titles

## Notes
- Existing required checks are unchanged in the GitHub ruleset.
- The repo ruleset now requires `semantic-pr-title` and allows squash merges only.