### PR TITLE
feat(recall): add state_mode=current|history recall alias

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Makefile - Development commands
-.PHONY: help install dev stop test fmt lint test-integration test-live test-locomo test-locomo-live test-longmemeval test-longmemeval-live test-longmemeval-watch clean logs deploy deploy-check bench-health
+.PHONY: help install dev stop test fmt lint test-integration test-live test-locomo test-locomo-live test-longmemeval test-longmemeval-live test-longmemeval-watch clean logs deploy deploy-check bench-current-state bench-health
 
 VENV_DIR := $(if $(wildcard .venv/bin/python),.venv,venv)
 VENV_BIN := $(VENV_DIR)/bin
@@ -29,6 +29,7 @@ help:
 	@echo "  make bench-ingest BENCH=locomo - Ingest + snapshot (run once)"
 	@echo "  make bench-eval BENCH=locomo CONFIG=baseline - Eval from snapshot (~2 min)"
 	@echo "  make bench-compare BENCH=locomo CONFIG=bm25 BASELINE=baseline - A/B compare"
+	@echo "  make bench-current-state    - No-LLM current-state recall smoke"
 	@echo "  make bench-health             - Recall health check (score dist, entities, latency)"
 	@echo "  make test-locomo          - Full LoCoMo benchmark (local)"
 	@echo "  make test-locomo-live     - Full LoCoMo benchmark (Railway)"
@@ -159,6 +160,9 @@ bench-compare:
 
 bench-compare-branch:
 	@scripts/bench/compare_branch.sh $(BRANCH) $(or $(CONFIG),baseline) $(or $(BENCH),locomo)
