### PR TITLE
fix(backup): make backup_automem.py runnable as `python scripts/backup_automem.py`

### DIFF
--- a/scripts/backup_automem.py
+++ b/scripts/backup_automem.py
@@ -28,6 +28,13 @@ from dotenv import load_dotenv
 from falkordb import FalkorDB
 from qdrant_client import QdrantClient
 
+# Make the repo root importable when invoked as `python scripts/backup_automem.py`:
+# Python puts the script's own dir (scripts/) on sys.path[0], not the repo root,
+# so the `automem` package one level up would otherwise be unimportable.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 from automem.backup import (
     cleanup_old_backup_files,
     write_falkordb_backup_file,


### PR DESCRIPTION
## Summary

`scripts/backup_automem.py` can no longer be run as a script — `python scripts/backup_automem.py` crashes immediately on import:

```
Traceback (most recent call last):
  File ".../scripts/backup_automem.py", line 31, in <module>
    from automem.backup import (
ModuleNotFoundError: No module named 'automem'
```

## Root cause

#162 (`8b1f2649`) moved the backup helpers into the `automem.backup` package, and the script now does `from automem.backup import ...`. But when a file is run as `python scripts/backup_automem.py`, Python puts the **script's own directory** (`scripts/`) on `sys.path[0]` — not the repo root — so the `automem` package one level up isn't importable. Nothing installs the package either (`requirements.txt` has no `-e .`).

## Impact

The scheduled **AutoMem Backup** workflow (`.github/workflows/backup.yml`) runs exactly this command and has been **failing on every run since the refactor landed (2026-06-06)** — no automated FalkorDB/Qdrant backup has succeeded for ~2 days. The failure is identical across all runs (`ModuleNotFoundError: No module named 'automem'`).

## Fix

Prepend the repo root to `sys.path` before the package import, using the **same idiom already in `scripts/backfill_tag_prefixes.py`**:

```python
PROJECT_ROOT = Path(__file__).resolve().parents[1]
if str(PROJECT_ROOT) not in sys.path:
    sys.path.insert(0, str(PROJECT_ROOT))
```

This fixes the documented usage (`python scripts/backup_automem.py`), the CI workflow, Railway cron, and manual/local runs in one place — no workflow change required.

## Verification

- `python -m py_compile scripts/backup_automem.py` ✅
- `PROJECT_ROOT` resolves to the repo root containing `automem/__init__.py` and `automem/backup.py` ✅
- `black --check` and `isort --check-only --profile black` both pass ✅ (and E402 is not in `.flake8`'s `select` set)
- The equivalent fix (adding the repo root to the import path) was applied to a downstream wrapper of this workflow and a manual run completed end-to-end: `✅ Backup completed successfully` → `"s3_uploaded": true`.
