### PR TITLE
fix(entity): restore person-shape exemption on the slug validation path

### DIFF
--- a/automem/utils/entity_quality.py
+++ b/automem/utils/entity_quality.py
@@ -208,6 +208,7 @@ _NON_PERSON_TECH_TOKENS = {
     "cli",
     "cloud",
     "compose",
+    "data",
     "db",
     "docker",
     "hub",
@@ -467,8 +468,12 @@ def _looks_tool_or_org_like(value: str, slug: str, context: Optional[str]) -> bo
 
     # Context hints are too weak to condemn a multi-token person-shaped name:
     # in a technical corpus nearly every memory mentions data/projects/tools,
-    # which would reject virtually every real person discussed at work.
-    if " " in (value or "").strip() and len(parts) >= 2 and _has_person_name_shape(parts):
+    # which would reject virtually every real person discussed at work. This
+    # must hold for slug-only inputs too (validate_entity_tag has no display
+    # value), or stored entity:people tags get re-rejected during repair.
+    # Brand-like pairs such as data-dog are handled by the per-token
+    # vocabulary checks in validate_entity_slug, not by context hints.
+    if len(parts) >= 2 and _has_person_name_shape(parts):
         return False
 
     lowered_context = (context or "").lower()

--- a/tests/test_entity_quality.py
+++ b/tests/test_entity_quality.py
@@ -299,3 +299,34 @@ def test_common_word_pairs_are_not_people(slug: str) -> None:
 
     assert result.accepted is False
     assert result.reason == "low_signal_people_slug"
+
+
+@pytest.mark.parametrize("slug", ["mara-quinn", "tobias-lehman"])
+def test_people_tags_survive_technical_context_on_slug_path(slug: str) -> None:
+    """Stored tags only retain the slug — no spaced display value exists.
+
+    validate_entity_tag(context=...) is the repair-script path; the
+    person-shape exemption must apply to slug-only inputs or every real
+    person mentioned alongside data/projects/tooling gets re-rejected.
+    """
+    from automem.utils.entity_quality import validate_entity_tag
+
+    context = (
+        "Met about the data pipeline project; the platform tooling and "
+        "database service migration are on track."
+    )
+    result = validate_entity_tag(f"entity:people:{slug}", context=context)
+
+    assert result.accepted is True
+
+
+def test_brandlike_token_pairs_rejected_on_slug_path_without_context() -> None:
+    """Tool brands that slug into person-shaped pairs (data-dog) must be
+    caught by token vocabulary, not context hints, so the rejection also
+    fires on the tag path."""
+    from automem.utils.entity_quality import validate_entity_tag
+
+    result = validate_entity_tag("entity:people:data-dog")
+
+    assert result.accepted is False
+    assert result.reason == "low_signal_people_slug"

--- a/tests/test_entity_quality.py
+++ b/tests/test_entity_quality.py
@@ -311,8 +311,9 @@ def test_people_tags_survive_technical_context_on_slug_path(slug: str) -> None:
     """
     from automem.utils.entity_quality import validate_entity_tag
 
+    display = slug.replace("-", " ").title()
     context = (
-        "Met about the data pipeline project; the platform tooling and "
+        f"Met with {display} about the data pipeline project; the platform tooling and "
         "database service migration are on track."
     )
     result = validate_entity_tag(f"entity:people:{slug}", context=context)


### PR DESCRIPTION
## Why

PR #178's applied review suggestion (commit e6876b0f, "Potential fix for pull request finding") gated the person-shape exemption on the display value containing a space:

```python
if " " in (value or "").strip() and len(parts) >= 2 and _has_person_name_shape(parts):
```

Stored entity tags only retain the slug (`entity:people:jack-arturo`), so `validate_entity_tag(context=...)` — the path `scripts/lab/repair_entity_tags.py` uses — never satisfies the guard, and the context-hint branch re-rejects every real person mentioned alongside data/projects/tooling.

**Empirical impact (prod dry-run, read-only):** 7,494 planned rejections with the guard vs ~6,106 expected with the exemption — ~1,390 legitimate person tags (jack-arturo ×51, zack-katz ×27, jason-coleman ×25, katie-keith ×14, ...) wrongly planned for removal. CI stayed green because every existing test exercised the spaced-value path (`validate_entity_value("people", "Mara Quinn", ...)`), never the slug path with context.

## What

- Restore the plain person-shape exemption (no space guard) in `_looks_tool_or_org_like`.
- Address the original Copilot concern (`entity:people:data-dog`) deterministically: add `"data"` to `_NON_PERSON_TECH_TOKENS`, so brand-like person-shaped pairs are rejected by the per-token vocabulary check on **every** path (with or without context) — strictly stronger than the context-hint rejection the guard tried to preserve.
- Regression tests for the slug path: real-person tags survive technical context via `validate_entity_tag`; `data-dog` is rejected with `low_signal_people_slug` without needing context.

## Verification

- `pytest tests/`: 490 passed, 12 skipped
- Spot checks: `jack-arturo`/`zack-katz`/`jason-coleman`/`katie-keith` accepted with technical context on the tag path; `data-dog`, `growthmath`, `claude-code`-as-people still rejected

Part of the issue #72 production repair rollout (follow-up to #178).

🤖 Generated with [Claude Code](https://claude.com/claude-code)