### PR TITLE
feat(scripts): safer reclassify_with_llm.py with provider flags + tighter prompt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ OPENAI_API_KEY=
 # For OpenAI-compatible providers (OpenRouter, LiteLLM, vLLM, etc.):
 # OPENAI_BASE_URL=https://openrouter.ai/api/v1
 # EMBEDDING_MODEL=openai/text-embedding-3-small
+# --- LLM classification (scripts/reclassify_with_llm.py) ---
+# Optional. Defaults to OpenAI gpt-4o-mini via OPENAI_API_KEY.
+# OPENROUTER_API_KEY=                    # used by --provider openrouter
+# CLASSIFICATION_BASE_URL=               # any OpenAI-compatible endpoint
+# CLASSIFICATION_API_KEY=                # key paired with CLASSIFICATION_BASE_URL
 AUTOMEM_API_TOKEN=
 ADMIN_API_TOKEN=
 ENABLE_GRAPH_VIEWER=true

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -241,6 +241,9 @@ Controls embedding provider and classification model settings.
 | `VECTOR_SIZE` | Embedding dimension | `1024` | Must match embedding provider (1024=voyage-4, 1536=text-embedding-3-small native; choose ≤1536 when truncating, 3072=text-embedding-3-large native) |
 | `VECTOR_SIZE_AUTODETECT` | Adopt existing collection dimension instead of failing on mismatch | `true` | `false` to enforce strict matching |
 | `CLASSIFICATION_MODEL` | LLM for memory type classification | `gpt-4o-mini` | `gpt-4o-mini`, `gpt-4.1`, `gpt-5.1` |
+| `CLASSIFICATION_BASE_URL` | Optional OpenAI-compatible endpoint for `scripts/reclassify_with_llm.py` | _(unset → OpenAI)_ | e.g. `https://openrouter.ai/api/v1` |
+| `CLASSIFICATION_API_KEY` | API key paired with `CLASSIFICATION_BASE_URL` (never falls back across providers) | _(unset)_ | provider key |
+| `OPENROUTER_API_KEY` | API key consumed when `scripts/reclassify_with_llm.py --provider openrouter` is selected | _(unset)_ | OpenRouter key |
 
 **Embedding Provider Comparison:**
 

--- a/scripts/reclassify_with_llm.py
+++ b/scripts/reclassify_with_llm.py
@@ -300,9 +300,7 @@ def main():
     # response_format=json_object is OpenAI-only. Gate on the endpoint, not the
     # model name — a gpt-* model name routed through OpenRouter would otherwise
     # request a parameter the gateway may reject.
-    supports_json_mode = base_url is None and model.startswith(
-        ("gpt-", "o1-", "o3-", "o4-")
-    )
+    supports_json_mode = base_url is None and model.startswith(("gpt-", "o1-", "o3-", "o4-"))
 
     print("=" * 70)
     print("🤖 AutoMem LLM Reclassification Tool")
@@ -315,7 +313,9 @@ def main():
 
     if not api_key:
         if args.provider == "openrouter":
-            print("❌ No API key for OpenRouter. Set OPENROUTER_API_KEY (or CLASSIFICATION_API_KEY).")
+            print(
+                "❌ No API key for OpenRouter. Set OPENROUTER_API_KEY (or CLASSIFICATION_API_KEY)."
+            )
         elif base_url:
             print(f"❌ No API key for {base_url}. Set CLASSIFICATION_API_KEY.")
         else:
@@ -351,7 +351,9 @@ def main():
     # Initialize OpenAI-compatible client (OpenAI or OpenRouter)
     endpoint_label = base_url or "https://api.openai.com/v1 (OpenAI default)"
     print(f"🤖 Initializing client (model: {model}, endpoint: {endpoint_label})")
-    openai_client = OpenAI(api_key=api_key, base_url=base_url) if base_url else OpenAI(api_key=api_key)
+    openai_client = (
+        OpenAI(api_key=api_key, base_url=base_url) if base_url else OpenAI(api_key=api_key)
+    )
     print("✅ Client ready\n")
 
     # Push --limit into Cypher for head sampling so we don't materialize the
