### PR TITLE
feat(recall): make recency decay window and curve configurable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,7 +268,7 @@ SEARCH_WEIGHT_RELATION=0.25        # Graph relationship boost
 SEARCH_WEIGHT_TAG=0.20             # Tag overlap scoring
 SEARCH_WEIGHT_EXACT=0.20           # Exact phrase in metadata
 SEARCH_WEIGHT_IMPORTANCE=0.10      # Memory importance score
-SEARCH_WEIGHT_RECENCY=0.10         # Linear decay over 180 days
+SEARCH_WEIGHT_RECENCY=0.10         # Decay per SEARCH_RECENCY_* (default: linear over 180 days)
 SEARCH_WEIGHT_CONFIDENCE=0.05      # Memory confidence score
 SEARCH_WEIGHT_RELEVANCE=0.0        # Consolidation decay relevance (disabled by default)
 
@@ -382,7 +382,7 @@ Shows: total count, date range, archived count, memories by month (bar chart), t
 python scripts/browse_memories.py diagnose 2751e70e
 ```
 
-Checks: FalkorDB existence, archived status, Qdrant presence + embedding quality, recency score (180-day decay), simulated relevance score breakdown (decay factor, access factor, relationship factor, importance floor), and current search weight config. Reports issues at `[CRITICAL]`, `[WARNING]`, and `[INFO]` severity levels.
+Checks: FalkorDB existence, archived status, Qdrant presence + embedding quality, recency score (configurable decay, default 180-day), simulated relevance score breakdown (decay factor, access factor, relationship factor, importance floor), and current search weight config. Reports issues at `[CRITICAL]`, `[WARNING]`, and `[INFO]` severity levels.
 ### Recall Quality Lab (`scripts/lab/`)
 - **clone_production.sh** - Clone production FalkorDB + Qdrant data to local Docker for safe testing
 - **create_test_queries.py** - Generate test queries with expected results from local data

--- a/automem/config.py
+++ b/automem/config.py
@@ -463,6 +463,12 @@ SEARCH_WEIGHT_EXACT = float(os.getenv("SEARCH_WEIGHT_EXACT", "0.2"))
 SEARCH_WEIGHT_RELATION = float(os.getenv("SEARCH_WEIGHT_RELATION", "0.25"))
 SEARCH_WEIGHT_RELEVANCE = float(os.getenv("SEARCH_WEIGHT_RELEVANCE", "0.0"))
 
+# Recency decay tuning: window in days, curve "linear" (score hits 0 at window)
+# or "exp" (window acts as half-life). Invalid curve values fall back to linear.
+SEARCH_RECENCY_WINDOW_DAYS = float(os.getenv("SEARCH_RECENCY_WINDOW_DAYS", "180"))
+_RECENCY_CURVE_RAW = os.getenv("SEARCH_RECENCY_CURVE", "linear").strip().lower()
+SEARCH_RECENCY_CURVE = _RECENCY_CURVE_RAW if _RECENCY_CURVE_RAW in {"linear", "exp"} else "linear"
+
 # API tokens
 API_TOKEN = os.getenv("AUTOMEM_API_TOKEN")
 ADMIN_TOKEN = os.getenv("ADMIN_API_TOKEN")

--- a/automem/config.py
+++ b/automem/config.py
@@ -463,9 +463,24 @@ SEARCH_WEIGHT_EXACT = float(os.getenv("SEARCH_WEIGHT_EXACT", "0.2"))
 SEARCH_WEIGHT_RELATION = float(os.getenv("SEARCH_WEIGHT_RELATION", "0.25"))
 SEARCH_WEIGHT_RELEVANCE = float(os.getenv("SEARCH_WEIGHT_RELEVANCE", "0.0"))
 
+
+def _positive_or_default(raw: str, default: float) -> float:
+    """Parse a float env value, falling back to ``default`` when not strictly positive.
+
+    Unparseable values raise ValueError, matching the neighboring float() parses;
+    only the domain (value > 0) is guarded here.
+    """
+    value = float(raw)
+    return value if value > 0 else default
+
+
 # Recency decay tuning: window in days, curve "linear" (score hits 0 at window)
-# or "exp" (window acts as half-life). Invalid curve values fall back to linear.
-SEARCH_RECENCY_WINDOW_DAYS = float(os.getenv("SEARCH_RECENCY_WINDOW_DAYS", "180"))
+# or "exp" (window acts as half-life). Invalid curve values fall back to linear;
+# non-positive window values fall back to 180 (a window <= 0 would divide by
+# zero or produce unbounded scores at recall time).
+SEARCH_RECENCY_WINDOW_DAYS = _positive_or_default(
+    os.getenv("SEARCH_RECENCY_WINDOW_DAYS", "180"), 180.0
+)
 _RECENCY_CURVE_RAW = os.getenv("SEARCH_RECENCY_CURVE", "linear").strip().lower()
 SEARCH_RECENCY_CURVE = _RECENCY_CURVE_RAW if _RECENCY_CURVE_RAW in {"linear", "exp"} else "linear"
 

--- a/automem/utils/scoring.py
+++ b/automem/utils/scoring.py
@@ -5,6 +5,8 @@ import re
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from automem.config import (
+    SEARCH_RECENCY_CURVE,
+    SEARCH_RECENCY_WINDOW_DAYS,
     SEARCH_WEIGHT_CONFIDENCE,
     SEARCH_WEIGHT_EXACT,
     SEARCH_WEIGHT_IMPORTANCE,
@@ -70,8 +72,11 @@ def _compute_recency_score(timestamp: Optional[str]) -> float:
     age_days = max((datetime.now(timezone.utc) - parsed).total_seconds() / 86400.0, 0.0)
     if age_days <= 0:
         return 1.0
-    # Linear decay over 180 days
-    return max(0.0, 1.0 - (age_days / 180.0))
+    if SEARCH_RECENCY_CURVE == "exp":
+        # Exponential decay where the window acts as the half-life.
+        return 0.5 ** (age_days / SEARCH_RECENCY_WINDOW_DAYS)
+    # Linear decay reaching zero at the window boundary
+    return max(0.0, 1.0 - (age_days / SEARCH_RECENCY_WINDOW_DAYS))
 
 
 def _context_tag_hit(tags: Set[str], priority_tags: Set[str]) -> bool:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,13 @@ services:
     build: .
     ports:
       - "${AUTOMEM_API_HOST_PORT:-8001}:8001" # Flask API
+    env_file:
+      # Lab harness overrides (scripts/lab/run_recall_test.py writes this file).
+      # Required so SEARCH_*/RECALL_*/CONSOLIDATION_* config actually reaches the
+      # container: `docker compose --env-file` only affects compose-file
+      # interpolation, never container environment.
+      - path: .env.bench
+        required: false
     environment:
       FLASK_ENV: development
       FLASK_DEBUG: "1"

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -80,7 +80,7 @@ When building your own is the right answer:
 | **Tag** | 0.20 | Tag overlap between query and memory |
 | **Exact** | 0.20 | Exact phrase match in memory metadata |
 | **Importance** | 0.10 | The memory's `importance` score (0–1) |
-| **Recency** | 0.10 | Linear decay over a 180-day window |
+| **Recency** | 0.10 | Configurable decay (default: linear over 180 days) |
 | **Confidence** | 0.05 | The memory's `confidence` score (0–1) |
 | **Relevance** | 0.00 | Consolidation decay relevance — disabled by default |
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -324,7 +324,7 @@ Controls how different factors are weighted in memory recall scoring.
 | `SEARCH_WEIGHT_CONFIDENCE` | Confidence score | `0.05` | Memory reliability |
 | `SEARCH_WEIGHT_RELEVANCE` | Consolidation relevance | `0.0` | Decay-derived score (see below) |
 
-These act as **relative weights** in the scoring formula. Keeping them roughly normalized (summing to ~1.0) is recommended for interpretability, but the service does not auto-normalize them.
+The `SEARCH_WEIGHT_*` variables act as **relative weights** in the scoring formula. Keeping them roughly normalized (summing to ~1.0) is recommended for interpretability, but the service does not auto-normalize them.
 
 **`SEARCH_WEIGHT_RELEVANCE` (new):** This weight incorporates `relevance_score`, a value maintained by the consolidation decay engine that reflects access patterns and age. It's synced to both FalkorDB and Qdrant payloads. Default is `0.0` (disabled) — set to e.g. `0.15` to boost frequently-accessed memories. Use the Recall Quality Lab to test different values before changing production.
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -318,7 +318,9 @@ Controls how different factors are weighted in memory recall scoring.
 | `SEARCH_WEIGHT_TAG` | Tag matching | `0.20` | Tag overlap scoring |
 | `SEARCH_WEIGHT_EXACT` | Exact phrase match | `0.20` | Full query in metadata |
 | `SEARCH_WEIGHT_IMPORTANCE` | Memory importance | `0.10` | User/system defined |
-| `SEARCH_WEIGHT_RECENCY` | Recent memories | `0.10` | Linear decay over 180 days |
+| `SEARCH_WEIGHT_RECENCY` | Recent memories | `0.10` | Decay shaped by `SEARCH_RECENCY_WINDOW_DAYS` and `SEARCH_RECENCY_CURVE` |
+| `SEARCH_RECENCY_WINDOW_DAYS` | Recency decay window in days | `180` | Used by the recency score, not a weight |
+| `SEARCH_RECENCY_CURVE` | Recency decay curve | `linear` | `linear` (score reaches 0 at the window) or `exp` (window acts as half-life); invalid values fall back to `linear` |
 | `SEARCH_WEIGHT_CONFIDENCE` | Confidence score | `0.05` | Memory reliability |
 | `SEARCH_WEIGHT_RELEVANCE` | Consolidation relevance | `0.0` | Decay-derived score (see below) |
 

--- a/scripts/browse_memories.py
+++ b/scripts/browse_memories.py
@@ -758,11 +758,22 @@ def cmd_diagnose(args, graph, qdrant_client, qdrant_collection):
     else:
         issues.append(("INFO", "Qdrant not connected", "Cannot verify vector presence"))
 
-    # Step 4: Recency score (180-day linear decay)
+    # Step 4: Recency score (decay shaped by SEARCH_RECENCY_WINDOW_DAYS / SEARCH_RECENCY_CURVE,
+    # matching automem/config.py validation semantics)
+    recency_window = float(os.getenv("SEARCH_RECENCY_WINDOW_DAYS", "180"))
+    if recency_window <= 0:
+        recency_window = 180.0
+    recency_curve = os.getenv("SEARCH_RECENCY_CURVE", "linear").strip().lower()
+    if recency_curve not in {"linear", "exp"}:
+        recency_curve = "linear"
+
     created = parse_ts(props.get("timestamp"))
     if created:
         age_days = max(0.0, (now - created).total_seconds() / 86400.0)
-        recency = max(0.0, 1.0 - (age_days / 180.0))
+        if recency_curve == "exp":
+            recency = 0.5 ** (age_days / recency_window)
+        else:
+            recency = max(0.0, 1.0 - (age_days / recency_window))
     else:
         age_days = 0
         recency = 0.0
@@ -772,7 +783,8 @@ def cmd_diagnose(args, graph, qdrant_client, qdrant_collection):
             (
                 "INFO",
                 f"Recency score = 0.0 (age: {age_days:.0f} days)",
-                "Linear 180-day decay — this memory is beyond the recency window",
+                f"{recency_curve.capitalize()} {recency_window:.0f}-day decay — "
+                "this memory is beyond the recency window",
             )
         )
 

--- a/scripts/browse_memories.py
+++ b/scripts/browse_memories.py
@@ -761,7 +761,7 @@ def cmd_diagnose(args, graph, qdrant_client, qdrant_collection):
     # Step 4: Recency score (decay shaped by SEARCH_RECENCY_WINDOW_DAYS / SEARCH_RECENCY_CURVE,
     # matching automem/config.py validation semantics)
     recency_window = float(os.getenv("SEARCH_RECENCY_WINDOW_DAYS", "180"))
-    if recency_window <= 0:
+    if not math.isfinite(recency_window) or recency_window <= 0:
         recency_window = 180.0
     recency_curve = os.getenv("SEARCH_RECENCY_CURVE", "linear").strip().lower()
     if recency_curve not in {"linear", "exp"}:

--- a/scripts/lab/run_recall_test.py
+++ b/scripts/lab/run_recall_test.py
@@ -161,10 +161,8 @@ def restart_api_with_config(config: Dict[str, str], api_url: str = API_URL) -> N
     Writes overrides to .env.bench and uses --env-file to ensure Docker
     actually picks up the new values (not just the subprocess environment).
     """
-    # Check if any scoring/consolidation weights changed — these need restart
-    needs_restart = any(
-        k.startswith(("SEARCH_WEIGHT_", "CONSOLIDATION_", "RECALL_")) for k in config
-    )
+    # Check if any scoring/consolidation settings changed — these need restart
+    needs_restart = any(k.startswith(("SEARCH_", "CONSOLIDATION_", "RECALL_")) for k in config)
 
     if not needs_restart:
         return

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -16,7 +16,8 @@ import app
 from app import _normalize_timestamp, utc_now
 from automem import config
 from automem.api.recall import _expand_related_memories, handle_recall
-from automem.utils.scoring import _compute_metadata_score
+from automem.utils import scoring
+from automem.utils.scoring import _compute_metadata_score, _compute_recency_score
 from automem.utils.text import _extract_keywords
 from tests.support.fake_graph import FakeGraph
 
@@ -423,6 +424,59 @@ def test_compute_metadata_score_ignores_generated_entities_for_generic_tag_score
     )
 
     assert components["tag"] == 1 / 3
+
+
+def _timestamp_days_ago(days: float) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+
+
+def test_compute_recency_score_age_zero_scores_one():
+    assert _compute_recency_score(_timestamp_days_ago(0)) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_compute_recency_score_future_timestamp_scores_one():
+    assert _compute_recency_score(_timestamp_days_ago(-5)) == 1.0
+
+
+def test_compute_recency_score_linear_half_window_scores_half():
+    assert _compute_recency_score(_timestamp_days_ago(90)) == pytest.approx(0.5, abs=1e-6)
+
+
+def test_compute_recency_score_linear_beyond_window_scores_zero():
+    assert _compute_recency_score(_timestamp_days_ago(180)) == pytest.approx(0.0, abs=1e-6)
+    assert _compute_recency_score(_timestamp_days_ago(400)) == 0.0
+
+
+def test_compute_recency_score_exp_window_is_half_life(monkeypatch):
+    monkeypatch.setattr(scoring, "SEARCH_RECENCY_CURVE", "exp")
+
+    assert _compute_recency_score(_timestamp_days_ago(180)) == pytest.approx(0.5, abs=1e-6)
+    assert _compute_recency_score(_timestamp_days_ago(360)) == pytest.approx(0.25, abs=1e-6)
+
+
+def test_compute_recency_score_missing_timestamp_scores_zero():
+    assert _compute_recency_score(None) == 0.0
+    assert _compute_recency_score("") == 0.0
+
+
+def test_compute_recency_score_unparseable_timestamp_scores_zero():
+    assert _compute_recency_score("not-a-timestamp") == 0.0
+
+
+def test_compute_recency_score_respects_configured_window(monkeypatch):
+    monkeypatch.setattr(scoring, "SEARCH_RECENCY_WINDOW_DAYS", 90.0)
+
+    assert _compute_recency_score(_timestamp_days_ago(45)) == pytest.approx(0.5, abs=1e-6)
+    assert _compute_recency_score(_timestamp_days_ago(90)) == pytest.approx(0.0, abs=1e-6)
+    assert _compute_recency_score(_timestamp_days_ago(120)) == 0.0
+
+
+def test_compute_recency_score_defaults_match_legacy_behavior():
+    # No monkeypatching: defaults must reproduce the historical
+    # linear-decay-over-180-days behavior exactly.
+    assert scoring.SEARCH_RECENCY_WINDOW_DAYS == 180.0
+    assert scoring.SEARCH_RECENCY_CURVE == "linear"
+    assert _compute_recency_score(_timestamp_days_ago(90)) == pytest.approx(0.5, abs=1e-6)
 
 
 def test_recall_with_query(client, mock_state, auth_headers):

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -471,12 +471,24 @@ def test_compute_recency_score_respects_configured_window(monkeypatch):
     assert _compute_recency_score(_timestamp_days_ago(120)) == 0.0
 
 
-def test_compute_recency_score_defaults_match_legacy_behavior():
-    # No monkeypatching: defaults must reproduce the historical
-    # linear-decay-over-180-days behavior exactly.
-    assert scoring.SEARCH_RECENCY_WINDOW_DAYS == 180.0
-    assert scoring.SEARCH_RECENCY_CURVE == "linear"
+def test_compute_recency_score_defaults_match_legacy_behavior(monkeypatch):
+    # Pin the default window/curve explicitly (config.py runs load_dotenv() at
+    # import, so a tuned .env would otherwise leak into this test) and verify
+    # the historical linear-decay-over-180-days behavior.
+    monkeypatch.setattr(scoring, "SEARCH_RECENCY_WINDOW_DAYS", 180.0)
+    monkeypatch.setattr(scoring, "SEARCH_RECENCY_CURVE", "linear")
+
     assert _compute_recency_score(_timestamp_days_ago(90)) == pytest.approx(0.5, abs=1e-6)
+
+
+def test_recency_window_config_rejects_non_positive_values():
+    # A window <= 0 would cause a request-time ZeroDivisionError (window == 0)
+    # or unbounded scores (window < 0); the config guard falls back to 180.
+    assert config._positive_or_default("0", 180.0) == 180.0
+    assert config._positive_or_default("-30", 180.0) == 180.0
+    assert config._positive_or_default("90", 180.0) == 90.0
+    with pytest.raises(ValueError):
+        config._positive_or_default("not-a-number", 180.0)
 
 
 def test_recall_with_query(client, mock_state, auth_headers):

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -430,40 +430,46 @@ def _timestamp_days_ago(days: float) -> str:
     return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
 
 
-def test_compute_recency_score_age_zero_scores_one():
+@pytest.fixture
+def legacy_recency_config(monkeypatch):
+    monkeypatch.setattr(scoring, "SEARCH_RECENCY_WINDOW_DAYS", 180.0)
+    monkeypatch.setattr(scoring, "SEARCH_RECENCY_CURVE", "linear")
+
+
+def test_compute_recency_score_age_zero_scores_one(legacy_recency_config):
     assert _compute_recency_score(_timestamp_days_ago(0)) == pytest.approx(1.0, abs=1e-6)
 
 
-def test_compute_recency_score_future_timestamp_scores_one():
+def test_compute_recency_score_future_timestamp_scores_one(legacy_recency_config):
     assert _compute_recency_score(_timestamp_days_ago(-5)) == 1.0
 
 
-def test_compute_recency_score_linear_half_window_scores_half():
+def test_compute_recency_score_linear_half_window_scores_half(legacy_recency_config):
     assert _compute_recency_score(_timestamp_days_ago(90)) == pytest.approx(0.5, abs=1e-6)
 
 
-def test_compute_recency_score_linear_beyond_window_scores_zero():
+def test_compute_recency_score_linear_beyond_window_scores_zero(legacy_recency_config):
     assert _compute_recency_score(_timestamp_days_ago(180)) == pytest.approx(0.0, abs=1e-6)
     assert _compute_recency_score(_timestamp_days_ago(400)) == 0.0
 
 
-def test_compute_recency_score_exp_window_is_half_life(monkeypatch):
+def test_compute_recency_score_exp_window_is_half_life(monkeypatch, legacy_recency_config):
     monkeypatch.setattr(scoring, "SEARCH_RECENCY_CURVE", "exp")
 
     assert _compute_recency_score(_timestamp_days_ago(180)) == pytest.approx(0.5, abs=1e-6)
     assert _compute_recency_score(_timestamp_days_ago(360)) == pytest.approx(0.25, abs=1e-6)
 
 
-def test_compute_recency_score_missing_timestamp_scores_zero():
+def test_compute_recency_score_missing_timestamp_scores_zero(legacy_recency_config):
     assert _compute_recency_score(None) == 0.0
     assert _compute_recency_score("") == 0.0
 
 
-def test_compute_recency_score_unparseable_timestamp_scores_zero():
+def test_compute_recency_score_unparseable_timestamp_scores_zero(legacy_recency_config):
     assert _compute_recency_score("not-a-timestamp") == 0.0
 
 
-def test_compute_recency_score_respects_configured_window(monkeypatch):
+def test_compute_recency_score_respects_configured_window(monkeypatch, legacy_recency_config):
     monkeypatch.setattr(scoring, "SEARCH_RECENCY_WINDOW_DAYS", 90.0)
 
     assert _compute_recency_score(_timestamp_days_ago(45)) == pytest.approx(0.5, abs=1e-6)


### PR DESCRIPTION
## Summary
- `SEARCH_RECENCY_WINDOW_DAYS` (default 180) and `SEARCH_RECENCY_CURVE` (`linear`|`exp`, default `linear`) replace the hardcoded 180-day linear decay in `_compute_recency_score()`. Defaults are bit-for-bit identical to current behavior; `exp` treats the window as a half-life.
- Window values ≤ 0 fall back to 180 (a `0` would otherwise 500 every recall with `ZeroDivisionError`; negatives produce unbounded scores).
- `scripts/browse_memories.py diagnose` now simulates recency with the same env config instead of its own hardcoded copy.
- Lab harness fix: `run_recall_test.py` restarted the API container only for `SEARCH_WEIGHT_*` keys, so sweeps of any other `SEARCH_*` var silently tested the baseline — prefix widened to `SEARCH_`.

## Why
Recency was dead for any memory older than 180 days (and for entire benchmark corpora, which are dated 2023) — zero temporal discrimination among conflicting facts. This is the substrate for the date-aware ranking work (#158/#159) and makes the window/curve sweepable via `make lab-sweep`.

## Testing
- 10 new unit tests (defaults, linear/exp curves, guards, monkeypatched windows, config domain validation)
- Full suite: 497 passed, 12 skipped; black + flake8 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)