### PR TITLE
docs(evals): mark Memora/FAMA/WRIT lifecycle diagnostics as diagnostic-only

### DIFF
--- a/benchmarks/EXPERIMENT_LOG.md
+++ b/benchmarks/EXPERIMENT_LOG.md
@@ -103,6 +103,9 @@ follow-up issues #158 and #159.
 These results are useful validation signals, but they are not current headline
 claims. BEAM entries came from `automem-evals` exploratory runners. LongMemEval
 prefix entries are legacy/provisional because dataset prefixes are biased.
+Memora/FAMA and WRIT lifecycle diagnostics are also exploratory unless their
+scenario, harness, and artifacts are promoted through this repo's official
+benchmark policy.
 
 | Date | Benchmark | Scope | Score | Retrieval | Notes |
 |------|-----------|-------|-------|-----------|-------|

--- a/benchmarks/EXPERIMENT_LOG.md
+++ b/benchmarks/EXPERIMENT_LOG.md
@@ -103,7 +103,7 @@ follow-up issues #158 and #159.
 These results are useful validation signals, but they are not current headline
 claims. BEAM entries came from `automem-evals` exploratory runners. LongMemEval
 prefix entries are legacy/provisional because dataset prefixes are biased.
-Memora/FAMA and WRIT lifecycle diagnostics are also exploratory unless their
+Memora/FAMA and WRIT lifecycle diagnostics are diagnostic signals unless their
 scenario, harness, and artifacts are promoted through this repo's official
 benchmark policy.
 

--- a/docs/EVALS_CONTRACT.md
+++ b/docs/EVALS_CONTRACT.md
@@ -37,4 +37,5 @@ If an eval needs behavior outside those endpoints, document the dependency clear
 - Treat AutoMem as a black-box server under test.
 - Do not make published benchmark claims from experimental harnesses unless the result is also reproduced through the official `automem` benchmark flow.
 - If an experiment needs LoCoMo or LongMemEval, call the official harness here or label any adapter as experimental rather than canonical.
+- Treat Memora/FAMA, WRIT, and similar lifecycle diagnostics from `automem-evals` as diagnostic signals until their scenario, harness, and artifacts are promoted into this repo's benchmark policy.
 - Do not make `automem` depend on uncommitted files from an external eval repo.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -371,6 +371,10 @@ Use the separate `automem-evals` repo for:
 - cross-agent or cross-backend comparisons
 - bulky timestamped result artifacts and exploratory writeups
 
+Memora/FAMA and WRIT runs remain diagnostic unless their scenario, harness,
+and result artifacts are promoted into this repo's official benchmark flow and
+recorded in `benchmarks/EXPERIMENT_LOG.md`.
+
 If you are building an external eval harness against local AutoMem, use the contract in [`EVALS_CONTRACT.md`](EVALS_CONTRACT.md) and treat this repo as the system under test.
 
 ### AutoMem's Advantages


### PR DESCRIPTION
## Summary
Documentation-only hygiene. Clarifies across `EVALS_CONTRACT.md`, `TESTING.md`, and `EXPERIMENT_LOG.md` that Memora/FAMA and WRIT lifecycle diagnostics from `automem-evals` remain **diagnostic signals** until their scenario, harness, and result artifacts are promoted into this repo's official benchmark policy.

Keeps benchmark-claim ownership in `automem`, consistent with the existing Benchmark Ownership policy.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)