@@ -425,9 +427,7 @@ def main():
         if args.dry_run:
             success_count += 1
             print(f"   🧪 (dry-run, not written)")
-        elif update_memory_type(
-            falkor_client, qdrant_client, memory_id, new_type, new_confidence
-        ):
+        elif update_memory_type(falkor_client, qdrant_client, memory_id, new_type, new_confidence):
             success_count += 1
             print(f"   ✅ Updated")
         else:

--- a/scripts/reclassify_with_llm.py
+++ b/scripts/reclassify_with_llm.py
@@ -8,8 +8,10 @@ Environment:
     CLASSIFICATION_MODEL: LLM model for classification (default: gpt-4o-mini)
 """
 
+import argparse
 import json
 import os
+import random
 import sys
 import time
 from pathlib import Path
@@ -31,20 +33,47 @@ QDRANT_URL = os.getenv("QDRANT_URL", "http://localhost:6333")
 QDRANT_API_KEY = os.getenv("QDRANT_API_KEY")
 QDRANT_COLLECTION = os.getenv("QDRANT_COLLECTION", "memories")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
+# CLASSIFICATION_BASE_URL lets you point at any OpenAI-compatible endpoint
+# (e.g. https://openrouter.ai/api/v1 for OpenRouter).
+CLASSIFICATION_BASE_URL = os.getenv("CLASSIFICATION_BASE_URL")
+CLASSIFICATION_API_KEY = os.getenv("CLASSIFICATION_API_KEY")
 CLASSIFICATION_MODEL = os.getenv("CLASSIFICATION_MODEL", "gpt-4o-mini")
 
 # Valid memory types
 VALID_TYPES = {"Decision", "Pattern", "Preference", "Style", "Habit", "Insight", "Context"}
 
-SYSTEM_PROMPT = """You are a memory classification system. Classify each memory into exactly ONE of these types:
+SYSTEM_PROMPT = """You classify a single memory into exactly ONE type. Read the content carefully and pick the most specific type that fits. When multiple fit, use the priority rules at the bottom.
 
-- **Decision**: Choices made, selected options, what was decided
-- **Pattern**: Recurring behaviors, typical approaches, consistent tendencies
-- **Preference**: Likes/dislikes, favorites, personal tastes
-- **Style**: Communication approach, formatting, tone used
-- **Habit**: Regular routines, repeated actions, schedules
-- **Insight**: Discoveries, learnings, realizations, key findings
-- **Context**: Situational background, what was happening, circumstances
+TYPES (with strict definitions):
+
+- **Decision**: A choice was actively made between alternatives, or a commitment was made. Keywords: "chose", "decided", "will use", "picked X over Y", "going with". NOT every recommendation or protocol is a Decision — only if *someone made a choice*.
+
+- **Pattern**: A reusable approach, template, or recurring way of doing something. Keywords: "pattern", "approach", "template", "workflow", "always do X when Y". Repeatable and generalizable.
+
+- **Preference**: A stated like/dislike, favorite, or taste. Someone prefers X. Keywords: "prefers", "likes", "dislikes", "favorite", "wants X over Y" (as a taste, not a decision).
+
+- **Style**: Formatting, tone, naming convention, or communication approach. Keywords: "tabs not spaces", "short commit messages", "formal tone", "snake_case".
+
+- **Habit**: A regular routine or repeated behavior. Keywords: "always X", "every morning", "routinely", "every Friday". Time-regularity is the marker.
+
+- **Insight**: A genuine *realization* or *learning* from experience — something the author *discovered* or *figured out*. Keywords: "turns out", "learned that", "root cause", "realized", "the trick is", "gotcha". NOT textbook facts or product descriptions.
+
+- **Context**: Background facts about a person, place, product, tool, or situation. Keywords: "X is a Y", "X offers Y", "X released", "X is located at", biographical facts, product descriptions, tool capabilities, session logs, conversation fragments. This is the correct type for factual statements that aren't discoveries.
+
+PRIORITY RULES (apply in order):
+
+1. If the memory starts with "Fact:", "Concept:", "[X in #channel]", "Session:", or is biographical/descriptive about an entity → **Context**, not Insight.
+2. If the memory describes a gotcha, failure mode, root cause, unexpected behavior, or something the author discovered through experience → **Insight**.
+3. A security protocol, best practice, or recommendation is NOT a Decision unless someone explicitly chose it over an alternative → usually **Insight** or **Context**.
+4. A tool description ("X does Y", "X is a library that...") is **Context**, not Insight, even if interesting.
+5. A DM fragment or conversation excerpt is **Context**, not Decision.
+6. A "how I set up X" or "how X works" explanation is **Context** unless it's framed as a reusable approach → then **Pattern**.
+7. Only return **Preference** / **Style** / **Habit** when the memory is unambiguously one of those — these are narrow categories, don't stretch them.
+
+Be conservative with Insight — it should mean genuine experiential learning, not any statement that sounds smart. If you're unsure between Insight and Context, pick Context.
+
+Confidence: 0.95+ if the type is obvious, 0.75-0.9 if you had to apply a priority rule, 0.5-0.7 if genuinely ambiguous.
 
 Return JSON with: {"type": "<type>", "confidence": <0.0-1.0>}"""
 
