### PR TITLE
fix(recall): respect current memory state

### DIFF
--- a/automem/api/memory.py
+++ b/automem/api/memory.py
@@ -415,6 +415,8 @@ def create_memory_blueprint_full(
                                     "timestamp": created_at,
                                     "type": memory_type,
                                     "confidence": type_confidence,
+                                    "t_valid": t_valid or created_at,
+                                    "t_invalid": t_invalid,
                                     "updated_at": updated_at,
                                     "last_accessed": last_accessed,
                                     "metadata": metadata,
@@ -534,6 +536,8 @@ def create_memory_blueprint_full(
         memory_type = payload.get("type", current.get("type"))
         confidence = payload.get("confidence", current.get("confidence"))
         timestamp = payload.get("timestamp", current.get("timestamp"))
+        t_valid = payload.get("t_valid", current.get("t_valid"))
+        t_invalid = payload.get("t_invalid", current.get("t_invalid"))
         metadata_raw = payload.get("metadata", parse_metadata_field(current.get("metadata")))
         updated_at = payload.get("updated_at", current.get("updated_at", utc_now()))
         last_accessed = payload.get("last_accessed", current.get("last_accessed"))
@@ -551,6 +555,18 @@ def create_memory_blueprint_full(
                 timestamp = normalize_timestamp(timestamp)
             except ValueError as exc:
                 abort(400, description=f"Invalid timestamp: {exc}")
+
+        if t_valid:
+            try:
+                t_valid = normalize_timestamp(t_valid)
+            except ValueError as exc:
+                abort(400, description=f"Invalid t_valid: {exc}")
+
+        if t_invalid:
+            try:
+                t_invalid = normalize_timestamp(t_invalid)
+            except ValueError as exc:
+                abort(400, description=f"Invalid t_invalid: {exc}")
 
         if updated_at:
             try:
@@ -573,6 +589,8 @@ def create_memory_blueprint_full(
                 m.type = $type,
                 m.confidence = $confidence,
                 m.timestamp = $timestamp,
+                m.t_valid = $t_valid,
+                m.t_invalid = $t_invalid,
                 m.metadata = $metadata,
                 m.updated_at = $updated_at,
                 m.last_accessed = $last_accessed
@@ -590,6 +608,8 @@ def create_memory_blueprint_full(
                 "type": memory_type,
                 "confidence": confidence,
                 "timestamp": timestamp,
+                "t_valid": t_valid,
+                "t_invalid": t_invalid,
                 "metadata": metadata_json,
                 "updated_at": updated_at,
                 "last_accessed": last_accessed,
@@ -623,6 +643,8 @@ def create_memory_blueprint_full(
                     "timestamp": timestamp,
                     "type": memory_type,
                     "confidence": confidence,
+                    "t_valid": t_valid,
+                    "t_invalid": t_invalid,
                     "updated_at": updated_at,
                     "last_accessed": last_accessed,
                     "metadata": metadata,

--- a/automem/api/recall.py
+++ b/automem/api/recall.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import re
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple
 
@@ -21,6 +22,7 @@ from automem.config import (
     normalize_relation_type,
 )
 from automem.utils.graph import _serialize_node
+from automem.utils.time import _parse_iso_datetime
 
 DEFAULT_STYLE_PRIORITY_TAGS: Set[str] = {
     "coding-style",
@@ -69,6 +71,8 @@ EXTENSION_LANGUAGE_MAP: Dict[str, str] = {
     ".cxx": "cpp",
     ".swift": "swift",
 }
+
+STATE_SUPPRESSING_RELATIONS: Set[str] = {"INVALIDATED_BY", "EVOLVED_INTO"}
 
 # Words to skip when extracting entities from queries
 ENTITY_STOPWORDS: Set[str] = {
@@ -371,6 +375,221 @@ def _dedupe_results(results: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]]
         deduped.append(item)
 
     return deduped, removed
+
+
+def _result_memory_id(result: Dict[str, Any]) -> str:
+    memory = result.get("memory") or {}
+    return str(
+        result.get("id")
+        or memory.get("id")
+        or memory.get("memory_id")
+        or memory.get("uuid")
+        or ""
+    ).strip()
+
+
+def _state_reason_for_memory(memory: Dict[str, Any], now: datetime) -> Optional[str]:
+    if memory.get("archived") is True:
+        return "archived"
+
+    t_valid = _parse_iso_datetime(memory.get("t_valid"))
+    if t_valid is not None and t_valid > now:
+        return "not_yet_valid"
+
+    t_invalid = _parse_iso_datetime(memory.get("t_invalid"))
+    if t_invalid is not None and t_invalid <= now:
+        return "expired"
+
+    return None
+
+
+def _active_replacement_for_memory(
+    graph: Any,
+    memory_id: str,
+    now: datetime,
+    logger: Any,
+) -> Optional[Dict[str, Any]]:
+    if graph is None or not memory_id:
+        return None
+
+    try:
+        records = graph.query(
+            """
+            MATCH (m:Memory {id: $id})-[r]->(related:Memory)
+            WHERE type(r) IN $types
+            RETURN type(r) as relation_type,
+                   coalesce(
+                       r.strength,
+                       r.score,
+                       r.confidence,
+                       r.similarity,
+                       toFloat(r.count),
+                       0.0
+                   ) as strength,
+                   r.kind as relation_kind,
+                   related
+            ORDER BY coalesce(r.updated_at, related.timestamp) DESC
+            LIMIT $limit
+            """,
+            {"id": memory_id, "types": sorted(STATE_SUPPRESSING_RELATIONS), "limit": 5},
+        )
+    except Exception:
+        logger.exception("Failed to load current-state replacement for memory %s", memory_id)
+        return None
+
+    for row in getattr(records, "result_set", []) or []:
+        if len(row) >= 4:
+            relation_type, strength, relation_kind, related = row[:4]
+        elif len(row) >= 3:
+            relation_type, strength, related = row[:3]
+            relation_kind = None
+        else:  # pragma: no cover - defensive for malformed graph rows
+            continue
+
+        replacement = _serialize_node(related)
+        replacement_id = str(replacement.get("id") or "")
+        if not replacement_id:
+            continue
+        if _state_reason_for_memory(replacement, now) is not None:
+            continue
+
+        normalized_type, normalized_props = normalize_relation_type(
+            relation_type,
+            {"kind": relation_kind} if relation_kind else {},
+        )
+        replacement["_state_relation"] = {
+            "type": normalized_type,
+            "strength": float(strength or 0.0),
+        }
+        kind = normalized_props.get("kind")
+        if kind:
+            replacement["_state_relation"]["kind"] = kind
+        return replacement
+
+    return None
+
+
+def _apply_current_state_filter(
+    *,
+    results: List[Dict[str, Any]],
+    graph: Any,
+    result_passes_filters: Callable[
+        [
+            Dict[str, Any],
+            Optional[str],
+            Optional[str],
+            Optional[List[str]],
+            str,
+            str,
+            Optional[List[str]],
+        ],
+        bool,
+    ],
+    start_time: Optional[str],
+    end_time: Optional[str],
+    tag_filters: Optional[List[str]],
+    tag_mode: str,
+    tag_match: str,
+    exclude_tags: Optional[List[str]],
+    logger: Any,
+    state_debug: bool = False,
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    now = datetime.now(timezone.utc)
+    kept: List[Dict[str, Any]] = []
+    replacements: List[Dict[str, Any]] = []
+    seen_ids = {_result_memory_id(result) for result in results if _result_memory_id(result)}
+    suppressed_debug: List[Dict[str, Any]] = []
+    replacements_debug: List[Dict[str, Any]] = []
+    suppressed_count = 0
+
+    for result in results:
+        memory = result.get("memory") or {}
+        memory_id = _result_memory_id(result)
+        reason = _state_reason_for_memory(memory, now)
+        replacement = None
+        relation_type = None
+
+        if memory_id:
+            replacement = _active_replacement_for_memory(graph, memory_id, now, logger)
+            if replacement is not None:
+                relation = replacement.get("_state_relation") or {}
+                relation_type = str(relation.get("type") or "").strip() or None
+                if reason is None:
+                    reason = "superseded"
+
+        if reason is None:
+            kept.append(result)
+            continue
+
+        suppressed_count += 1
+        debug_item: Dict[str, Any] = {"id": memory_id, "reason": reason}
+
+        if replacement is not None:
+            replacement_id = str(replacement.get("id") or "")
+            debug_item["replacement_id"] = replacement_id
+            if relation_type:
+                debug_item["relation_type"] = relation_type
+
+            candidate_memory = dict(replacement)
+            relation = candidate_memory.pop("_state_relation", {})
+            candidate = {
+                "id": replacement_id,
+                "score": float(result.get("score") or result.get("final_score") or 0.0),
+                "match_score": float(result.get("match_score") or result.get("score") or 0.0),
+                "match_type": "state_replacement",
+                "source": "graph",
+                "memory": candidate_memory,
+                "relations": [
+                    {
+                        "type": relation.get("type", relation_type or "INVALIDATED_BY"),
+                        "strength": float(relation.get("strength") or 0.0),
+                        "from": memory_id,
+                    }
+                ],
+                "state_replaces": memory_id,
+                "final_score": float(result.get("final_score") or result.get("score") or 0.0),
+                "score_components": dict(result.get("score_components") or {}),
+            }
+            if relation.get("kind"):
+                candidate["relations"][0]["kind"] = relation["kind"]
+
+            if (
+                replacement_id
+                and replacement_id not in seen_ids
+                and result_passes_filters(
+                    candidate,
+                    start_time,
+                    end_time,
+                    tag_filters,
+                    tag_mode,
+                    tag_match,
+                    exclude_tags,
+                )
+            ):
+                replacements.append(candidate)
+                seen_ids.add(replacement_id)
+                if state_debug:
+                    replacements_debug.append(
+                        {
+                            "id": replacement_id,
+                            "replaces_id": memory_id,
+                            "relation_type": relation_type,
+                        }
+                    )
+
+        if state_debug:
+            suppressed_debug.append(debug_item)
+
+    state_filter: Dict[str, Any] = {
+        "current_only": True,
+        "suppressed_count": suppressed_count,
+        "replacement_count": len(replacements),
+    }
+    if state_debug:
+        state_filter["suppressed"] = suppressed_debug
+        state_filter["replacements"] = replacements_debug
+
+    return kept + replacements, state_filter
 
 
 def _split_multi_value(raw: Any) -> List[str]:
@@ -1269,6 +1488,8 @@ def handle_recall(
         request.args.get("expand_respect_tags"),
         False,
     )
+    current_only = _parse_bool_param(request.args.get("current_only"), True)
+    state_debug = _parse_bool_param(request.args.get("state_debug"), False)
 
     # Entity expansion for multi-hop reasoning
     expand_entities = _parse_bool_param(
@@ -1642,6 +1863,22 @@ def handle_recall(
             ]
         results = seed_results + expansion_results + entity_expansion_results
 
+    state_filter_info: Optional[Dict[str, Any]] = None
+    if current_only:
+        results, state_filter_info = _apply_current_state_filter(
+            results=results,
+            graph=graph,
+            result_passes_filters=result_passes_filters,
+            start_time=start_time,
+            end_time=end_time,
+            tag_filters=tag_filters,
+            tag_mode=tag_mode,
+            tag_match=tag_match,
+            exclude_tags=exclude_tags,
+            logger=logger,
+            state_debug=state_debug,
+        )
+
     pre_filter_count = len(results)
 
     # Apply adaptive score floor: detect a pronounced dropoff without discarding most results.
@@ -1724,6 +1961,8 @@ def handle_recall(
         response["tags"] = tag_filters
     if exclude_tags:
         response["exclude_tags"] = exclude_tags
+    if state_filter_info is not None:
+        response["state_filter"] = state_filter_info
     response["tag_mode"] = tag_mode
     response["tag_match"] = tag_match
     if jit_enriched_count:

--- a/automem/api/recall.py
+++ b/automem/api/recall.py
@@ -403,21 +403,24 @@ def _state_reason_for_memory(memory: Dict[str, Any], now: datetime) -> Optional[
     return None
 
 
-def _active_replacement_for_memory(
+def _active_replacements_for_memories(
     graph: Any,
-    memory_id: str,
+    memory_ids: List[str],
     now: datetime,
     logger: Any,
-) -> Optional[Dict[str, Any]]:
-    if graph is None or not memory_id:
-        return None
+) -> Dict[str, Dict[str, Any]]:
+    ordered_ids = list(dict.fromkeys(memory_id for memory_id in memory_ids if memory_id))
+    if graph is None or not ordered_ids:
+        return {}
 
     try:
         records = graph.query(
             """
-            MATCH (m:Memory {id: $id})-[r]->(related:Memory)
+            UNWIND $ids AS source_id
+            MATCH (m:Memory {id: source_id})-[r]->(related:Memory)
             WHERE type(r) IN $types
-            RETURN type(r) as relation_type,
+            RETURN source_id,
+                   type(r) as relation_type,
                    coalesce(
                        r.strength,
                        r.score,
@@ -428,22 +431,26 @@ def _active_replacement_for_memory(
                    ) as strength,
                    r.kind as relation_kind,
                    related
-            ORDER BY coalesce(r.updated_at, related.timestamp) DESC
-            LIMIT $limit
+            ORDER BY source_id, coalesce(r.updated_at, related.timestamp) DESC
             """,
-            {"id": memory_id, "types": sorted(STATE_SUPPRESSING_RELATIONS), "limit": 5},
+            {"ids": ordered_ids, "types": sorted(STATE_SUPPRESSING_RELATIONS)},
         )
     except Exception:
-        logger.exception("Failed to load current-state replacement for memory %s", memory_id)
-        return None
+        logger.exception("Failed to load current-state replacements for %d memories", len(ordered_ids))
+        return {}
 
+    replacements: Dict[str, Dict[str, Any]] = {}
     for row in getattr(records, "result_set", []) or []:
-        if len(row) >= 4:
-            relation_type, strength, relation_kind, related = row[:4]
-        elif len(row) >= 3:
-            relation_type, strength, related = row[:3]
+        if len(row) >= 5:
+            source_id, relation_type, strength, relation_kind, related = row[:5]
+        elif len(row) >= 4:
+            source_id, relation_type, strength, related = row[:4]
             relation_kind = None
         else:  # pragma: no cover - defensive for malformed graph rows
+            continue
+
+        source_id = str(source_id or "")
+        if not source_id or source_id in replacements:
             continue
 
         replacement = _serialize_node(related)
@@ -464,9 +471,9 @@ def _active_replacement_for_memory(
         kind = normalized_props.get("kind")
         if kind:
             replacement["_state_relation"]["kind"] = kind
-        return replacement
+        replacements[source_id] = replacement
 
-    return None
+    return replacements
 
 
 def _apply_current_state_filter(
@@ -498,6 +505,12 @@ def _apply_current_state_filter(
     kept: List[Dict[str, Any]] = []
     replacements: List[Dict[str, Any]] = []
     seen_ids = {_result_memory_id(result) for result in results if _result_memory_id(result)}
+    replacements_by_id = _active_replacements_for_memories(
+        graph,
+        [_result_memory_id(result) for result in results],
+        now,
+        logger,
+    )
     suppressed_debug: List[Dict[str, Any]] = []
     replacements_debug: List[Dict[str, Any]] = []
     suppressed_count = 0
@@ -510,7 +523,7 @@ def _apply_current_state_filter(
         relation_type = None
 
         if memory_id:
-            replacement = _active_replacement_for_memory(graph, memory_id, now, logger)
+            replacement = replacements_by_id.get(memory_id)
             if replacement is not None:
                 relation = replacement.get("_state_relation") or {}
                 relation_type = str(relation.get("type") or "").strip() or None

--- a/automem/api/recall.py
+++ b/automem/api/recall.py
@@ -380,11 +380,7 @@ def _dedupe_results(results: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]]
 def _result_memory_id(result: Dict[str, Any]) -> str:
     memory = result.get("memory") or {}
     return str(
-        result.get("id")
-        or memory.get("id")
-        or memory.get("memory_id")
-        or memory.get("uuid")
-        or ""
+        result.get("id") or memory.get("id") or memory.get("memory_id") or memory.get("uuid") or ""
     ).strip()
 
 
@@ -436,7 +432,9 @@ def _active_replacements_for_memories(
             {"ids": ordered_ids, "types": sorted(STATE_SUPPRESSING_RELATIONS)},
         )
     except Exception:
-        logger.exception("Failed to load current-state replacements for %d memories", len(ordered_ids))
+        logger.exception(
+            "Failed to load current-state replacements for %d memories", len(ordered_ids)
+        )
         return {}
 
     replacements: Dict[str, Dict[str, Any]] = {}

--- a/automem/api/recall.py
+++ b/automem/api/recall.py
@@ -502,8 +502,7 @@ def _apply_current_state_filter(
     state_debug: bool = False,
 ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
     now = datetime.now(timezone.utc)
-    kept: List[Dict[str, Any]] = []
-    replacements: List[Dict[str, Any]] = []
+    filtered_results: List[Dict[str, Any]] = []
     seen_ids = {_result_memory_id(result) for result in results if _result_memory_id(result)}
     replacements_by_id = _active_replacements_for_memories(
         graph,
@@ -514,6 +513,7 @@ def _apply_current_state_filter(
     suppressed_debug: List[Dict[str, Any]] = []
     replacements_debug: List[Dict[str, Any]] = []
     suppressed_count = 0
+    replacement_count = 0
 
     for result in results:
         memory = result.get("memory") or {}
@@ -531,7 +531,7 @@ def _apply_current_state_filter(
                     reason = "superseded"
 
         if reason is None:
-            kept.append(result)
+            filtered_results.append(result)
             continue
 
         suppressed_count += 1
@@ -579,8 +579,9 @@ def _apply_current_state_filter(
                     exclude_tags,
                 )
             ):
-                replacements.append(candidate)
+                filtered_results.append(candidate)
                 seen_ids.add(replacement_id)
+                replacement_count += 1
                 if state_debug:
                     replacements_debug.append(
                         {
@@ -596,13 +597,13 @@ def _apply_current_state_filter(
     state_filter: Dict[str, Any] = {
         "current_only": True,
         "suppressed_count": suppressed_count,
-        "replacement_count": len(replacements),
+        "replacement_count": replacement_count,
     }
     if state_debug:
         state_filter["suppressed"] = suppressed_debug
         state_filter["replacements"] = replacements_debug
 
-    return kept + replacements, state_filter
+    return filtered_results, state_filter
 
 
 def _split_multi_value(raw: Any) -> List[str]:

--- a/automem/api/runtime_memory_routes.py
+++ b/automem/api/runtime_memory_routes.py
@@ -328,6 +328,8 @@ def store_memory(
                                 "timestamp": created_at,
                                 "type": memory_type,
                                 "confidence": type_confidence,
+                                "t_valid": t_valid or created_at,
+                                "t_invalid": t_invalid,
                                 "updated_at": updated_at,
                                 "last_accessed": last_accessed,
                                 "metadata": metadata,
@@ -456,6 +458,8 @@ def update_memory(
     memory_type = payload.get("type", current.get("type"))
     confidence = payload.get("confidence", current.get("confidence"))
     timestamp = payload.get("timestamp", current.get("timestamp"))
+    t_valid = payload.get("t_valid", current.get("t_valid"))
+    t_invalid = payload.get("t_invalid", current.get("t_invalid"))
     metadata_raw = payload.get("metadata", parse_metadata_field_fn(current.get("metadata")))
     updated_at = payload.get("updated_at", current.get("updated_at", utc_now_fn()))
     last_accessed = payload.get("last_accessed", current.get("last_accessed"))
@@ -478,6 +482,18 @@ def update_memory(
         except ValueError as exc:
             abort_fn(400, description=f"Invalid timestamp: {exc}")
 
+    if t_valid:
+        try:
+            t_valid = normalize_timestamp_fn(t_valid)
+        except ValueError as exc:
+            abort_fn(400, description=f"Invalid t_valid: {exc}")
+
+    if t_invalid:
+        try:
+            t_invalid = normalize_timestamp_fn(t_invalid)
+        except ValueError as exc:
+            abort_fn(400, description=f"Invalid t_invalid: {exc}")
+
     if updated_at:
         try:
             updated_at = normalize_timestamp_fn(updated_at)
@@ -499,6 +515,8 @@ def update_memory(
             m.type = $type,
             m.confidence = $confidence,
             m.timestamp = $timestamp,
+            m.t_valid = $t_valid,
+            m.t_invalid = $t_invalid,
             m.metadata = $metadata,
             m.updated_at = $updated_at,
             m.last_accessed = $last_accessed
@@ -516,6 +534,8 @@ def update_memory(
             "type": memory_type,
             "confidence": confidence,
             "timestamp": timestamp,
+            "t_valid": t_valid,
+            "t_invalid": t_invalid,
             "metadata": metadata_json,
             "updated_at": updated_at,
             "last_accessed": last_accessed,
@@ -549,6 +569,8 @@ def update_memory(
                 "timestamp": timestamp,
                 "type": memory_type,
                 "confidence": confidence,
+                "t_valid": t_valid,
+                "t_invalid": t_invalid,
                 "updated_at": updated_at,
                 "last_accessed": last_accessed,
                 "metadata": metadata,

--- a/tests/support/fake_graph.py
+++ b/tests/support/fake_graph.py
@@ -428,6 +428,40 @@ class FakeGraph:
                 )
             return FakeResult(rows[: int(params.get("limit") or len(rows) or 1)])
 
+        if (
+            "UNWIND $ids AS source_id" in query
+            and "RETURN source_id" in query
+            and "related" in query
+        ):
+            source_ids = [str(memory_id) for memory_id in (params.get("ids") or [])]
+            requested_types = {
+                str(rel_type).strip()
+                for rel_type in (params.get("types") or [])
+                if str(rel_type).strip()
+            }
+            rows = []
+            for source_id in source_ids:
+                for rel in self.relationships:
+                    rel_type = str(rel.get("type") or "")
+                    if requested_types and rel_type not in requested_types:
+                        continue
+                    if rel.get("id1") != source_id:
+                        continue
+                    related_id = str(rel.get("id2") or "")
+                    related = self.memories.get(related_id)
+                    if related is None:
+                        continue
+                    rows.append(
+                        [
+                            source_id,
+                            rel_type,
+                            rel.get("strength", 0.5),
+                            rel.get("kind"),
+                            FakeNode(related),
+                        ]
+                    )
+            return FakeResult(rows)
+
         # Recall-style graph query over memories
         if (
             "MATCH (m:Memory)" in query

--- a/tests/support/fake_graph.py
+++ b/tests/support/fake_graph.py
@@ -187,6 +187,8 @@ class FakeGraph:
                 "metadata": params.get("metadata", existing.get("metadata", "{}")),
                 "updated_at": params.get("updated_at", existing.get("updated_at")),
                 "last_accessed": params.get("last_accessed", existing.get("last_accessed")),
+                "t_valid": params.get("t_valid", existing.get("t_valid")),
+                "t_invalid": params.get("t_invalid", existing.get("t_invalid")),
                 "confidence": params.get("confidence", existing.get("confidence", 1.0)),
                 "summary": params.get("summary", existing.get("summary")),
                 "processed": params.get("processed", existing.get("processed", False)),
@@ -213,6 +215,8 @@ class FakeGraph:
                     "timestamp": params.get("timestamp", memory.get("timestamp")),
                     "last_accessed": params.get("last_accessed", memory.get("last_accessed")),
                     "updated_at": params.get("updated_at", _utc_now()),
+                    "t_valid": params.get("t_valid", memory.get("t_valid")),
+                    "t_invalid": params.get("t_invalid", memory.get("t_invalid")),
                 }
             )
             return FakeResult([[FakeNode(memory)]])
@@ -386,6 +390,43 @@ class FakeGraph:
                 }
             )
             return FakeResult([["created"]])
+
+        if (
+            "MATCH (m:Memory {id: $id})-[r" in query
+            and "RETURN type(r) as relation_type" in query
+            and "related" in query
+        ):
+            memory_id = str(params.get("id") or "")
+            requested_types = {
+                str(rel_type).strip()
+                for rel_type in (params.get("types") or [])
+                if str(rel_type).strip()
+            }
+            directed = "]->" in query
+            rows = []
+            for rel in self.relationships:
+                rel_type = str(rel.get("type") or "")
+                if requested_types and rel_type not in requested_types:
+                    continue
+                related_id = None
+                if rel.get("id1") == memory_id:
+                    related_id = str(rel.get("id2") or "")
+                elif not directed and rel.get("id2") == memory_id:
+                    related_id = str(rel.get("id1") or "")
+                if not related_id:
+                    continue
+                related = self.memories.get(related_id)
+                if related is None:
+                    continue
+                rows.append(
+                    [
+                        rel_type,
+                        rel.get("strength", 0.5),
+                        rel.get("kind"),
+                        FakeNode(related),
+                    ]
+                )
+            return FakeResult(rows[: int(params.get("limit") or len(rows) or 1)])
 
         # Recall-style graph query over memories
         if (

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -635,9 +635,7 @@ def test_recall_current_only_injects_active_replacement(
     assert data["state_filter"]["suppressed"][0]["replacement_id"] == replacement_id
 
 
-def test_recall_current_only_batch_loads_relation_replacements(
-    client, mock_state, auth_headers
-):
+def test_recall_current_only_batch_loads_relation_replacements(client, mock_state, auth_headers):
     mock_state.memory_graph.memories.clear()
     mock_state.memory_graph.relationships.clear()
 
@@ -680,9 +678,7 @@ def test_recall_current_only_batch_loads_relation_replacements(
     assert len(replacement_queries) == 1
 
 
-def test_recall_current_only_keeps_replacement_score_order(
-    client, mock_state, auth_headers
-):
+def test_recall_current_only_keeps_replacement_score_order(client, mock_state, auth_headers):
     mock_state.memory_graph.memories.clear()
     mock_state.memory_graph.relationships.clear()
     old_id = "cc000000-0000-0000-0000-000000000019"
@@ -706,9 +702,7 @@ def test_recall_current_only_keeps_replacement_score_order(
     assert [result["id"] for result in data["results"]] == [replacement_id, active_id]
 
 
-def test_recall_current_only_replacement_respects_tag_filter(
-    client, mock_state, auth_headers
-):
+def test_recall_current_only_replacement_respects_tag_filter(client, mock_state, auth_headers):
     mock_state.memory_graph.memories.clear()
     mock_state.memory_graph.relationships.clear()
     old_id = "cc000000-0000-0000-0000-000000000012"
@@ -767,9 +761,7 @@ def test_recall_current_only_false_keeps_relation_history(
     assert "state_filter" not in data
 
 
-def test_recall_current_only_does_not_suppress_contradictions(
-    client, mock_state, auth_headers
-):
+def test_recall_current_only_does_not_suppress_contradictions(client, mock_state, auth_headers):
     mock_state.memory_graph.memories.clear()
     mock_state.memory_graph.relationships.clear()
     old_id = "cc000000-0000-0000-0000-000000000020"

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -505,7 +505,14 @@ def test_recall_with_high_limit(client, mock_state, auth_headers):
 
 
 def _store_memory(
-    mock_state, memory_id, content, tags, importance, mem_type="Context", timestamp=None
+    mock_state,
+    memory_id,
+    content,
+    tags,
+    importance,
+    mem_type="Context",
+    timestamp=None,
+    **extra,
 ):
     mock_state.memory_graph.memories[memory_id] = {
         "id": memory_id,
@@ -514,7 +521,267 @@ def _store_memory(
         "importance": importance,
         "type": mem_type,
         "timestamp": timestamp or utc_now(),
+        **extra,
     }
+
+
+def test_recall_current_only_filters_temporal_state(client, mock_state, auth_headers):
+    mock_state.memory_graph.memories.clear()
+    now = datetime.now(timezone.utc)
+    active_id = "cc000000-0000-0000-0000-000000000001"
+    expired_id = "cc000000-0000-0000-0000-000000000002"
+    future_id = "cc000000-0000-0000-0000-000000000003"
+
+    _store_memory(mock_state, active_id, "Active current state", ["state"], 0.9)
+    _store_memory(
+        mock_state,
+        expired_id,
+        "Expired stale state",
+        ["state"],
+        0.95,
+        t_invalid=(now - timedelta(days=1)).isoformat(),
+    )
+    _store_memory(
+        mock_state,
+        future_id,
+        "Future state",
+        ["state"],
+        0.98,
+        t_valid=(now + timedelta(days=1)).isoformat(),
+    )
+
+    response = client.get(
+        "/recall?tags=state&limit=10&state_debug=true",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    ids = [result["id"] for result in data["results"]]
+    assert ids == [active_id]
+    assert data["state_filter"]["suppressed_count"] == 2
+    reasons = {item["reason"] for item in data["state_filter"]["suppressed"]}
+    assert reasons == {"expired", "not_yet_valid"}
+
+    response = client.get(
+        "/recall?tags=state&limit=10&current_only=false",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    ids = {result["id"] for result in data["results"]}
+    assert {active_id, expired_id, future_id}.issubset(ids)
+    assert "state_filter" not in data
+
+
+@pytest.mark.parametrize("relation_type", ["INVALIDATED_BY", "EVOLVED_INTO"])
+def test_recall_current_only_injects_active_replacement(
+    client, mock_state, auth_headers, relation_type
+):
+    mock_state.memory_graph.memories.clear()
+    mock_state.memory_graph.relationships.clear()
+    old_id = "cc000000-0000-0000-0000-000000000010"
+    replacement_id = "cc000000-0000-0000-0000-000000000011"
+
+    _store_memory(mock_state, old_id, "Legacy favorite editor was Vim", ["state"], 1.0)
+    _store_memory(
+        mock_state,
+        replacement_id,
+        "Current favorite editor is Zed",
+        ["replacement"],
+        0.1,
+    )
+    mock_state.memory_graph.relationships.append(
+        {"id1": old_id, "id2": replacement_id, "type": relation_type, "strength": 0.9}
+    )
+
+    response = client.get("/recall?limit=1&state_debug=true", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert [result["id"] for result in data["results"]] == [replacement_id]
+    assert data["results"][0]["match_type"] == "state_replacement"
+    assert data["state_filter"]["suppressed_count"] == 1
+    assert data["state_filter"]["replacement_count"] == 1
+    assert data["state_filter"]["suppressed"][0]["replacement_id"] == replacement_id
+
+
+def test_recall_current_only_does_not_suppress_contradictions(
+    client, mock_state, auth_headers
+):
+    mock_state.memory_graph.memories.clear()
+    mock_state.memory_graph.relationships.clear()
+    old_id = "cc000000-0000-0000-0000-000000000020"
+    conflicting_id = "cc000000-0000-0000-0000-000000000021"
+
+    _store_memory(mock_state, old_id, "Legacy plan used SQLite", ["state"], 1.0)
+    _store_memory(mock_state, conflicting_id, "Conflicting plan used Postgres", ["state"], 0.1)
+    mock_state.memory_graph.relationships.append(
+        {"id1": old_id, "id2": conflicting_id, "type": "CONTRADICTS", "strength": 0.9}
+    )
+
+    response = client.get("/recall?limit=1&state_debug=true", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert [result["id"] for result in data["results"]] == [old_id]
+    assert data["state_filter"]["suppressed_count"] == 0
+
+
+def test_recall_current_only_injects_replacement_for_expired_memory(
+    client, mock_state, auth_headers
+):
+    mock_state.memory_graph.memories.clear()
+    mock_state.memory_graph.relationships.clear()
+    now = datetime.now(timezone.utc)
+    old_id = "cc000000-0000-0000-0000-000000000025"
+    replacement_id = "cc000000-0000-0000-0000-000000000026"
+
+    _store_memory(
+        mock_state,
+        old_id,
+        "Expired favorite editor was Vim",
+        ["state"],
+        1.0,
+        t_invalid=(now - timedelta(days=1)).isoformat(),
+    )
+    _store_memory(mock_state, replacement_id, "Current favorite editor is Zed", ["state"], 0.1)
+    mock_state.memory_graph.relationships.append(
+        {"id1": old_id, "id2": replacement_id, "type": "INVALIDATED_BY", "strength": 0.9}
+    )
+
+    response = client.get("/recall?limit=1&state_debug=true", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert [result["id"] for result in data["results"]] == [replacement_id]
+    assert data["state_filter"]["suppressed"][0]["reason"] == "expired"
+    assert data["state_filter"]["replacements"][0]["replaces_id"] == old_id
+
+
+def test_recall_current_only_filters_vector_results(client, mock_state, auth_headers):
+    now = datetime.now(timezone.utc)
+
+    def custom_search(
+        collection_name: str,
+        query_vector: list[float],
+        limit: int = 5,
+        *,
+        with_payload: bool = True,
+        with_vectors: bool = False,
+        query_filter=None,
+    ) -> list[Any]:
+        _ = collection_name, query_vector, limit, with_payload, with_vectors, query_filter
+        return [
+            SimpleNamespace(
+                id="vec-active",
+                score=0.75,
+                payload={
+                    "id": "vec-active",
+                    "content": "Active vector state",
+                    "tags": ["state"],
+                    "importance": 0.5,
+                    "timestamp": utc_now(),
+                },
+            ),
+            SimpleNamespace(
+                id="vec-expired",
+                score=0.74,
+                payload={
+                    "id": "vec-expired",
+                    "content": "Expired vector state",
+                    "tags": ["state"],
+                    "importance": 0.5,
+                    "timestamp": utc_now(),
+                    "t_invalid": (now - timedelta(days=1)).isoformat(),
+                },
+            ),
+        ]
+
+    mock_state.qdrant.search = custom_search
+
+    response = client.get("/recall?query=state&limit=2", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert [result["id"] for result in data["results"]] == ["vec-active"]
+    assert data["state_filter"]["suppressed_count"] == 1
+
+    response = client.get(
+        "/recall?query=state&limit=2&current_only=false",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert {result["id"] for result in data["results"]} == {"vec-active", "vec-expired"}
+
+
+def test_recall_current_only_filters_tag_only_results(client, mock_state, auth_headers):
+    now = datetime.now(timezone.utc)
+    mock_state.memory_graph = None
+    mock_state.qdrant.points = {
+        "tag-active": {
+            "vector": [0.1] * 3,
+            "payload": {
+                "id": "tag-active",
+                "content": "Active tag state",
+                "tags": ["state"],
+                "importance": 0.5,
+                "timestamp": utc_now(),
+            },
+        },
+        "tag-expired": {
+            "vector": [0.1] * 3,
+            "payload": {
+                "id": "tag-expired",
+                "content": "Expired tag state",
+                "tags": ["state"],
+                "importance": 0.6,
+                "timestamp": utc_now(),
+                "t_invalid": (now - timedelta(days=1)).isoformat(),
+            },
+        },
+    }
+
+    response = client.get("/recall?tags=state&tag_match=exact&limit=10", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert [result["id"] for result in data["results"]] == ["tag-active"]
+    assert data["state_filter"]["suppressed_count"] == 1
+
+
+def test_recall_current_only_filters_relation_expansion(client, mock_state, auth_headers):
+    mock_state.memory_graph.memories.clear()
+    mock_state.memory_graph.relationships.clear()
+    now = datetime.now(timezone.utc)
+    seed_id = "cc000000-0000-0000-0000-000000000030"
+    expired_related_id = "cc000000-0000-0000-0000-000000000031"
+
+    _store_memory(mock_state, seed_id, "Seed state", ["state"], 0.9)
+    _store_memory(
+        mock_state,
+        expired_related_id,
+        "Expired related state",
+        ["related"],
+        0.8,
+        t_invalid=(now - timedelta(days=1)).isoformat(),
+    )
+    mock_state.memory_graph.relationships.append(
+        {"id1": seed_id, "id2": expired_related_id, "type": "RELATES_TO", "strength": 0.9}
+    )
+
+    response = client.get(
+        "/recall?tags=state&limit=1&expand_relations=true&relation_limit=5",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert [result["id"] for result in data["results"]] == [seed_id]
+    assert data["state_filter"]["suppressed_count"] == 1
 
 
 def test_recall_prioritizes_style_context(client, mock_state, auth_headers):
@@ -798,6 +1065,49 @@ def test_update_memory_success(client, mock_state, auth_headers):
     data = response.get_json()
     assert data["status"] == "success"
     assert data["memory_id"] == memory_id
+
+
+def test_update_memory_preserves_temporal_validity_in_graph_and_qdrant(
+    client, mock_state, auth_headers
+):
+    memory_id = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeef"
+    original_valid = "2026-01-01T00:00:00+00:00"
+    original_invalid = "2026-06-01T00:00:00+00:00"
+    mock_state.memory_graph.memories[memory_id] = {
+        "id": memory_id,
+        "content": "Temporal memory",
+        "tags": ["test"],
+        "importance": 0.5,
+        "timestamp": "2026-01-01T00:00:00+00:00",
+        "metadata": "{}",
+        "t_valid": original_valid,
+        "t_invalid": original_invalid,
+    }
+    mock_state.qdrant.points[memory_id] = {
+        "vector": [0.1] * 768,
+        "payload": {
+            "content": "Temporal memory",
+            "tags": ["test"],
+            "importance": 0.5,
+            "timestamp": "2026-01-01T00:00:00+00:00",
+            "t_valid": original_valid,
+            "t_invalid": original_invalid,
+        },
+    }
+
+    response = client.patch(
+        f"/memory/{memory_id}",
+        json={"content": "Temporal memory updated"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    memory = mock_state.memory_graph.memories[memory_id]
+    assert memory["t_valid"] == original_valid
+    assert memory["t_invalid"] == original_invalid
+    payload = mock_state.qdrant.points[memory_id]["payload"]
+    assert payload["t_valid"] == original_valid
+    assert payload["t_invalid"] == original_invalid
 
 
 @pytest.mark.usefixtures("mock_state")

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -575,6 +575,34 @@ def test_recall_current_only_filters_temporal_state(client, mock_state, auth_hea
     assert "state_filter" not in data
 
 
+def test_recall_current_only_filters_archived_state(client, mock_state, auth_headers):
+    mock_state.memory_graph.memories.clear()
+    active_id = "cc000000-0000-0000-0000-000000000004"
+    archived_id = "cc000000-0000-0000-0000-000000000005"
+
+    _store_memory(mock_state, active_id, "Active retained state", ["state"], 0.9)
+    _store_memory(
+        mock_state,
+        archived_id,
+        "Archived stale state",
+        ["state"],
+        0.95,
+        archived=True,
+    )
+
+    response = client.get(
+        "/recall?tags=state&limit=10&state_debug=true",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert [result["id"] for result in data["results"]] == [active_id]
+    assert data["state_filter"]["suppressed_count"] == 1
+    assert data["state_filter"]["suppressed"][0]["id"] == archived_id
+    assert data["state_filter"]["suppressed"][0]["reason"] == "archived"
+
+
 @pytest.mark.parametrize("relation_type", ["INVALIDATED_BY", "EVOLVED_INTO"])
 def test_recall_current_only_injects_active_replacement(
     client, mock_state, auth_headers, relation_type
@@ -605,6 +633,51 @@ def test_recall_current_only_injects_active_replacement(
     assert data["state_filter"]["suppressed_count"] == 1
     assert data["state_filter"]["replacement_count"] == 1
     assert data["state_filter"]["suppressed"][0]["replacement_id"] == replacement_id
+
+
+def test_recall_current_only_batch_loads_relation_replacements(
+    client, mock_state, auth_headers
+):
+    mock_state.memory_graph.memories.clear()
+    mock_state.memory_graph.relationships.clear()
+
+    old_ids = [
+        "cc000000-0000-0000-0000-000000000016",
+        "cc000000-0000-0000-0000-000000000017",
+        "cc000000-0000-0000-0000-000000000018",
+    ]
+    replacement_ids = [
+        "cc000000-0000-0000-0000-000000000116",
+        "cc000000-0000-0000-0000-000000000117",
+        "cc000000-0000-0000-0000-000000000118",
+    ]
+    for idx, (old_id, replacement_id) in enumerate(zip(old_ids, replacement_ids)):
+        _store_memory(mock_state, old_id, f"Legacy state {idx}", ["state"], 1.0 - idx / 10)
+        _store_memory(mock_state, replacement_id, f"Current state {idx}", ["state"], 0.1)
+        mock_state.memory_graph.relationships.append(
+            {
+                "id1": old_id,
+                "id2": replacement_id,
+                "type": "INVALIDATED_BY",
+                "strength": 0.9,
+            }
+        )
+
+    response = client.get(
+        "/recall?tags=state&limit=3&state_debug=true",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert [result["id"] for result in data["results"]] == replacement_ids
+    assert data["state_filter"]["suppressed_count"] == 3
+    replacement_queries = [
+        query
+        for query, params in mock_state.memory_graph.queries
+        if "RETURN source_id" in query and set(params.get("ids") or []) == set(old_ids)
+    ]
+    assert len(replacement_queries) == 1
 
 
 def test_recall_current_only_replacement_respects_tag_filter(

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -680,6 +680,32 @@ def test_recall_current_only_batch_loads_relation_replacements(
     assert len(replacement_queries) == 1
 
 
+def test_recall_current_only_keeps_replacement_score_order(
+    client, mock_state, auth_headers
+):
+    mock_state.memory_graph.memories.clear()
+    mock_state.memory_graph.relationships.clear()
+    old_id = "cc000000-0000-0000-0000-000000000019"
+    active_id = "cc000000-0000-0000-0000-000000000119"
+    replacement_id = "cc000000-0000-0000-0000-000000000219"
+
+    _store_memory(mock_state, old_id, "Highest scoring legacy state", ["state"], 1.0)
+    _store_memory(mock_state, active_id, "Lower scoring active state", ["state"], 0.9)
+    _store_memory(mock_state, replacement_id, "Current replacement state", ["state"], 0.1)
+    mock_state.memory_graph.relationships.append(
+        {"id1": old_id, "id2": replacement_id, "type": "INVALIDATED_BY", "strength": 0.9}
+    )
+
+    response = client.get(
+        "/recall?tags=state&limit=2&state_debug=true",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert [result["id"] for result in data["results"]] == [replacement_id, active_id]
+
+
 def test_recall_current_only_replacement_respects_tag_filter(
     client, mock_state, auth_headers
 ):

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -607,6 +607,67 @@ def test_recall_current_only_injects_active_replacement(
     assert data["state_filter"]["suppressed"][0]["replacement_id"] == replacement_id
 
 
+def test_recall_current_only_replacement_respects_tag_filter(
+    client, mock_state, auth_headers
+):
+    mock_state.memory_graph.memories.clear()
+    mock_state.memory_graph.relationships.clear()
+    old_id = "cc000000-0000-0000-0000-000000000012"
+    replacement_id = "cc000000-0000-0000-0000-000000000013"
+
+    _store_memory(mock_state, old_id, "Legacy gated billing plan was Basic", ["gated-old"], 1.0)
+    _store_memory(
+        mock_state,
+        replacement_id,
+        "Current gated billing plan is Pro",
+        ["gated-current"],
+        0.1,
+    )
+    mock_state.memory_graph.relationships.append(
+        {"id1": old_id, "id2": replacement_id, "type": "INVALIDATED_BY", "strength": 0.9}
+    )
+
+    response = client.get(
+        "/recall?tags=gated-old&tag_match=exact&limit=1&state_debug=true",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["results"] == []
+    assert data["state_filter"]["suppressed_count"] == 1
+    assert data["state_filter"]["replacement_count"] == 0
+    assert data["state_filter"]["suppressed"][0]["id"] == old_id
+    assert data["state_filter"]["suppressed"][0]["replacement_id"] == replacement_id
+    assert data["state_filter"]["replacements"] == []
+
+
+@pytest.mark.parametrize("relation_type", ["INVALIDATED_BY", "EVOLVED_INTO"])
+def test_recall_current_only_false_keeps_relation_history(
+    client, mock_state, auth_headers, relation_type
+):
+    mock_state.memory_graph.memories.clear()
+    mock_state.memory_graph.relationships.clear()
+    old_id = "cc000000-0000-0000-0000-000000000014"
+    replacement_id = "cc000000-0000-0000-0000-000000000015"
+
+    _store_memory(mock_state, old_id, "Historical tracker was Jira", ["state"], 1.0)
+    _store_memory(mock_state, replacement_id, "Current tracker is Linear", ["state"], 0.9)
+    mock_state.memory_graph.relationships.append(
+        {"id1": old_id, "id2": replacement_id, "type": relation_type, "strength": 0.9}
+    )
+
+    response = client.get(
+        "/recall?tags=state&limit=2&current_only=false&state_debug=true",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert [result["id"] for result in data["results"]] == [old_id, replacement_id]
+    assert "state_filter" not in data
+
+
 def test_recall_current_only_does_not_suppress_contradictions(
     client, mock_state, auth_headers
 ):
@@ -621,11 +682,11 @@ def test_recall_current_only_does_not_suppress_contradictions(
         {"id1": old_id, "id2": conflicting_id, "type": "CONTRADICTS", "strength": 0.9}
     )
 
-    response = client.get("/recall?limit=1&state_debug=true", headers=auth_headers)
+    response = client.get("/recall?limit=2&state_debug=true", headers=auth_headers)
 
     assert response.status_code == 200
     data = response.get_json()
-    assert [result["id"] for result in data["results"]] == [old_id]
+    assert [result["id"] for result in data["results"]] == [old_id, conflicting_id]
     assert data["state_filter"]["suppressed_count"] == 0
 
 


### PR DESCRIPTION
Summary
- Adds current_only and state_debug recall params, with current_only enabled by default.
- Suppresses archived, future-valid, expired, invalidated, and superseded memories from active recall results.
- Injects active replacements from INVALIDATED_BY or EVOLVED_INTO relations when replacements pass caller filters.
- Preserves t_valid and t_invalid through PATCH /memory/<id> and Qdrant payload sync.

Tests
- .venv/bin/pytest tests/ --ignore=tests/benchmarks

Related issues
Closes #169
Updates #158
Updates #159