+
+bench-current-state:
+	@PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 $(VENV_BIN)/pytest tests/test_api_endpoints.py -k 'recall_state_mode or recall_current_only' -q
 
 bench-health:
 	@$(or $(VENV_BIN),.venv/bin)/python scripts/bench/health_check.py --base-url $(or $(BASE_URL),http://localhost:8001)

--- a/automem/api/recall.py
+++ b/automem/api/recall.py
@@ -1500,7 +1500,20 @@ def handle_recall(
         request.args.get("expand_respect_tags"),
         False,
     )
-    current_only = _parse_bool_param(request.args.get("current_only"), True)
+    state_mode_param = (request.args.get("state_mode") or "").strip().lower()
+    if state_mode_param and state_mode_param not in {"current", "history"}:
+        abort(400, description="'state_mode' must be 'current' or 'history'")
+
+    current_only_param = request.args.get("current_only")
+    if current_only_param is not None:
+        current_only = _parse_bool_param(current_only_param, True)
+        resolved_state_mode = "current" if current_only else "history"
+    elif state_mode_param:
+        resolved_state_mode = state_mode_param
+        current_only = resolved_state_mode == "current"
+    else:
+        current_only = True
+        resolved_state_mode = "current"
     state_debug = _parse_bool_param(request.args.get("state_debug"), False)
 
     # Entity expansion for multi-hop reasoning
@@ -1941,6 +1954,7 @@ def handle_recall(
         "count": len(results),
         "dedup_removed": dedup_removed,
         "sort": sort_param,
+        "state_mode": resolved_state_mode,
         "vector_search": {
             "enabled": qdrant_client is not None,
             "matched": bool(total_vector_matches),

--- a/benchmarks/EXPERIMENT_LOG.md
+++ b/benchmarks/EXPERIMENT_LOG.md
@@ -10,6 +10,7 @@ on the snapshot-based bench infrastructure (PR #97, merged 2026-03-02).
 | Tier | Benchmark | Runtime | Cost | When to use |
 |------|-----------|---------|------|-------------|
 | 0 | `make test` (unit) | 30s | free | Every change |
+| 0 | `make bench-current-state` (state-aware recall smoke) | <30s | free | Recall state contract changes |
 | 1 | `locomo-mini` (2 convos, 304 Qs) | 2-3 min | free / ~$0.20 with judge | Rapid iteration |
 | 2 | `locomo` (10 convos, 1986 Qs) | 5-10 min | free / ~$1-3 with judge | Before merge |
 | 3 | `longmemeval-mini` (stratified 30 Qs) | 15 min | ~$1 | Scoring/entity changes |

--- a/docs/API.md
+++ b/docs/API.md
@@ -53,6 +53,12 @@ Recall
     - `score` (default) - hybrid relevance/importance ranking
     - `time_desc` / `time_asc` - chronological ordering by `updated_at`/`timestamp` within the filter window (use for "what happened since X")
     - `updated_desc` / `updated_asc` - explicit alias (same ordering key as time\_\*)
+  - **State filtering**:
+    - `state_mode=current|history` controls whether recall returns only currently valid state or full state history. Default: `current`.
+    - `current` is equivalent to `current_only=true`: suppresses memories that are expired, not yet valid, archived, or invalidated/evolved by active replacements.
+    - `history` is equivalent to `current_only=false`: returns stale and future state when it matches the query/filter.
+    - `current_only` remains supported for backward compatibility and wins over `state_mode` when both resolve to a value. A malformed `state_mode` is still rejected with `400` even when `current_only` is supplied — the value is validated before precedence is applied.
+    - `state_debug=true` includes suppression/replacement details in `state_filter`.
   - **Context hints**: `context`, `language`, `active_path`, `context_tags`, `context_types`, `priority_ids`
   - **Graph expansion**:
     - `expand_relations` - Follow graph edges from seed results to related memories
@@ -62,8 +68,9 @@ Recall
   - **Expansion filtering** (reduce noise in expanded results):
     - `expand_min_importance` - Minimum importance (0-1) for expanded memories. Seed results are never filtered, only expanded ones. Recommended: 0.3-0.5 for broad context, 0.6+ for focused results.
     - `expand_min_strength` - Minimum relation strength (0-1) to traverse during graph expansion. Only edges above this threshold are followed. Recommended: 0.3 for exploratory, 0.6+ for high-confidence connections.
-  - Response: `{ "status": "success", "results": [...], "count": M, "context_priority": {...} }`
+  - Response: `{ "status": "success", "results": [...], "count": M, "state_mode": "current", "context_priority": {...} }`
   - Echoed filters (for debugging): `tags`, `exclude_tags`, `tag_mode`, `tag_match`
+  - Echoed state: `state_mode` always reflects the resolved mode after `current_only` precedence. When current-state filtering runs, `state_filter` may include suppressed and replacement IDs, including `INVALIDATED_BY`, `EVOLVED_INTO`, and `CONTRADICTS` handling details when `state_debug=true`.
   - When `expand_entities=true`: includes `entity_expansion: { enabled, expanded_count, entities_found }`
   - When `expand_relations=true`: includes `expansion: { enabled, seed_count, expanded_count, relation_limit }`
 
@@ -85,6 +92,16 @@ GET /recall?tags=user_1&exclude_tags=conversation_5,conversation_6&limit=5
 
 # Exclude temporary/draft memories
 GET /recall?query=project%20plan&exclude_tags=temp,draft&limit=10
+```
+
+**Current-State Recall Examples:**
+
+```bash
+# Default: return active/current state only
+GET /recall?query=current%20project%20plan
+
+# Historical audit: include expired, future, invalidated, and evolved facts
+GET /recall?query=project%20plan&state_mode=history
 ```
 
 - GET `/memories/{id}/related`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -319,6 +319,17 @@ See `benchmarks/EXPERIMENT_LOG.md` for the full per-category table. If you run w
 
 Current baselines and methodology notes live in `benchmarks/EXPERIMENT_LOG.md`.
 
+## Current-State Recall Smoke
+
+Use `make bench-current-state` as the no-LLM regression gate for recall state
+semantics. It covers active, expired, future, archived, invalidated, evolved,
+contradictory, replacement, and tag-gated replacement cases, plus the public
+`state_mode=current|history` contract.
+
+The smoke target is deterministic and runs against unit fixtures, so it is
+appropriate for every recall contract change. Use LongMemEval or LoCoMo only
+when the change affects ranking, scoring, entity expansion, or answer quality.
+
 ## LongMemEval Benchmark
 
 AutoMem also includes a LongMemEval harness for milestone validation against the ICLR 2025 long-term memory dataset. Treat prefix slices as smoke tests only; cite the canonical full run or the stratified representative mini for current results.

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -575,6 +575,128 @@ def test_recall_current_only_filters_temporal_state(client, mock_state, auth_hea
     assert "state_filter" not in data
 
 
+def test_recall_state_mode_defaults_to_current_and_echoes_mode(
+    client, mock_state, auth_headers
+):
+    mock_state.memory_graph.memories.clear()
+    now = datetime.now(timezone.utc)
+    active_id = "cc000000-0000-0000-0000-000000000032"
+    expired_id = "cc000000-0000-0000-0000-000000000033"
+
+    _store_memory(mock_state, active_id, "Active state mode current", ["state"], 0.9)
+    _store_memory(
+        mock_state,
+        expired_id,
+        "Expired state mode current",
+        ["state"],
+        0.95,
+        t_invalid=(now - timedelta(days=1)).isoformat(),
+    )
+
+    response = client.get("/recall?tags=state&limit=10", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["state_mode"] == "current"
+    assert [result["id"] for result in data["results"]] == [active_id]
+    assert data["state_filter"]["suppressed_count"] == 1
+
+
+def test_recall_state_mode_history_preserves_state_history(
+    client, mock_state, auth_headers
+):
+    mock_state.memory_graph.memories.clear()
+    now = datetime.now(timezone.utc)
+    active_id = "cc000000-0000-0000-0000-000000000034"
+    expired_id = "cc000000-0000-0000-0000-000000000035"
+    future_id = "cc000000-0000-0000-0000-000000000036"
+
+    _store_memory(mock_state, active_id, "Active state mode history", ["state"], 0.9)
+    _store_memory(
+        mock_state,
+        expired_id,
+        "Expired state mode history",
+        ["state"],
+        0.95,
+        t_invalid=(now - timedelta(days=1)).isoformat(),
+    )
+    _store_memory(
+        mock_state,
+        future_id,
+        "Future state mode history",
+        ["state"],
+        0.98,
+        t_valid=(now + timedelta(days=1)).isoformat(),
+    )
+
+    response = client.get(
+        "/recall?tags=state&limit=10&state_mode=history&state_debug=true",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["state_mode"] == "history"
+    ids = {result["id"] for result in data["results"]}
+    assert {active_id, expired_id, future_id}.issubset(ids)
+    assert "state_filter" not in data
+
+
+@pytest.mark.parametrize(
+    ("state_mode", "current_only", "expected_mode", "expects_current"),
+    [
+        ("history", "true", "current", True),
+        ("current", "false", "history", False),
+    ],
+)
+def test_recall_current_only_takes_precedence_over_state_mode(
+    client,
+    mock_state,
+    auth_headers,
+    state_mode,
+    current_only,
+    expected_mode,
+    expects_current,
+):
+    mock_state.memory_graph.memories.clear()
+    now = datetime.now(timezone.utc)
+    active_id = "cc000000-0000-0000-0000-000000000037"
+    expired_id = "cc000000-0000-0000-0000-000000000038"
+
+    _store_memory(mock_state, active_id, "Active precedence state", ["state"], 0.9)
+    _store_memory(
+        mock_state,
+        expired_id,
+        "Expired precedence state",
+        ["state"],
+        0.95,
+        t_invalid=(now - timedelta(days=1)).isoformat(),
+    )
+
+    response = client.get(
+        f"/recall?tags=state&limit=10&state_mode={state_mode}&current_only={current_only}",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["state_mode"] == expected_mode
+    ids = {result["id"] for result in data["results"]}
+    if expects_current:
+        assert ids == {active_id}
+        assert data["state_filter"]["suppressed_count"] == 1
+    else:
+        assert {active_id, expired_id}.issubset(ids)
+        assert "state_filter" not in data
+
+
+def test_recall_state_mode_rejects_unknown_value(client, auth_headers):
+    response = client.get("/recall?state_mode=latest", headers=auth_headers)
+
+    assert response.status_code == 400
+    assert "state_mode" in response.get_data(as_text=True)
+
+
 def test_recall_current_only_filters_archived_state(client, mock_state, auth_headers):
     mock_state.memory_graph.memories.clear()
     active_id = "cc000000-0000-0000-0000-000000000004"

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -575,9 +575,7 @@ def test_recall_current_only_filters_temporal_state(client, mock_state, auth_hea
     assert "state_filter" not in data
 
 
-def test_recall_state_mode_defaults_to_current_and_echoes_mode(
-    client, mock_state, auth_headers
-):
+def test_recall_state_mode_defaults_to_current_and_echoes_mode(client, mock_state, auth_headers):
     mock_state.memory_graph.memories.clear()
     now = datetime.now(timezone.utc)
     active_id = "cc000000-0000-0000-0000-000000000032"
@@ -602,9 +600,7 @@ def test_recall_state_mode_defaults_to_current_and_echoes_mode(
     assert data["state_filter"]["suppressed_count"] == 1
 
 
-def test_recall_state_mode_history_preserves_state_history(
-    client, mock_state, auth_headers
-):
+def test_recall_state_mode_history_preserves_state_history(client, mock_state, auth_headers):
     mock_state.memory_graph.memories.clear()
     now = datetime.now(timezone.utc)
     active_id = "cc000000-0000-0000-0000-000000000034"

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -3,7 +3,6 @@
 import subprocess
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -1,0 +1,26 @@
+"""Tests for developer-facing Makefile benchmark targets."""
+
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_bench_current_state_target_is_no_llm_pytest_gate() -> None:
+    result = subprocess.run(
+        ["make", "-n", "bench-current-state"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    output = result.stdout
+    assert "pytest" in output
+    assert "tests/test_api_endpoints.py" in output
+    assert "recall_state_mode" in output
+    assert "recall_current_only" in output
+    assert "--llm-eval" not in output
+    assert "OPENAI_API_KEY" not in output


### PR DESCRIPTION
## Summary
Adds a public `state_mode=current|history` recall query param as a semantic alias over the boolean `current_only` (#170).

- Resolution order: explicit `current_only` wins → else `state_mode` → else default `current`.
- Unknown `state_mode` values return `400`, validated *before* precedence is applied.
- The resolved mode is echoed in the response (`"state_mode": ...`), always present in both modes.
- `state_mode` is a **pure presentation alias** — the downstream current-state filter still reads only the boolean, so there is **no behavior change** to filtering and the param is fully backward compatible.

## Tooling
- New Tier-0 no-LLM smoke gate: `make bench-current-state` (`pytest -k 'recall_state_mode or recall_current_only'`).
- `tests/test_makefile_targets.py` locks that target as a deterministic, no-LLM pytest gate.

## Tests
- `pytest tests/test_api_endpoints.py tests/test_makefile_targets.py` → 104 passed / 1 skipped
- `make bench-current-state` → 19 passed

## Follow-up
- MCP exposure tracked in #172 (the MCP `recall_memory` tool doesn't surface `state_mode` yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)