@@ -76,21 +105,50 @@ def get_fallback_memories(client) -> list[Dict[str, Any]]:
     return memories
 
 
-def classify_with_llm(openai_client: OpenAI, content: str) -> tuple[str, float]:
-    """Use OpenAI to classify memory type."""
+def _extract_json(text: str) -> dict:
+    """Parse JSON from model output, tolerating ```json fences and prose."""
+    text = text.strip()
+    # Strip ```json ... ``` fencing
+    if text.startswith("```"):
+        text = text.strip("`")
+        if text.lower().startswith("json"):
+            text = text[4:]
+        text = text.strip()
+        # Trim trailing fence leftover
+        if text.endswith("```"):
+            text = text[:-3].strip()
+    # First try direct parse
     try:
-        response = openai_client.chat.completions.create(
-            model=CLASSIFICATION_MODEL,
-            messages=[
-                {"role": "system", "content": SYSTEM_PROMPT},
-                {"role": "user", "content": content[:1000]},
-            ],
-            response_format={"type": "json_object"},
-            temperature=0.3,
-            max_tokens=50,
-        )
+        return json.loads(text)
+    except Exception:
+        pass
+    # Fallback: find first { ... } block
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        return json.loads(text[start : end + 1])
+    raise ValueError(f"No JSON object found in: {text[:200]}")
 
-        result = json.loads(response.choices[0].message.content)
+
+def classify_with_llm(openai_client: OpenAI, content: str) -> tuple[str, float]:
+    """Classify memory type via OpenAI-compatible chat completion."""
+    kwargs = dict(
+        model=CLASSIFICATION_MODEL,
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": content[:1000]},
+        ],
+        temperature=0.3,
+        max_tokens=50,
+    )
+    # Only request json_object mode for OpenAI models — OpenRouter Gemini rejects it.
+    if CLASSIFICATION_MODEL.startswith(("gpt-", "o1-", "o3-", "o4-")):
+        kwargs["response_format"] = {"type": "json_object"}
+
+    try:
+        response = openai_client.chat.completions.create(**kwargs)
+        raw = response.choices[0].message.content or ""
+        result = _extract_json(raw)
         memory_type = result.get("type", "Context")
         confidence = float(result.get("confidence", 0.7))
 
@@ -140,13 +198,78 @@ def update_memory_type(
 
 def main():
     """Main reclassification process."""
+    parser = argparse.ArgumentParser(description="Reclassify fallback 'Memory' types via LLM.")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Process at most N memories (sampled). Useful for dry-runs.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Classify and print proposed changes without writing to FalkorDB or Qdrant.",
+    )
+    parser.add_argument(
+        "--sample",
+        choices=["head", "random"],
+        default="head",
+        help="How to pick memories when --limit is set (default: head).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Random seed for --sample random (for reproducible slices).",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the interactive confirmation prompt.",
+    )
+    parser.add_argument(
+        "--provider",
+        choices=["openai", "openrouter"],
+        default=None,
+        help="Shortcut for setting base URL + key. 'openrouter' uses OPENROUTER_API_KEY.",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Override CLASSIFICATION_MODEL (e.g. google/gemini-3.1-flash-lite-preview).",
+    )
+    args = parser.parse_args()
+
+    # Resolve provider → base_url + api_key
+    base_url = CLASSIFICATION_BASE_URL
+    api_key = CLASSIFICATION_API_KEY
+    if args.provider == "openrouter":
+        base_url = base_url or "https://openrouter.ai/api/v1"
+        api_key = api_key or OPENROUTER_API_KEY
+    elif args.provider == "openai":
+        base_url = None  # use OpenAI default
+        api_key = api_key or OPENAI_API_KEY
+
+    # Fallbacks
+    if not api_key:
+        api_key = OPENAI_API_KEY
+
+    # Override model if passed on CLI
+    model = args.model or CLASSIFICATION_MODEL
+    # Share model with classify_with_llm via a module-level rebind
+    globals()["CLASSIFICATION_MODEL"] = model
+
     print("=" * 70)
     print("🤖 AutoMem LLM Reclassification Tool")
+    if args.dry_run:
+        print("   [DRY-RUN MODE — no writes]")
+    if args.limit is not None:
+        print(f"   [LIMIT: {args.limit} memories, sample={args.sample}]")
     print("=" * 70)
     print()
 
-    if not OPENAI_API_KEY:
-        print("❌ OPENAI_API_KEY not found in environment!")
+    if not api_key:
+        print("❌ No API key found. Set OPENAI_API_KEY or OPENROUTER_API_KEY.")
         sys.exit(1)
 
     # Connect to FalkorDB
@@ -174,10 +297,11 @@ def main():
             print(f"⚠️  Qdrant connection failed: {e}")
             print("   (Will update FalkorDB only)\n")
 
-    # Initialize OpenAI
-    print(f"🤖 Initializing OpenAI client (model: {CLASSIFICATION_MODEL})")
-    openai_client = OpenAI(api_key=OPENAI_API_KEY)
-    print("✅ OpenAI ready\n")
+    # Initialize OpenAI-compatible client (OpenAI or OpenRouter)
+    endpoint_label = base_url or "https://api.openai.com/v1 (OpenAI default)"
+    print(f"🤖 Initializing client (model: {model}, endpoint: {endpoint_label})")
+    openai_client = OpenAI(api_key=api_key, base_url=base_url) if base_url else OpenAI(api_key=api_key)
+    print("✅ Client ready\n")
 
     # Get fallback memories
     memories = get_fallback_memories(falkor_client)
@@ -185,6 +309,18 @@ def main():
     if not memories:
         print("✅ No memories need reclassification!")
         return
+
+    total_available = len(memories)
+
+    # Apply --limit slice
+    if args.limit is not None and args.limit < len(memories):
+        if args.sample == "random":
+            if args.seed is not None:
+                random.seed(args.seed)
+            memories = random.sample(memories, args.limit)
+        else:  # head
+            memories = memories[: args.limit]
+        print(f"🎯 Sliced to {len(memories)} memories (of {total_available} available)\n")
 
     # Estimate cost
     tokens_per_memory = 370  # ~350 input + 20 output
@@ -195,11 +331,12 @@ def main():
     print(f"📊 Tokens: ~{total_tokens:,}")
     print()
 
-    # Confirm
-    response = input(f"🔄 Reclassify {len(memories)} memories with LLM? [y/N]: ")
-    if response.lower() != "y":
-        print("❌ Reclassification cancelled")
-        sys.exit(0)
+    # Confirm (unless --yes or --dry-run)
+    if not args.yes and not args.dry_run:
+        response = input(f"🔄 Reclassify {len(memories)} memories with LLM? [y/N]: ")
+        if response.lower() != "y":
+            print("❌ Reclassification cancelled")
+            sys.exit(0)
 
     print()
     print("🔄 Starting reclassification...")
@@ -222,7 +359,12 @@ def main():
 
         print(f"   → {new_type} (confidence: {new_confidence:.2f})")
 
-        if update_memory_type(falkor_client, qdrant_client, memory_id, new_type, new_confidence):
+        if args.dry_run:
+            success_count += 1
+            print(f"   🧪 (dry-run, not written)")
+        elif update_memory_type(
+            falkor_client, qdrant_client, memory_id, new_type, new_confidence
+        ):
             success_count += 1
             print(f"   ✅ Updated")
         else:

--- a/scripts/reclassify_with_llm.py
+++ b/scripts/reclassify_with_llm.py
@@ -6,6 +6,11 @@ them using the configured CLASSIFICATION_MODEL for more accurate type assignment
 
 Environment:
     CLASSIFICATION_MODEL: LLM model for classification (default: gpt-4o-mini)
+    CLASSIFICATION_BASE_URL: Optional OpenAI-compatible endpoint
+        (e.g. https://openrouter.ai/api/v1 for OpenRouter).
+    CLASSIFICATION_API_KEY: API key paired with CLASSIFICATION_BASE_URL.
+    OPENROUTER_API_KEY: Fallback key when --provider openrouter is selected.
+    OPENAI_API_KEY: Fallback key when --provider openai (or default) is selected.
 """
 
 import argparse
@@ -78,18 +83,27 @@ Confidence: 0.95+ if the type is obvious, 0.75-0.9 if you had to apply a priorit
 Return JSON with: {"type": "<type>", "confidence": <0.0-1.0>}"""
 
 
-def get_fallback_memories(client) -> list[Dict[str, Any]]:
-    """Fetch all memories with type='Memory' (fallback)."""
+def get_fallback_memories(client, db_limit: int | None = None) -> list[Dict[str, Any]]:
+    """Fetch memories with type='Memory' (fallback).
+
+    When `db_limit` is set, the cap is applied in Cypher so we don't materialize
+    the whole corpus on head-sampled partial runs. Random sampling still requires
+    the full set, so this stays None in that path.
+    """
     print("📥 Fetching memories with fallback type='Memory'...")
     g = client.select_graph("memories")
 
-    result = g.query(
-        """
-        MATCH (m:Memory)
-        WHERE m.type = 'Memory'
-        RETURN m.id as id, m.content as content, m.confidence as confidence
-    """
+    cypher = (
+        "MATCH (m:Memory) "
+        "WHERE m.type = 'Memory' "
+        "RETURN m.id as id, m.content as content, m.confidence as confidence"
     )
+    params: Dict[str, Any] = {}
+    if db_limit is not None:
+        cypher += " LIMIT $limit"
+        params["limit"] = db_limit
+
+    result = g.query(cypher, params) if params else g.query(cypher)
 
     memories = []
     for row in result.result_set:
@@ -127,10 +141,14 @@ def _extract_json(text: str) -> dict:
     end = text.rfind("}")
     if start != -1 and end != -1 and end > start:
         return json.loads(text[start : end + 1])
-    raise ValueError(f"No JSON object found in: {text[:200]}")
+    # Avoid echoing model output (may include memory content) into the exception
+    # message — the caller logs exceptions, which would leak corpus data.
+    raise ValueError("Model returned non-JSON output (no parseable object)")
 
 
-def classify_with_llm(openai_client: OpenAI, content: str) -> tuple[str, float]:
+def classify_with_llm(
+    openai_client: OpenAI, content: str, *, supports_json_mode: bool = False
+) -> tuple[str, float]:
     """Classify memory type via OpenAI-compatible chat completion."""
     kwargs = dict(
         model=CLASSIFICATION_MODEL,
@@ -141,8 +159,9 @@ def classify_with_llm(openai_client: OpenAI, content: str) -> tuple[str, float]:
         temperature=0.3,
         max_tokens=50,
     )
-    # Only request json_object mode for OpenAI models — OpenRouter Gemini rejects it.
-    if CLASSIFICATION_MODEL.startswith(("gpt-", "o1-", "o3-", "o4-")):
+    # response_format=json_object is OpenAI-specific. Gate on the selected endpoint
+    # (not the model name) — OpenRouter etc. may reject it even for gpt-* models.
+    if supports_json_mode:
         kwargs["response_format"] = {"type": "json_object"}
 
     try:
@@ -196,14 +215,25 @@ def update_memory_type(
         return False
 
 
+def _positive_int(raw: str) -> int:
+    """argparse type for a positive integer (rejects 0 and negatives)."""
+    try:
+        value = int(raw)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"expected integer, got {raw!r}")
+    if value < 1:
+        raise argparse.ArgumentTypeError(f"must be >= 1, got {value}")
+    return value
+
+
 def main():
     """Main reclassification process."""
     parser = argparse.ArgumentParser(description="Reclassify fallback 'Memory' types via LLM.")
     parser.add_argument(
         "--limit",
-        type=int,
+        type=_positive_int,
         default=None,
-        help="Process at most N memories (sampled). Useful for dry-runs.",
+        help="Process at most N memories (must be >= 1). Useful for dry-runs.",
     )
     parser.add_argument(
         "--dry-run",
@@ -240,24 +270,39 @@ def main():
     )
     args = parser.parse_args()
 
-    # Resolve provider → base_url + api_key
-    base_url = CLASSIFICATION_BASE_URL
-    api_key = CLASSIFICATION_API_KEY
+    # Resolve provider → base_url + api_key.
+    #
+    # Explicit --provider FORCES its canonical base URL so a stale
+    # CLASSIFICATION_BASE_URL in the env can't pair an OpenRouter key with the
+    # wrong endpoint (or vice versa). Provider-specific keys are only honored
+    # for that provider — we never silently fall back across providers (which
+    # would leak e.g. OPENAI_API_KEY to a third-party endpoint).
     if args.provider == "openrouter":
-        base_url = base_url or "https://openrouter.ai/api/v1"
-        api_key = api_key or OPENROUTER_API_KEY
+        base_url = "https://openrouter.ai/api/v1"
+        api_key = CLASSIFICATION_API_KEY or OPENROUTER_API_KEY
     elif args.provider == "openai":
-        base_url = None  # use OpenAI default
-        api_key = api_key or OPENAI_API_KEY
-
-    # Fallbacks
-    if not api_key:
-        api_key = OPENAI_API_KEY
+        base_url = None  # OpenAI default endpoint
+        api_key = CLASSIFICATION_API_KEY or OPENAI_API_KEY
+    else:
+        # No explicit provider. Honor CLASSIFICATION_BASE_URL if present
+        # (with its paired CLASSIFICATION_API_KEY only), else default to OpenAI.
+        base_url = CLASSIFICATION_BASE_URL
+        if base_url:
+            api_key = CLASSIFICATION_API_KEY
+        else:
+            api_key = CLASSIFICATION_API_KEY or OPENAI_API_KEY
 
     # Override model if passed on CLI
     model = args.model or CLASSIFICATION_MODEL
     # Share model with classify_with_llm via a module-level rebind
     globals()["CLASSIFICATION_MODEL"] = model
+
+    # response_format=json_object is OpenAI-only. Gate on the endpoint, not the
+    # model name — a gpt-* model name routed through OpenRouter would otherwise
+    # request a parameter the gateway may reject.
+    supports_json_mode = base_url is None and model.startswith(
+        ("gpt-", "o1-", "o3-", "o4-")
+    )
 
     print("=" * 70)
     print("🤖 AutoMem LLM Reclassification Tool")
@@ -269,7 +314,13 @@ def main():
     print()
 
     if not api_key:
-        print("❌ No API key found. Set OPENAI_API_KEY or OPENROUTER_API_KEY.")
+        if args.provider == "openrouter":
+            print("❌ No API key for OpenRouter. Set OPENROUTER_API_KEY (or CLASSIFICATION_API_KEY).")
+        elif base_url:
+            print(f"❌ No API key for {base_url}. Set CLASSIFICATION_API_KEY.")
+        else:
+            print("❌ No API key for OpenAI. Set OPENAI_API_KEY,")
+            print("   or pass --provider openrouter (with OPENROUTER_API_KEY) to use OpenRouter.")
         sys.exit(1)
 
     # Connect to FalkorDB
@@ -303,8 +354,11 @@ def main():
     openai_client = OpenAI(api_key=api_key, base_url=base_url) if base_url else OpenAI(api_key=api_key)
     print("✅ Client ready\n")
 
-    # Get fallback memories
-    memories = get_fallback_memories(falkor_client)
+    # Push --limit into Cypher for head sampling so we don't materialize the
+    # entire fallback corpus on partial runs. Random sampling still requires
+    # the full set, so we only cap at the DB for head mode.
+    db_limit = args.limit if (args.limit is not None and args.sample == "head") else None
+    memories = get_fallback_memories(falkor_client, db_limit=db_limit)
 
     if not memories:
         print("✅ No memories need reclassification!")
@@ -312,22 +366,29 @@ def main():
 
     total_available = len(memories)
 
-    # Apply --limit slice
-    if args.limit is not None and args.limit < len(memories):
-        if args.sample == "random":
-            if args.seed is not None:
-                random.seed(args.seed)
-            memories = random.sample(memories, args.limit)
-        else:  # head
-            memories = memories[: args.limit]
+    # Apply --limit slice (random sampling still needs the full set).
+    if args.limit is not None and args.sample == "random" and args.limit < len(memories):
+        if args.seed is not None:
+            random.seed(args.seed)
+        memories = random.sample(memories, args.limit)
         print(f"🎯 Sliced to {len(memories)} memories (of {total_available} available)\n")
+    elif args.limit is not None and args.sample == "head":
+        print(f"🎯 Capped at {len(memories)} memories (head, db-side LIMIT)\n")
 
-    # Estimate cost
+    # Estimate cost — the per-token figure below is OpenAI gpt-4o-mini pricing.
+    # For other models / providers (OpenRouter, Azure, vLLM, …) actual cost
+    # varies; surface the assumption so the confirmation prompt isn't misleading.
     tokens_per_memory = 370  # ~350 input + 20 output
     total_tokens = len(memories) * tokens_per_memory
-    estimated_cost = (total_tokens / 1_000_000) * 0.20  # Combined input/output
+    estimated_cost = (total_tokens / 1_000_000) * 0.20  # OpenAI gpt-4o-mini blended rate
 
+    pricing_basis = (
+        "OpenAI gpt-4o-mini pricing"
+        if base_url is None and model.startswith("gpt-4o-mini")
+        else f"OpenAI gpt-4o-mini pricing — actual cost depends on {model}"
+    )
     print(f"💰 Estimated cost: ${estimated_cost:.4f} (~{estimated_cost * 100:.1f} cents)")
+    print(f"   ({pricing_basis})")
     print(f"📊 Tokens: ~{total_tokens:,}")
     print()
 
@@ -354,7 +415,9 @@ def main():
         print(f"[{i}/{len(memories)}] {content_preview}")
 
         # Classify with LLM
-        new_type, new_confidence = classify_with_llm(openai_client, content)
+        new_type, new_confidence = classify_with_llm(
+            openai_client, content, supports_json_mode=supports_json_mode
+        )
         type_counts[new_type] = type_counts.get(new_type, 0) + 1
 
         print(f"   → {new_type} (confidence: {new_confidence:.2f})")


### PR DESCRIPTION
## Why

`scripts/reclassify_with_llm.py` is a one-shot maintenance tool, but in its current form it's all-or-nothing: there's no way to dry-run it, no way to sample a subset, and no way to point it at anything except OpenAI. That makes it scary to actually run on a real corpus, and impossible to benchmark alternative classification models without forking.

This PR makes it safe to use on a production corpus and provider-agnostic, plus tightens the classification prompt based on a 100-memory benchmark.

## What changes

### 1. CLI flags for safe partial runs

| Flag | Purpose |
|------|---------|
| `--limit N` | Cap memories processed (must be >= 1) |
| `--sample {head,random}` | How to pick when `--limit` is set (default: `head`) |
| `--seed N` | Reproducibility for `--sample random` |
| `--dry-run` | Classify but don't write back to FalkorDB |
| `--yes` | Skip the interactive confirmation prompt |
| `--provider {openai,openrouter}` | Force base URL + key (default: `openai`) |
| `--model M` | Override `CLASSIFICATION_MODEL` per-run |

Typical workflow now:
```bash
# 1. Sanity-check on 100 random memories, no writes
./scripts/reclassify_with_llm.py --limit 100 --sample random --seed 42 --dry-run

# 2. If the distribution looks right, commit to the full pass
./scripts/reclassify_with_llm.py --yes
```

For head sampling the cap is pushed into Cypher, so partial dry-runs no longer materialize the full fallback corpus.

### 2. OpenRouter / OpenAI-compatible provider support

Adds three env vars: `OPENROUTER_API_KEY`, `CLASSIFICATION_BASE_URL`, `CLASSIFICATION_API_KEY` (documented in `.env.example` and `docs/ENVIRONMENT_VARIABLES.md`). Same script can now target OpenRouter, LiteLLM, vLLM, Azure, or any OpenAI-compatible endpoint without code changes.

`--provider` forces the canonical base URL for its provider; provider-specific keys never fall back across providers (so `OPENAI_API_KEY` can't leak to a third-party endpoint).

Includes a **tolerant JSON extractor** for models that don't honor `response_format=json` (Gemini families on OpenRouter return prose-wrapped JSON and otherwise crash the strict parser). `response_format` is now gated on the selected endpoint, not the model name.

### 3. Tightened SYSTEM_PROMPT

The prior prompt was a loose 7-bullet type list. New prompt has strict definitions, keyword cues, and explicit priority rules ("Fact:" and descriptive statements go to `Context`, not `Insight`; chat/DM fragments aren't `Decisions` just because they contain "decided").

**Empirical impact on a 100-memory sample (Gemini 3.1 Flash-Lite via OpenRouter):**

| Type | Before (loose) | After (strict) |
|------|---------------:|---------------:|
| Insight | **56%** (catch-all) | **8%** |
| False Decisions on DM/session fragments | several | **0** |
| Context, Pattern, Habit | underused | distribution closer to intent |

## Out of scope

- The startup-tick guard from the same flint-branch commit (`automem/consolidation/runtime_scheduler.py`) is **not** in this PR — it's a separate concern (FalkorDB RDB-loading race at init) and will land as its own PR.
- `discover_creative_associations` (the rule-based "dreaming" edge inference in `consolidation.py`) is unchanged here. There's an open thought to LLM-replace that with the same Gemini 3.1 Flash-Lite + tight-prompt pattern — happy to file a separate issue if it's interesting to benchmark.

## Test plan

- [ ] `./scripts/reclassify_with_llm.py --help` shows all new flags
- [ ] `--dry-run --limit 10` runs against a dev FalkorDB without writing
- [ ] `--provider openrouter --model google/gemini-3.1-flash-lite-preview --limit 10 --sample random --dry-run` works end-to-end
- [ ] `--limit 0` and `--limit -5` are rejected at CLI parse time
- [ ] Default behavior (no flags, OpenAI) is unchanged from prior script
