### PR TITLE
feat(benchmarks): LongMemEval failure-mode diagnosis harness + judge quota preflight

### DIFF
--- a/test-longmemeval-benchmark.sh
+++ b/test-longmemeval-benchmark.sh
@@ -264,6 +264,22 @@ if [ "$RESUME" = true ]; then
     PYTHON_CMD+=(--resume)
 fi
 
+# Judge quota/auth preflight — abort before any ingestion or question-loop
+# work if the pinned judge model is unreachable or out of quota.
+if [ "$LLM_EVAL" = true ]; then
+    echo ""
+    echo -e "${BLUE}Running judge quota preflight...${NC}"
+    PREFLIGHT_CMD=("$PYTHON_BIN" -m tests.benchmarks.judge_preflight)
+    if [ -n "$EVAL_LLM_MODEL" ]; then
+        PREFLIGHT_CMD+=(--model "$EVAL_LLM_MODEL")
+    fi
+    if ! (cd "$SCRIPT_DIR" && "${PREFLIGHT_CMD[@]}"); then
+        echo -e "${RED}Judge preflight failed — aborting before the question loop${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}Judge preflight passed${NC}"
+fi
+
 echo ""
 echo -e "${BLUE}Config: $CONFIG${NC}"
 echo -e "${BLUE}Starting benchmark evaluation...${NC}"

--- a/test-longmemeval-benchmark.sh
+++ b/test-longmemeval-benchmark.sh
@@ -273,11 +273,13 @@ if [ "$LLM_EVAL" = true ]; then
     if [ -n "$EVAL_LLM_MODEL" ]; then
         PREFLIGHT_CMD+=(--model "$EVAL_LLM_MODEL")
     fi
-    if ! (cd "$SCRIPT_DIR" && "${PREFLIGHT_CMD[@]}"); then
+    if (cd "$SCRIPT_DIR" && "${PREFLIGHT_CMD[@]}"); then
+        echo -e "${GREEN}Judge preflight passed${NC}"
+    else
+        preflight_status=$?
         echo -e "${RED}Judge preflight failed — aborting before the question loop${NC}"
-        exit 1
+        exit "$preflight_status"
     fi
-    echo -e "${GREEN}Judge preflight passed${NC}"
 fi
 
 echo ""

--- a/tests/benchmarks/judge_preflight.py
+++ b/tests/benchmarks/judge_preflight.py
@@ -1,0 +1,149 @@
+"""Judge quota/auth preflight for AutoMem benchmark runs.
+
+Makes one minimal chat completion against the pinned benchmark judge model
+(see tests/benchmarks/judge_policy.py) before a benchmark's question loop
+starts, so quota or auth failures abort the run before any ingestion work.
+
+Exit codes:
+    0  preflight passed (judge reachable, quota available)
+    1  other failure (network, unexpected error, openai missing)
+    2  quota / rate-limit failure (HTTP 429, insufficient_quota)
+    3  auth failure (HTTP 401, missing/invalid OPENAI_API_KEY)
+
+CLI:
+    python -m tests.benchmarks.judge_preflight [--model MODEL]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Any, Optional, Tuple
+
+# Allow running as a script as well as a module.
+_project_root = str(Path(__file__).resolve().parent.parent.parent)
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - dotenv is a benchmark dependency
+    load_dotenv = None
+
+try:
+    from openai import OpenAI
+except ImportError:  # pragma: no cover - exercised via classify paths
+    OpenAI = None
+
+from tests.benchmarks.judge_policy import CANONICAL_BENCHMARK_JUDGE_MODEL, is_gpt5_family
+
+EXIT_OK = 0
+EXIT_OTHER = 1
+EXIT_QUOTA = 2
+EXIT_AUTH = 3
+
+_QUOTA_MARKERS = (
+    "insufficient_quota",
+    "rate limit",
+    "rate_limit",
+    "ratelimit",
+    "429",
+    "quota",
+)
+_AUTH_MARKERS = (
+    "invalid_api_key",
+    "incorrect api key",
+    "authentication",
+    "unauthorized",
+    "401",
+    "api key",
+)
+
+
+def classify_judge_error(exc: BaseException) -> str:
+    """Classify a judge call failure into 'quota', 'auth', or 'other'.
+
+    Matches on exception class name + message text rather than openai
+    exception classes so it stays import-safe and easy to test.
+    """
+    text = f"{type(exc).__name__}: {exc}".lower()
+    if any(marker in text for marker in _QUOTA_MARKERS):
+        return "quota"
+    if any(marker in text for marker in _AUTH_MARKERS):
+        return "auth"
+    return "other"
+
+
+def _build_client() -> Tuple[Optional[Any], Optional[Tuple[int, str]]]:
+    """Construct the same OpenAI client the benchmark harness uses."""
+    if load_dotenv is not None:
+        load_dotenv()
+        load_dotenv(Path.home() / ".config" / "automem" / ".env")
+    if OpenAI is None:
+        return None, (EXIT_OTHER, "judge preflight FAILED: openai package not installed")
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return None, (
+            EXIT_AUTH,
+            "judge preflight FAILED: OPENAI_API_KEY is not set "
+            "(export it or add it to .env / ~/.config/automem/.env)",
+        )
+    return OpenAI(api_key=api_key), None
+
+
+def run_preflight(model: Optional[str] = None, client: Optional[Any] = None) -> Tuple[int, str]:
+    """Make one minimal judge completion; return (exit_code, one-line message)."""
+    model = model or CANONICAL_BENCHMARK_JUDGE_MODEL
+    if client is None:
+        client, error = _build_client()
+        if error is not None:
+            return error
+
+    request_kwargs: dict = {
+        "model": model,
+        "messages": [{"role": "user", "content": "Reply with OK."}],
+    }
+    if is_gpt5_family(model):
+        request_kwargs["max_completion_tokens"] = 16
+    else:
+        request_kwargs["temperature"] = 0
+        request_kwargs["max_tokens"] = 16
+
+    try:
+        client.chat.completions.create(**request_kwargs)
+    except Exception as exc:  # noqa: BLE001 - classify every failure mode
+        category = classify_judge_error(exc)
+        if category == "quota":
+            return (
+                EXIT_QUOTA,
+                f"judge preflight FAILED: quota/rate-limit error for {model} "
+                f"({exc}) — top up OpenAI billing or wait and retry before "
+                "starting the benchmark",
+            )
+        if category == "auth":
+            return (
+                EXIT_AUTH,
+                f"judge preflight FAILED: auth error for {model} ({exc}) — " "check OPENAI_API_KEY",
+            )
+        return (EXIT_OTHER, f"judge preflight FAILED: {model} unreachable ({exc})")
+
+    return (EXIT_OK, f"judge preflight OK: {model} reachable with available quota")
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model",
+        default=CANONICAL_BENCHMARK_JUDGE_MODEL,
+        help=f"Judge model to probe (default: {CANONICAL_BENCHMARK_JUDGE_MODEL})",
+    )
+    args = parser.parse_args(argv)
+    code, message = run_preflight(model=args.model)
+    print(message)
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmarks/longmemeval/diagnose_failures.py
+++ b/tests/benchmarks/longmemeval/diagnose_failures.py
@@ -78,6 +78,7 @@ except ImportError:  # pragma: no cover - only needed for --llm
     OpenAI = None
 
 from tests.benchmarks.judge_policy import CANONICAL_BENCHMARK_JUDGE_MODEL, is_gpt5_family
+from tests.benchmarks.longmemeval.analyze_results import _result_details
 from tests.benchmarks.longmemeval.evaluator import check_abstention_response
 
 # ---------------------------------------------------------------------------
@@ -130,6 +131,8 @@ _STOPWORDS: FrozenSet[str] = frozenset(
 
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
 _SESSION_DATE_RE = re.compile(r"(\d{4})/(\d{2})/(\d{2})(?:\s*\([^)]*\))?\s*(\d{2}):(\d{2})")
+# Deliberately over-triggers on temporal-reasoning questions (broad markers
+# like \bbefore\b and \bfirst\b); stage 2 (--llm) cross-checks the labels.
 _DATE_MATH_RE = re.compile(
     r"\bhow long\b"
     r"|\bhow many\s+(?:days|weeks|months|years)\b"
@@ -322,16 +325,6 @@ def suggested_mode(question_type: str, evidence: Dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 # Stage 1 driver
 # ---------------------------------------------------------------------------
-
-
-def _result_details(results: Dict[str, Any]) -> List[Dict[str, Any]]:
-    details = results.get("details")
-    if isinstance(details, list):
-        return details
-    legacy = results.get("results")
-    if isinstance(legacy, list):
-        return legacy
-    return []
 
 
 def select_failures(
@@ -585,6 +578,8 @@ def run_stage2(
     dataset_by_id = {item.get("question_id"): item for item in dataset}
     agreement: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
     matches = 0
+    scored = 0
+    llm_errors = 0
     for record in report["questions"]:
         dataset_item = dataset_by_id.get(record["question_id"])
         session_index = build_session_index(dataset_item) if dataset_item else {}
@@ -592,17 +587,24 @@ def run_stage2(
         record["llm_mode"] = verdict["mode"]
         record["llm_rationale"] = verdict["rationale"]
         record["llm_error"] = verdict["error"]
+        if verdict["error"] is not None:
+            # Transport/parse failures carry no labeling signal: keep the
+            # per-record llm_error, but exclude the record from the
+            # agreement matrix and the exact-agreement rate.
+            llm_errors += 1
+            continue
+        scored += 1
         agreement[record["suggested_mode"]][verdict["mode"]] += 1
         if record["suggested_mode"] == verdict["mode"]:
             matches += 1
 
-    total = len(report["questions"])
     report["agreement"] = {
         "llm_model": model,
+        "llm_errors": llm_errors,
         "matrix": {
             stage1: dict(sorted(stage2.items())) for stage1, stage2 in sorted(agreement.items())
         },
-        "exact_agreement": matches / total if total else None,
+        "exact_agreement": matches / scored if scored else None,
         "llm_mode_counts": dict(
             sorted(Counter(r["llm_mode"] for r in report["questions"]).items())
         ),
@@ -682,7 +684,9 @@ def main(argv: Optional[List[str]] = None) -> int:
         for mode, count in agreement["llm_mode_counts"].items():
             print(f"  {mode:<26} {count}")
         rate = agreement["exact_agreement"]
-        print(f"  stage1/stage2 exact agreement: {rate:.1%}" if rate is not None else "")
+        if rate is not None:
+            print(f"  stage1/stage2 exact agreement: {rate:.1%}")
+        print(f"  stage-2 llm errors (excluded from agreement): {agreement.get('llm_errors', 0)}")
 
     if args.out:
         args.out.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/benchmarks/longmemeval/diagnose_failures.py
+++ b/tests/benchmarks/longmemeval/diagnose_failures.py
@@ -1,0 +1,696 @@
+"""LongMemEval failure-mode diagnosis harness (issues #158/#159).
+
+Classifies "failed-but-retrieved" questions — wrong answer despite the
+answer session being inside the top-5 retrieved sessions
+(``is_correct == false AND recall_hit_at_5 == true``) — so ranking fixes
+can be prioritized by failure mode instead of anecdote.
+
+Stage 1 (always, pure code) joins each failure to the dataset's haystack
+sessions/dates and emits deterministic per-question evidence plus a
+``suggested_mode``. Stage 2 (``--llm``) asks the pinned benchmark judge
+model for an independent label and records the stage1-vs-stage2
+agreement matrix.
+
+Suggested-mode heuristic (first matching rule wins; auditable on purpose):
+
+    1. abstained_despite_hit                          -> answer-construction
+       (evidence was retrieved but the model refused to answer)
+    2. type in {knowledge-update, single-session-preference}
+       and stale_candidate_above_answer               -> outdated-fact-selection
+       (an older, topically-overlapping non-answer session outranked the
+       newest answer session)
+    3. type == knowledge-update and staleness was
+       evaluated as False                             -> conflict-resolution
+       (old + new facts both visible; model picked the wrong one)
+    4. type == temporal-reasoning
+       and date_arithmetic_needed                     -> missing-date-use
+       (question requires date math over session dates)
+    5. type == multi-session
+       and answer_coverage_top5 < 1.0                 -> retrieval-gap-rank6-10
+       (some required answer sessions are missing from the top-5;
+       with recall depth 10 they sit at rank 6-10 or beyond)
+    6. answer_rank == 1                               -> answer-construction
+       (retrieval did its job; generation still failed)
+    7. answer_rank >= 2                               -> ranking
+       (answer session buried under higher-ranked candidates)
+    8. otherwise                                      -> other
+
+Type filter default: ALL question types. The canonical full run
+(longmemeval_full_gpt5mini_20260425_231308.json) has 58 failed-but-
+retrieved questions across six types; the four weak categories
+(multi-session, temporal-reasoning, knowledge-update,
+single-session-preference) cover 54 of them. Pass ``--types`` to
+restrict.
+
+CLI:
+    python -m tests.benchmarks.longmemeval.diagnose_failures \
+        --results benchmarks/results/longmemeval_full_gpt5mini_20260425_231308.json \
+        --dataset tests/benchmarks/longmemeval/data/longmemeval_s_cleaned.json \
+        [--types multi-session,temporal-reasoning,...] [--llm] \
+        [--llm-model MODEL] [--out failure_modes.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, FrozenSet, Iterable, List, Optional, Set
+
+# Allow running as a script as well as a module.
+_project_root = str(Path(__file__).resolve().parent.parent.parent.parent)
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - dotenv is a benchmark dependency
+    load_dotenv = None
+
+try:
+    from openai import OpenAI
+except ImportError:  # pragma: no cover - only needed for --llm
+    OpenAI = None
+
+from tests.benchmarks.judge_policy import CANONICAL_BENCHMARK_JUDGE_MODEL, is_gpt5_family
+from tests.benchmarks.longmemeval.evaluator import check_abstention_response
+
+# ---------------------------------------------------------------------------
+# Failure-mode labels
+# ---------------------------------------------------------------------------
+
+MODE_RANKING = "ranking"
+MODE_OUTDATED = "outdated-fact-selection"
+MODE_MISSING_DATE = "missing-date-use"
+MODE_CONFLICT = "conflict-resolution"
+MODE_ANSWER_CONSTRUCTION = "answer-construction"
+MODE_RETRIEVAL_GAP = "retrieval-gap-rank6-10"
+MODE_JUDGE_ERROR = "judge-error"
+MODE_OTHER = "other"
+
+STAGE1_MODES = (
+    MODE_RANKING,
+    MODE_OUTDATED,
+    MODE_MISSING_DATE,
+    MODE_CONFLICT,
+    MODE_ANSWER_CONSTRUCTION,
+    MODE_RETRIEVAL_GAP,
+    MODE_OTHER,
+)
+STAGE2_MODES = STAGE1_MODES[:-1] + (MODE_JUDGE_ERROR, MODE_OTHER)
+
+WEAK_TYPES = (
+    "multi-session",
+    "temporal-reasoning",
+    "knowledge-update",
+    "single-session-preference",
+)
+STALE_CHECK_TYPES = frozenset({"knowledge-update", "single-session-preference"})
+
+# ---------------------------------------------------------------------------
+# Tokenization / date parsing
+# ---------------------------------------------------------------------------
+
+_STOPWORDS: FrozenSet[str] = frozenset(
+    """
+    a an the is was were are am be been being do does did done i you he she it
+    we they my your his her its our their me him them us this that these those
+    what which who whom whose when where why how of in on at by for with about
+    to from as and or but not no nor so if then than too very can could will
+    would shall should may might must have has had having there here also any
+    some such own same just only into over under again further once during
+    each few more most other s t don
+    """.split()
+)
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_SESSION_DATE_RE = re.compile(r"(\d{4})/(\d{2})/(\d{2})(?:\s*\([^)]*\))?\s*(\d{2}):(\d{2})")
+_DATE_MATH_RE = re.compile(
+    r"\bhow long\b"
+    r"|\bhow many\s+(?:days|weeks|months|years)\b"
+    r"|\bbefore\b"
+    r"|\bafter\b"
+    r"|\bfirst\b"
+    r"|\blast time\b",
+    re.IGNORECASE,
+)
+_JSON_FENCE_RE = re.compile(r"^\s*```[a-zA-Z0-9_-]*\s*\n(?P<body>.*)\n\s*```\s*$", re.S)
+
+
+def keyword_tokens(text: Any) -> Set[str]:
+    """Lowercase word-set minus stopwords (simple, auditable tokenization)."""
+    if not text:
+        return set()
+    tokens = _TOKEN_RE.findall(str(text).lower())
+    return {token for token in tokens if len(token) >= 2 and token not in _STOPWORDS}
+
+
+def parse_session_date(raw: Any) -> Optional[datetime]:
+    """Parse LongMemEval session dates like ``2023/05/20 (Sat) 02:21``."""
+    if not raw:
+        return None
+    match = _SESSION_DATE_RE.search(str(raw))
+    if not match:
+        return None
+    year, month, day, hour, minute = (int(part) for part in match.groups())
+    try:
+        return datetime(year, month, day, hour, minute)
+    except ValueError:
+        return None
+
+
+def date_arithmetic_needed(question: Any) -> bool:
+    """Heuristic: does the question require date arithmetic?"""
+    return bool(_DATE_MATH_RE.search(str(question or "")))
+
+
+def is_refusal(hypothesis: Any) -> bool:
+    """True when the hypothesis is an 'I don't know'-style refusal."""
+    if not hypothesis:
+        return False
+    return check_abstention_response(hypothesis)
+
+
+def answer_rank(retrieved: Iterable[str], answer_ids: Iterable[str]) -> Optional[int]:
+    """1-based rank of the first answer session in the retrieved list."""
+    answer_set = set(answer_ids or [])
+    for rank, session_id in enumerate(retrieved or [], start=1):
+        if session_id in answer_set:
+            return rank
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Dataset join + evidence extraction
+# ---------------------------------------------------------------------------
+
+
+def _session_text(session: Any) -> str:
+    if not isinstance(session, list):
+        return ""
+    parts = []
+    for turn in session:
+        if isinstance(turn, dict):
+            content = turn.get("content")
+            if content:
+                parts.append(str(content))
+    return "\n".join(parts)
+
+
+def build_session_index(dataset_item: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Map session_id -> {raw_date, date, text, tokens} for one question."""
+    index: Dict[str, Dict[str, Any]] = {}
+    session_ids = dataset_item.get("haystack_session_ids") or []
+    dates = dataset_item.get("haystack_dates") or []
+    sessions = dataset_item.get("haystack_sessions") or []
+    for position, session_id in enumerate(session_ids):
+        raw_date = dates[position] if position < len(dates) else None
+        text = _session_text(sessions[position]) if position < len(sessions) else ""
+        index[session_id] = {
+            "raw_date": raw_date,
+            "date": parse_session_date(raw_date),
+            "text": text,
+            "tokens": keyword_tokens(text),
+        }
+    return index
+
+
+def compute_evidence(row: Dict[str, Any], dataset_item: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Deterministic stage-1 evidence for one failed-but-retrieved question."""
+    question_type = str(row.get("question_type") or "unknown")
+    question = row.get("question") or ""
+    retrieved = list(row.get("retrieved_session_ids") or [])
+    answer_ids = set(row.get("answer_session_ids") or [])
+
+    evidence: Dict[str, Any] = {
+        "answer_rank": answer_rank(retrieved, answer_ids),
+        "abstained_despite_hit": bool(row.get("is_abstention"))
+        or is_refusal(row.get("hypothesis")),
+        "stale_candidate_above_answer": None,
+        "noise_ratio": None,
+        "date_arithmetic_needed": (
+            date_arithmetic_needed(question) if question_type == "temporal-reasoning" else None
+        ),
+        "answer_coverage_top5": (
+            len(answer_ids & set(retrieved)) / len(answer_ids) if answer_ids else None
+        ),
+        "newest_answer_session_id": None,
+        "newest_answer_rank": None,
+        "dataset_missing": dataset_item is None,
+    }
+
+    if dataset_item is None:
+        return evidence
+
+    session_index = build_session_index(dataset_item)
+    question_tokens = keyword_tokens(question)
+
+    # noise_ratio: fraction of retrieved sessions sharing zero question keywords.
+    if retrieved:
+        noisy = sum(
+            1
+            for session_id in retrieved
+            if not (question_tokens & session_index.get(session_id, {}).get("tokens", set()))
+        )
+        evidence["noise_ratio"] = noisy / len(retrieved)
+
+    # Newest answer session (by haystack date) and its rank in the top-5.
+    dated_answers = [
+        (session_index[sid]["date"], sid)
+        for sid in answer_ids
+        if sid in session_index and session_index[sid]["date"] is not None
+    ]
+    if dated_answers:
+        newest_date, newest_id = max(dated_answers, key=lambda pair: pair[0])
+        evidence["newest_answer_session_id"] = newest_id
+        newest_rank = retrieved.index(newest_id) + 1 if newest_id in retrieved else None
+        evidence["newest_answer_rank"] = newest_rank
+
+        if question_type in STALE_CHECK_TYPES:
+            # A retrieved non-answer session that is OLDER than the newest
+            # answer session, topically overlapping with the question, and
+            # ranked ABOVE the newest answer session. If the newest answer
+            # session is absent from the top-5, every retrieved candidate
+            # ranks above it by construction.
+            cutoff_rank = newest_rank if newest_rank is not None else len(retrieved) + 1
+            stale = False
+            for rank, session_id in enumerate(retrieved, start=1):
+                if rank >= cutoff_rank or session_id in answer_ids:
+                    continue
+                info = session_index.get(session_id)
+                if not info or info["date"] is None:
+                    continue
+                if info["date"] < newest_date and (question_tokens & info["tokens"]):
+                    stale = True
+                    break
+            evidence["stale_candidate_above_answer"] = stale
+    elif question_type in STALE_CHECK_TYPES:
+        evidence["stale_candidate_above_answer"] = False
+
+    return evidence
+
+
+def suggested_mode(question_type: str, evidence: Dict[str, Any]) -> str:
+    """Deterministic evidence -> failure-mode mapping (see module docstring)."""
+    if evidence.get("abstained_despite_hit"):
+        return MODE_ANSWER_CONSTRUCTION
+    if question_type in STALE_CHECK_TYPES and evidence.get("stale_candidate_above_answer"):
+        return MODE_OUTDATED
+    if (
+        question_type == "knowledge-update"
+        and evidence.get("stale_candidate_above_answer") is False
+    ):
+        return MODE_CONFLICT
+    if question_type == "temporal-reasoning" and evidence.get("date_arithmetic_needed"):
+        return MODE_MISSING_DATE
+    coverage = evidence.get("answer_coverage_top5")
+    if question_type == "multi-session" and coverage is not None and coverage < 1.0:
+        return MODE_RETRIEVAL_GAP
+    rank = evidence.get("answer_rank")
+    if rank == 1:
+        return MODE_ANSWER_CONSTRUCTION
+    if rank is not None and rank >= 2:
+        return MODE_RANKING
+    return MODE_OTHER
+
+
+# ---------------------------------------------------------------------------
+# Stage 1 driver
+# ---------------------------------------------------------------------------
+
+
+def _result_details(results: Dict[str, Any]) -> List[Dict[str, Any]]:
+    details = results.get("details")
+    if isinstance(details, list):
+        return details
+    legacy = results.get("results")
+    if isinstance(legacy, list):
+        return legacy
+    return []
+
+
+def select_failures(
+    details: Iterable[Dict[str, Any]], types: Optional[Set[str]]
+) -> List[Dict[str, Any]]:
+    """Filter to failed-but-retrieved rows, optionally restricted by type."""
+    selected = []
+    for row in details:
+        if row.get("is_correct") is not False:
+            continue
+        if row.get("recall_hit_at_5") is not True:
+            continue
+        if types is not None and str(row.get("question_type")) not in types:
+            continue
+        selected.append(row)
+    return selected
+
+
+def diagnose_stage1(
+    results: Dict[str, Any],
+    dataset: List[Dict[str, Any]],
+    types: Optional[Set[str]] = None,
+    results_file: Optional[str] = None,
+    dataset_file: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Run pure-code stage-1 diagnosis and return the report dict."""
+    details = _result_details(results)
+    failures = [row for row in details if row.get("is_correct") is False]
+    selected = select_failures(details, types)
+    dataset_by_id = {item.get("question_id"): item for item in dataset}
+
+    questions = []
+    for row in selected:
+        question_id = row.get("question_id")
+        dataset_item = dataset_by_id.get(question_id)
+        evidence = compute_evidence(row, dataset_item)
+        mode = suggested_mode(str(row.get("question_type") or "unknown"), evidence)
+        session_index = build_session_index(dataset_item) if dataset_item else {}
+        answer_ids = set(row.get("answer_session_ids") or [])
+        question_tokens = keyword_tokens(row.get("question") or "")
+        retrieved_sessions = []
+        for rank, session_id in enumerate(row.get("retrieved_session_ids") or [], start=1):
+            info = session_index.get(session_id, {})
+            retrieved_sessions.append(
+                {
+                    "rank": rank,
+                    "session_id": session_id,
+                    "date": info.get("raw_date"),
+                    "is_answer": session_id in answer_ids,
+                    "question_keyword_overlap": len(question_tokens & info.get("tokens", set())),
+                }
+            )
+        questions.append(
+            {
+                "question_id": question_id,
+                "question_type": row.get("question_type"),
+                "question": row.get("question"),
+                "question_date": row.get("question_date"),
+                "reference": row.get("reference"),
+                "hypothesis": row.get("hypothesis"),
+                "explanation": row.get("explanation"),
+                "answer_session_ids": list(row.get("answer_session_ids") or []),
+                "retrieved_session_ids": list(row.get("retrieved_session_ids") or []),
+                "retrieved_sessions": retrieved_sessions,
+                "evidence": evidence,
+                "suggested_mode": mode,
+            }
+        )
+
+    mode_counts: Counter = Counter(record["suggested_mode"] for record in questions)
+    mode_counts_by_type: Dict[str, Dict[str, int]] = defaultdict(dict)
+    for record in questions:
+        qtype = str(record["question_type"])
+        mode_counts_by_type[qtype][record["suggested_mode"]] = (
+            mode_counts_by_type[qtype].get(record["suggested_mode"], 0) + 1
+        )
+
+    return {
+        "metadata": {
+            "results_file": results_file,
+            "dataset_file": dataset_file,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "types_filter": sorted(types) if types is not None else None,
+            "total_details": len(details),
+            "total_failures": len(failures),
+            "selected": len(questions),
+            "selected_by_type": dict(
+                sorted(Counter(str(r["question_type"]) for r in questions).items())
+            ),
+        },
+        "questions": questions,
+        "summary": {
+            "mode_counts": dict(sorted(mode_counts.items())),
+            "mode_counts_by_type": {
+                qtype: dict(sorted(modes.items()))
+                for qtype, modes in sorted(mode_counts_by_type.items())
+            },
+        },
+    }
+
+
+def format_summary(report: Dict[str, Any]) -> str:
+    """Human-readable mode-by-type summary table."""
+    metadata = report["metadata"]
+    by_type = report["summary"]["mode_counts_by_type"]
+    modes = [mode for mode in STAGE1_MODES if any(mode in row for row in by_type.values())]
+
+    lines = [
+        "LongMemEval failure-mode diagnosis (stage 1)",
+        f"  results: {metadata.get('results_file')}",
+        f"  selected failed-but-retrieved: {metadata['selected']} "
+        f"(of {metadata['total_failures']} total failures, "
+        f"{metadata['total_details']} questions)",
+        f"  types filter: {metadata.get('types_filter') or 'all'}",
+        "",
+    ]
+    type_width = max([len(t) for t in by_type] + [len("question type")]) + 2
+    header = "question type".ljust(type_width) + "".join(f"{mode:>26}" for mode in modes)
+    header += f"{'total':>8}"
+    lines.append(header)
+    lines.append("-" * len(header))
+    for qtype in sorted(by_type):
+        row_counts = by_type[qtype]
+        line = qtype.ljust(type_width)
+        line += "".join(f"{row_counts.get(mode, 0):>26}" for mode in modes)
+        line += f"{sum(row_counts.values()):>8}"
+        lines.append(line)
+    totals = report["summary"]["mode_counts"]
+    line = "TOTAL".ljust(type_width)
+    line += "".join(f"{totals.get(mode, 0):>26}" for mode in modes)
+    line += f"{metadata['selected']:>8}"
+    lines.append(line)
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Stage 2 (--llm): independent LLM classification
+# ---------------------------------------------------------------------------
+
+_STAGE2_SESSION_CHAR_LIMIT = 2500
+
+_STAGE2_LABEL_GUIDE = """\
+- ranking: the answer session was retrieved but ranked below distractors, and the model used a higher-ranked wrong source
+- outdated-fact-selection: an older/stale fact was preferred over the newest correct fact
+- missing-date-use: the model had the sessions but failed to use session dates / do date arithmetic
+- conflict-resolution: conflicting facts were both visible and the model resolved them incorrectly
+- answer-construction: retrieval was fine; the model refused, hedged, or composed a wrong answer from correct evidence
+- retrieval-gap-rank6-10: required evidence sessions were missing from the provided top-5 context
+- judge-error: the hypothesis actually matches the reference; the benchmark judge mis-scored it
+- other: none of the above fits"""
+
+
+def _build_stage2_prompt(record: Dict[str, Any], session_index: Dict[str, Any]) -> str:
+    session_blocks = []
+    for entry in record["retrieved_sessions"]:
+        session_id = entry["session_id"]
+        info = session_index.get(session_id, {})
+        text = (info.get("text") or "")[:_STAGE2_SESSION_CHAR_LIMIT]
+        marker = "ANSWER SESSION" if entry["is_answer"] else "non-answer"
+        session_blocks.append(
+            f"[Rank {entry['rank']} | session {session_id} | "
+            f"{entry.get('date') or 'unknown date'} | {marker}]\n{text}"
+        )
+    sessions_text = "\n\n".join(session_blocks) or "(no retrieved sessions)"
+    return f"""You are diagnosing why a long-term-memory QA system answered incorrectly even though a session containing the answer WAS retrieved in the top-5.
+
+Question (asked {record.get('question_date') or 'unknown date'}): {record.get('question')}
+Question type: {record.get('question_type')}
+Reference answer: {record.get('reference')}
+System's answer: {record.get('hypothesis')}
+Benchmark judge explanation: {record.get('explanation')}
+Answer session ids: {', '.join(record.get('answer_session_ids') or [])}
+
+Retrieved sessions in rank order:
+
+{sessions_text}
+
+Pick exactly ONE failure-mode label:
+{_STAGE2_LABEL_GUIDE}
+
+Respond with ONLY a JSON object:
+{{"mode": "<label>", "rationale": "<one sentence>"}}"""
+
+
+def classify_failure_with_llm(
+    client: Any, model: str, record: Dict[str, Any], session_index: Dict[str, Any]
+) -> Dict[str, Any]:
+    """One chat completion -> {"mode", "rationale", "error"} for one failure."""
+    prompt = _build_stage2_prompt(record, session_index)
+    request_kwargs: Dict[str, Any] = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    if is_gpt5_family(model):
+        request_kwargs["max_completion_tokens"] = 300
+        request_kwargs["response_format"] = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "failure_mode",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "mode": {"type": "string", "enum": list(STAGE2_MODES)},
+                        "rationale": {"type": "string"},
+                    },
+                    "required": ["mode", "rationale"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+    else:
+        request_kwargs["temperature"] = 0
+        request_kwargs["max_tokens"] = 300
+        request_kwargs["response_format"] = {"type": "json_object"}
+
+    try:
+        response = client.chat.completions.create(**request_kwargs)
+        content = (response.choices[0].message.content or "").strip()
+        fence_match = _JSON_FENCE_RE.match(content)
+        if fence_match:
+            content = fence_match.group("body").strip()
+        parsed = json.loads(content)
+        mode = str(parsed.get("mode") or "").strip()
+        if mode not in STAGE2_MODES:
+            return {
+                "mode": MODE_OTHER,
+                "rationale": str(parsed.get("rationale") or ""),
+                "error": f"unexpected label: {mode!r}",
+            }
+        return {"mode": mode, "rationale": str(parsed.get("rationale") or ""), "error": None}
+    except Exception as exc:  # noqa: BLE001 - one bad question must not kill the run
+        return {"mode": MODE_OTHER, "rationale": "", "error": f"{type(exc).__name__}: {exc}"}
+
+
+def run_stage2(
+    report: Dict[str, Any],
+    dataset: List[Dict[str, Any]],
+    model: str,
+    client: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Annotate the stage-1 report with LLM labels + agreement matrix."""
+    if client is None:
+        if OpenAI is None:
+            raise ImportError("openai package required for --llm stage 2")
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise ValueError("OPENAI_API_KEY required for --llm stage 2")
+        client = OpenAI(api_key=api_key)
+
+    dataset_by_id = {item.get("question_id"): item for item in dataset}
+    agreement: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    matches = 0
+    for record in report["questions"]:
+        dataset_item = dataset_by_id.get(record["question_id"])
+        session_index = build_session_index(dataset_item) if dataset_item else {}
+        verdict = classify_failure_with_llm(client, model, record, session_index)
+        record["llm_mode"] = verdict["mode"]
+        record["llm_rationale"] = verdict["rationale"]
+        record["llm_error"] = verdict["error"]
+        agreement[record["suggested_mode"]][verdict["mode"]] += 1
+        if record["suggested_mode"] == verdict["mode"]:
+            matches += 1
+
+    total = len(report["questions"])
+    report["agreement"] = {
+        "llm_model": model,
+        "matrix": {
+            stage1: dict(sorted(stage2.items())) for stage1, stage2 in sorted(agreement.items())
+        },
+        "exact_agreement": matches / total if total else None,
+        "llm_mode_counts": dict(
+            sorted(Counter(r["llm_mode"] for r in report["questions"]).items())
+        ),
+    }
+    report["metadata"]["llm_stage"] = True
+    report["metadata"]["llm_model"] = model
+    return report
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Diagnose LongMemEval failed-but-retrieved questions by failure mode."
+    )
+    parser.add_argument("--results", required=True, type=Path, help="Benchmark results JSON")
+    parser.add_argument(
+        "--dataset", required=True, type=Path, help="longmemeval_s_cleaned.json dataset"
+    )
+    parser.add_argument(
+        "--types",
+        default=None,
+        help=(
+            "Comma-separated question types to include "
+            f"(default: all; weak categories: {','.join(WEAK_TYPES)})"
+        ),
+    )
+    parser.add_argument(
+        "--llm", action="store_true", help="Run stage-2 LLM classification per failure"
+    )
+    parser.add_argument(
+        "--llm-model",
+        default=CANONICAL_BENCHMARK_JUDGE_MODEL,
+        help=f"Stage-2 model (default: {CANONICAL_BENCHMARK_JUDGE_MODEL})",
+    )
+    parser.add_argument("--out", type=Path, default=None, help="Write report JSON here")
+    args = parser.parse_args(argv)
+
+    if load_dotenv is not None:
+        load_dotenv()
+        load_dotenv(Path.home() / ".config" / "automem" / ".env")
+
+    with args.results.open("r", encoding="utf-8") as handle:
+        results = json.load(handle)
+    with args.dataset.open("r", encoding="utf-8") as handle:
+        dataset = json.load(handle)
+
+    types: Optional[Set[str]] = None
+    if args.types:
+        types = {part.strip() for part in args.types.split(",") if part.strip()}
+
+    report = diagnose_stage1(
+        results,
+        dataset,
+        types=types,
+        results_file=str(args.results),
+        dataset_file=str(args.dataset),
+    )
+
+    if args.llm:
+        from tests.benchmarks.judge_preflight import EXIT_OK, run_preflight
+
+        code, message = run_preflight(model=args.llm_model)
+        print(message)
+        if code != EXIT_OK:
+            return code
+        run_stage2(report, dataset, model=args.llm_model)
+
+    print(format_summary(report))
+    if args.llm and report.get("agreement"):
+        agreement = report["agreement"]
+        print("")
+        print(f"Stage-2 LLM labels ({agreement['llm_model']}):")
+        for mode, count in agreement["llm_mode_counts"].items():
+            print(f"  {mode:<26} {count}")
+        rate = agreement["exact_agreement"]
+        print(f"  stage1/stage2 exact agreement: {rate:.1%}" if rate is not None else "")
+
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        with args.out.open("w", encoding="utf-8") as handle:
+            json.dump(report, handle, indent=2, ensure_ascii=False)
+        print(f"\nWrote report: {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmarks/longmemeval/test_diagnose_failures.py
+++ b/tests/benchmarks/longmemeval/test_diagnose_failures.py
@@ -1,0 +1,435 @@
+"""Unit tests for the LongMemEval failure-mode diagnosis harness.
+
+All fixtures are synthetic (synthetic names only); no real benchmark
+artifacts or network calls are used, mirroring test_analysis.py.
+"""
+
+from types import SimpleNamespace
+
+from tests.benchmarks.judge_preflight import (
+    EXIT_AUTH,
+    EXIT_OK,
+    EXIT_OTHER,
+    EXIT_QUOTA,
+    classify_judge_error,
+    run_preflight,
+)
+from tests.benchmarks.longmemeval.diagnose_failures import (
+    MODE_ANSWER_CONSTRUCTION,
+    MODE_CONFLICT,
+    MODE_MISSING_DATE,
+    MODE_OTHER,
+    MODE_OUTDATED,
+    MODE_RANKING,
+    MODE_RETRIEVAL_GAP,
+    answer_rank,
+    compute_evidence,
+    date_arithmetic_needed,
+    diagnose_stage1,
+    format_summary,
+    is_refusal,
+    keyword_tokens,
+    parse_session_date,
+    run_stage2,
+    select_failures,
+    suggested_mode,
+)
+
+# ---------------------------------------------------------------------------
+# Synthetic fixtures
+# ---------------------------------------------------------------------------
+
+
+def _dataset_item(**overrides):
+    item = {
+        "question_id": "q-synth-1",
+        "question_type": "knowledge-update",
+        "question": "What city does the user live in now?",
+        "answer": "Lisbon",
+        "question_date": "2023/04/01 (Sat) 10:00",
+        "answer_session_ids": ["ans_1"],
+        "haystack_session_ids": ["old_1", "ans_1", "noise_1"],
+        "haystack_dates": [
+            "2023/01/05 (Thu) 10:00",
+            "2023/03/10 (Fri) 12:00",
+            "2023/02/01 (Wed) 09:00",
+        ],
+        "haystack_sessions": [
+            [{"role": "user", "content": "I live in Porto city right now."}],
+            [{"role": "user", "content": "Update: I moved and now live in Lisbon city."}],
+            [{"role": "user", "content": "My cat enjoys tuna snacks."}],
+        ],
+    }
+    item.update(overrides)
+    return item
+
+
+def _result_row(**overrides):
+    row = {
+        "question_id": "q-synth-1",
+        "question_type": "knowledge-update",
+        "question": "What city does the user live in now?",
+        "reference": "Lisbon",
+        "hypothesis": "Porto",
+        "is_correct": False,
+        "is_abstention": False,
+        "explanation": "Said Porto, reference is Lisbon.",
+        "question_date": "2023/04/01 (Sat) 10:00",
+        "answer_session_ids": ["ans_1"],
+        "retrieved_session_ids": ["old_1", "ans_1", "noise_1"],
+        "recall_hit_at_5": True,
+    }
+    row.update(overrides)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Tokenization and date parsing
+# ---------------------------------------------------------------------------
+
+
+def test_keyword_tokens_drops_stopwords_and_lowercases():
+    tokens = keyword_tokens("What city does the User LIVE in now?")
+    assert "city" in tokens
+    assert "live" in tokens
+    assert "what" not in tokens
+    assert "the" not in tokens
+    assert "in" not in tokens
+
+
+def test_parse_session_date_handles_longmemeval_format():
+    parsed = parse_session_date("2023/05/20 (Sat) 02:21")
+    assert parsed is not None
+    assert (parsed.year, parsed.month, parsed.day) == (2023, 5, 20)
+    assert (parsed.hour, parsed.minute) == (2, 21)
+
+
+def test_parse_session_date_returns_none_on_garbage():
+    assert parse_session_date("not a date") is None
+    assert parse_session_date("") is None
+    assert parse_session_date(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Evidence primitives
+# ---------------------------------------------------------------------------
+
+
+def test_answer_rank_is_one_based_first_hit():
+    assert answer_rank(["s1", "s2", "s3"], ["s2"]) == 2
+    assert answer_rank(["s1", "s2", "s3"], ["s3", "s1"]) == 1
+    assert answer_rank(["s1", "s2"], ["s9"]) is None
+    assert answer_rank([], ["s9"]) is None
+
+
+def test_is_refusal_detects_dont_know_responses():
+    assert is_refusal("I don't know.") is True
+    assert is_refusal("There is no information about that in my memory.") is True
+    assert is_refusal("Lisbon") is False
+    assert is_refusal("") is False
+
+
+def test_date_arithmetic_needed_markers():
+    assert date_arithmetic_needed("How long did the user wait?") is True
+    assert date_arithmetic_needed("How many days passed between visits?") is True
+    assert date_arithmetic_needed("What happened before the move?") is True
+    assert date_arithmetic_needed("When was the first concert?") is True
+    assert date_arithmetic_needed("What is the user's favorite color?") is False
+
+
+# ---------------------------------------------------------------------------
+# compute_evidence
+# ---------------------------------------------------------------------------
+
+
+def test_compute_evidence_stale_candidate_above_answer_true():
+    # old_1 (non-answer, older, topically overlapping) ranked above ans_1.
+    evidence = compute_evidence(_result_row(), _dataset_item())
+    assert evidence["answer_rank"] == 2
+    assert evidence["abstained_despite_hit"] is False
+    assert evidence["stale_candidate_above_answer"] is True
+    # noise_1 shares zero question keywords -> 1 of 3 retrieved is noise.
+    assert abs(evidence["noise_ratio"] - (1 / 3)) < 1e-9
+    # Not a temporal-reasoning question.
+    assert evidence["date_arithmetic_needed"] is None
+    assert evidence["answer_coverage_top5"] == 1.0
+
+
+def test_compute_evidence_stale_candidate_false_when_answer_ranked_first():
+    row = _result_row(retrieved_session_ids=["ans_1", "old_1", "noise_1"])
+    evidence = compute_evidence(row, _dataset_item())
+    assert evidence["answer_rank"] == 1
+    assert evidence["stale_candidate_above_answer"] is False
+
+
+def test_compute_evidence_stale_candidate_null_for_other_types():
+    row = _result_row(question_type="multi-session")
+    item = _dataset_item(question_type="multi-session")
+    evidence = compute_evidence(row, item)
+    assert evidence["stale_candidate_above_answer"] is None
+
+
+def test_compute_evidence_abstention_flags():
+    row = _result_row(hypothesis="I don't know.")
+    evidence = compute_evidence(row, _dataset_item())
+    assert evidence["abstained_despite_hit"] is True
+
+    row = _result_row(is_abstention=True, hypothesis="Porto")
+    evidence = compute_evidence(row, _dataset_item())
+    assert evidence["abstained_despite_hit"] is True
+
+
+def test_compute_evidence_temporal_question_sets_date_arithmetic():
+    row = _result_row(
+        question_type="temporal-reasoning",
+        question="How many days after the move did the user visit Lisbon?",
+    )
+    item = _dataset_item(
+        question_type="temporal-reasoning",
+        question="How many days after the move did the user visit Lisbon?",
+    )
+    evidence = compute_evidence(row, item)
+    assert evidence["date_arithmetic_needed"] is True
+
+
+def test_compute_evidence_partial_answer_coverage():
+    row = _result_row(
+        question_type="multi-session",
+        answer_session_ids=["ans_1", "missing_ans"],
+        retrieved_session_ids=["old_1", "ans_1"],
+    )
+    item = _dataset_item(
+        question_type="multi-session",
+        answer_session_ids=["ans_1", "missing_ans"],
+    )
+    evidence = compute_evidence(row, item)
+    assert evidence["answer_coverage_top5"] == 0.5
+
+
+# ---------------------------------------------------------------------------
+# suggested_mode heuristic
+# ---------------------------------------------------------------------------
+
+
+def _evidence(**overrides):
+    evidence = {
+        "answer_rank": 2,
+        "abstained_despite_hit": False,
+        "stale_candidate_above_answer": None,
+        "noise_ratio": 0.0,
+        "date_arithmetic_needed": None,
+        "answer_coverage_top5": 1.0,
+    }
+    evidence.update(overrides)
+    return evidence
+
+
+def test_suggested_mode_abstention_wins_first():
+    mode = suggested_mode("multi-session", _evidence(abstained_despite_hit=True))
+    assert mode == MODE_ANSWER_CONSTRUCTION
+
+
+def test_suggested_mode_stale_candidate_maps_to_outdated():
+    mode = suggested_mode("knowledge-update", _evidence(stale_candidate_above_answer=True))
+    assert mode == MODE_OUTDATED
+    mode = suggested_mode("single-session-preference", _evidence(stale_candidate_above_answer=True))
+    assert mode == MODE_OUTDATED
+
+
+def test_suggested_mode_knowledge_update_without_stale_is_conflict():
+    mode = suggested_mode("knowledge-update", _evidence(stale_candidate_above_answer=False))
+    assert mode == MODE_CONFLICT
+
+
+def test_suggested_mode_temporal_date_math_maps_to_missing_date_use():
+    mode = suggested_mode("temporal-reasoning", _evidence(date_arithmetic_needed=True))
+    assert mode == MODE_MISSING_DATE
+
+
+def test_suggested_mode_multi_session_partial_coverage_is_retrieval_gap():
+    mode = suggested_mode("multi-session", _evidence(answer_coverage_top5=0.5))
+    assert mode == MODE_RETRIEVAL_GAP
+
+
+def test_suggested_mode_answer_rank_one_is_answer_construction():
+    mode = suggested_mode("single-session-user", _evidence(answer_rank=1))
+    assert mode == MODE_ANSWER_CONSTRUCTION
+
+
+def test_suggested_mode_buried_answer_is_ranking():
+    mode = suggested_mode("single-session-user", _evidence(answer_rank=3))
+    assert mode == MODE_RANKING
+
+
+def test_suggested_mode_no_rank_falls_back_to_other():
+    mode = suggested_mode("single-session-user", _evidence(answer_rank=None))
+    assert mode == MODE_OTHER
+
+
+# ---------------------------------------------------------------------------
+# Selection filter
+# ---------------------------------------------------------------------------
+
+
+def test_select_failures_requires_incorrect_and_recall_hit():
+    details = [
+        _result_row(question_id="keep"),
+        _result_row(question_id="drop-correct", is_correct=True),
+        _result_row(question_id="drop-miss", recall_hit_at_5=False),
+        _result_row(question_id="drop-unknown", recall_hit_at_5=None),
+    ]
+    selected = select_failures(details, types=None)
+    assert [row["question_id"] for row in selected] == ["keep"]
+
+
+def test_select_failures_type_filter():
+    details = [
+        _result_row(question_id="ku", question_type="knowledge-update"),
+        _result_row(question_id="ms", question_type="multi-session"),
+        _result_row(question_id="ssu", question_type="single-session-user"),
+    ]
+    selected = select_failures(details, types={"multi-session", "knowledge-update"})
+    assert sorted(row["question_id"] for row in selected) == ["ku", "ms"]
+    # Default (types=None) keeps every failed-but-retrieved question type.
+    assert len(select_failures(details, types=None)) == 3
+
+
+# ---------------------------------------------------------------------------
+# Stage 1 end-to-end on synthetic data
+# ---------------------------------------------------------------------------
+
+
+def test_diagnose_stage1_end_to_end():
+    results = {"details": [_result_row(), _result_row(question_id="ok", is_correct=True)]}
+    dataset = [_dataset_item(), _dataset_item(question_id="ok")]
+    report = diagnose_stage1(results, dataset, types=None)
+
+    assert report["metadata"]["selected"] == 1
+    assert report["metadata"]["selected_by_type"] == {"knowledge-update": 1}
+    record = report["questions"][0]
+    assert record["question_id"] == "q-synth-1"
+    assert record["evidence"]["stale_candidate_above_answer"] is True
+    assert record["suggested_mode"] == MODE_OUTDATED
+    assert report["summary"]["mode_counts"][MODE_OUTDATED] == 1
+    assert report["summary"]["mode_counts_by_type"]["knowledge-update"][MODE_OUTDATED] == 1
+
+    text = format_summary(report)
+    assert "knowledge-update" in text
+    assert MODE_OUTDATED in text
+
+
+def test_diagnose_stage1_missing_dataset_entry_keeps_rank_evidence():
+    results = {"details": [_result_row(question_id="orphan")]}
+    report = diagnose_stage1(results, [], types=None)
+    record = report["questions"][0]
+    assert record["evidence"]["dataset_missing"] is True
+    # Dataset-dependent evidence is unavailable...
+    assert record["evidence"]["stale_candidate_above_answer"] is None
+    assert record["evidence"]["noise_ratio"] is None
+    # ...but rank evidence comes from the results row alone (answer at rank 2).
+    assert record["suggested_mode"] == MODE_RANKING
+
+
+# ---------------------------------------------------------------------------
+# Judge preflight
+# ---------------------------------------------------------------------------
+
+
+class _FakeCompletions:
+    def __init__(self, exc=None, content="OK"):
+        self.exc = exc
+        self.content = content
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.exc is not None:
+            raise self.exc
+        message = SimpleNamespace(content=self.content)
+        return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+class _FakeClient:
+    def __init__(self, exc=None, content="OK"):
+        self.chat = SimpleNamespace(completions=_FakeCompletions(exc=exc, content=content))
+
+
+def test_classify_judge_error_categories():
+    assert classify_judge_error(Exception("Error code: 429 - insufficient_quota")) == "quota"
+    assert classify_judge_error(Exception("Rate limit reached for gpt-5.4-mini")) == "quota"
+    assert classify_judge_error(Exception("Error code: 401 - invalid_api_key")) == "auth"
+    assert classify_judge_error(Exception("authentication failed")) == "auth"
+    assert classify_judge_error(Exception("connection reset")) == "other"
+
+
+def test_run_preflight_success_exits_zero():
+    client = _FakeClient()
+    code, message = run_preflight(model="gpt-5.4-mini-2026-03-17", client=client)
+    assert code == EXIT_OK
+    assert "gpt-5.4-mini-2026-03-17" in message
+    # gpt-5 family must use max_completion_tokens, not max_tokens.
+    call = client.chat.completions.calls[0]
+    assert "max_completion_tokens" in call
+    assert "max_tokens" not in call
+
+
+def test_run_preflight_quota_failure():
+    client = _FakeClient(exc=Exception("Error code: 429 - insufficient_quota"))
+    code, message = run_preflight(model="gpt-5.4-mini-2026-03-17", client=client)
+    assert code == EXIT_QUOTA
+    assert "quota" in message.lower() or "429" in message
+
+
+def test_run_preflight_auth_failure():
+    client = _FakeClient(exc=Exception("Error code: 401 - invalid_api_key"))
+    code, message = run_preflight(model="gpt-5.4-mini-2026-03-17", client=client)
+    assert code == EXIT_AUTH
+    assert "OPENAI_API_KEY" in message or "auth" in message.lower()
+
+
+def test_run_preflight_other_failure():
+    client = _FakeClient(exc=Exception("connection reset"))
+    code, message = run_preflight(model="gpt-5.4-mini-2026-03-17", client=client)
+    assert code == EXIT_OTHER
+    assert message
+
+
+# ---------------------------------------------------------------------------
+# Stage 2 with a mocked client (no network)
+# ---------------------------------------------------------------------------
+
+
+def test_run_stage2_with_mocked_client_records_labels_and_agreement():
+    results = {"details": [_result_row()]}
+    dataset = [_dataset_item()]
+    report = diagnose_stage1(results, dataset, types=None)
+    assert report["questions"][0]["suggested_mode"] == MODE_OUTDATED
+
+    client = _FakeClient(content='```json\n{"mode": "ranking", "rationale": "buried"}\n```')
+    run_stage2(report, dataset, model="gpt-5.4-mini-2026-03-17", client=client)
+
+    record = report["questions"][0]
+    assert record["llm_mode"] == MODE_RANKING
+    assert record["llm_rationale"] == "buried"
+    assert record["llm_error"] is None
+    agreement = report["agreement"]
+    assert agreement["matrix"] == {MODE_OUTDATED: {MODE_RANKING: 1}}
+    assert agreement["exact_agreement"] == 0.0
+    assert report["metadata"]["llm_stage"] is True
+    # Retrieved session content must appear in the prompt sent to the LLM.
+    prompt = client.chat.completions.calls[0]["messages"][0]["content"]
+    assert "Lisbon" in prompt
+    assert "ANSWER SESSION" in prompt
+
+
+def test_run_stage2_malformed_response_falls_back_to_other():
+    results = {"details": [_result_row()]}
+    dataset = [_dataset_item()]
+    report = diagnose_stage1(results, dataset, types=None)
+
+    client = _FakeClient(content="definitely not json")
+    run_stage2(report, dataset, model="gpt-5.4-mini-2026-03-17", client=client)
+
+    record = report["questions"][0]
+    assert record["llm_mode"] == MODE_OTHER
+    assert record["llm_error"]

--- a/tests/benchmarks/longmemeval/test_diagnose_failures.py
+++ b/tests/benchmarks/longmemeval/test_diagnose_failures.py
@@ -415,6 +415,7 @@ def test_run_stage2_with_mocked_client_records_labels_and_agreement():
     agreement = report["agreement"]
     assert agreement["matrix"] == {MODE_OUTDATED: {MODE_RANKING: 1}}
     assert agreement["exact_agreement"] == 0.0
+    assert agreement["llm_errors"] == 0
     assert report["metadata"]["llm_stage"] is True
     # Retrieved session content must appear in the prompt sent to the LLM.
     prompt = client.chat.completions.calls[0]["messages"][0]["content"]
@@ -433,3 +434,55 @@ def test_run_stage2_malformed_response_falls_back_to_other():
     record = report["questions"][0]
     assert record["llm_mode"] == MODE_OTHER
     assert record["llm_error"]
+    # Error records carry no labeling signal: excluded from agreement metrics.
+    agreement = report["agreement"]
+    assert agreement["llm_errors"] == 1
+    assert agreement["matrix"] == {}
+    assert agreement["exact_agreement"] is None
+
+
+class _FlakyCompletions:
+    """Raises on the call indices in ``fail_on``; succeeds otherwise."""
+
+    def __init__(self, fail_on, content):
+        self.fail_on = set(fail_on)
+        self.content = content
+        self.calls = []
+
+    def create(self, **kwargs):
+        index = len(self.calls)
+        self.calls.append(kwargs)
+        if index in self.fail_on:
+            raise RuntimeError("simulated transport failure")
+        message = SimpleNamespace(content=self.content)
+        return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+class _FlakyClient:
+    def __init__(self, fail_on, content):
+        self.chat = SimpleNamespace(completions=_FlakyCompletions(fail_on=fail_on, content=content))
+
+
+def test_run_stage2_transport_errors_excluded_from_agreement():
+    results = {"details": [_result_row(), _result_row(question_id="q-synth-2")]}
+    dataset = [_dataset_item(), _dataset_item(question_id="q-synth-2")]
+    report = diagnose_stage1(results, dataset, types=None)
+    assert [r["suggested_mode"] for r in report["questions"]] == [MODE_OUTDATED, MODE_OUTDATED]
+
+    # First LLM call raises (transport failure); second returns a valid label.
+    client = _FlakyClient(fail_on={0}, content='{"mode": "ranking", "rationale": "buried"}')
+    run_stage2(report, dataset, model="gpt-5.4-mini-2026-03-17", client=client)
+
+    errored, scored = report["questions"]
+    assert errored["llm_mode"] == MODE_OTHER
+    assert errored["llm_error"].startswith("RuntimeError")
+    assert scored["llm_mode"] == MODE_RANKING
+    assert scored["llm_error"] is None
+
+    agreement = report["agreement"]
+    assert agreement["llm_errors"] == 1
+    # Only the scored record lands in the matrix and the agreement rate.
+    assert agreement["matrix"] == {MODE_OUTDATED: {MODE_RANKING: 1}}
+    assert agreement["exact_agreement"] == 0.0
+    # Per-record llm_mode counts still cover every record, errors included.
+    assert agreement["llm_mode_counts"] == {MODE_OTHER: 1, MODE_RANKING: 1}

--- a/tests/benchmarks/longmemeval/test_longmemeval.py
+++ b/tests/benchmarks/longmemeval/test_longmemeval.py
@@ -630,7 +630,8 @@ Answer:"""
         """All recalled memories' session ids in rank order with per-memory score.
 
         Unlike _top_unique_session_ids this keeps every memory (duplicates
-        included) so failure diagnosis can see the full ranked pool.
+        included). Recorded in result artifacts for future rank-6-10 depth
+        analysis; not yet consumed by diagnose_failures.
         """
         rows: List[Dict[str, Any]] = []
         for memory in memories:

--- a/tests/benchmarks/longmemeval/test_longmemeval.py
+++ b/tests/benchmarks/longmemeval/test_longmemeval.py
@@ -87,6 +87,7 @@ class LongMemEvalResult(TypedDict, total=False):
     question_date: str
     answer_session_ids: List[str]
     retrieved_session_ids: List[str]
+    retrieved_session_ids_full: List[Dict[str, Any]]
     recall_hit_at_5: bool
     judge_attempts: int
     judge_error: Optional[str]
@@ -624,6 +625,22 @@ Question: {question}
 Answer:"""
         return prompt
 
+    @staticmethod
+    def _session_ids_with_scores(memories: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """All recalled memories' session ids in rank order with per-memory score.
+
+        Unlike _top_unique_session_ids this keeps every memory (duplicates
+        included) so failure diagnosis can see the full ranked pool.
+        """
+        rows: List[Dict[str, Any]] = []
+        for memory in memories:
+            metadata = memory.get("metadata") or {}
+            session_id = metadata.get("session_id")
+            if not session_id:
+                continue
+            rows.append({"session_id": session_id, "score": memory.get("score")})
+        return rows
+
     def generate_answer(
         self,
         question: str,
@@ -826,6 +843,7 @@ Answer:"""
             "question_date": question_date,
             "answer_session_ids": answer_session_ids,
             "retrieved_session_ids": retrieved_session_ids,
+            "retrieved_session_ids_full": self._session_ids_with_scores(memories),
             "recall_hit_at_5": recall_hit_at_5,
             "judge_attempts": judge_attempts,
             "judge_error": judge_error,
@@ -854,6 +872,7 @@ Answer:"""
             "question_date": item.get("question_date", ""),
             "answer_session_ids": list(item.get("answer_session_ids") or []),
             "retrieved_session_ids": [],
+            "retrieved_session_ids_full": [],
             "recall_hit_at_5": False,
             "judge_attempts": 0,
             "judge_error": None,


### PR DESCRIPTION
## Summary
- `tests/benchmarks/longmemeval/diagnose_failures.py`: two-stage classifier for failed-but-retrieved questions (`is_correct=false AND recall_hit_at_5=true`). Stage 1 is pure code (answer rank, abstention-despite-hit, stale-candidate-above-answer, noise ratio, date-math detection → documented 8-rule mode ladder); stage 2 (`--llm`) labels each failure with the pinned judge and reports a stage-1/stage-2 agreement matrix (transport errors counted and excluded).
- `tests/benchmarks/judge_preflight.py`: one minimal judge call before any judged run; exits non-zero with an actionable message on 429/insufficient_quota or auth failure. Wired into `test-longmemeval-benchmark.sh` (only when `--llm-eval`). Would have caught the June 6 quota-compromised runs before they started.
- Harness instrumentation: `retrieved_session_ids_full` (all 10 recalled memories + scores) recorded per question — closes the rank-6-10 blind spot for future runs.

## Findings on the canonical run (87.0% accuracy, recall@5 97.2%)
58 of 69 failures had the answer retrieved in the top 5. LLM labels (judge `gpt-5.4-mini-2026-03-17`): **answer-construction 42** (27 of them literal "I don't know" abstentions with the answer in context), missing-date-use 7, ranking 4, conflict-resolution 2, retrieval-gap 2, outdated-fact 1. This reprioritized the release: the harness answer-assembly path (see `feat/date-aware-ranking`) is the biggest benchmark lever; pure ranking fixes are the production-quality lever.

Report artifact: `benchmarks/results/failure_modes_canonical_llm_20260611.json` (local, gitignored).

## Testing
31 new tests (synthetic fixtures, mocked clients, no network); full suite 518 passed, 12 skipped; black + flake8 clean.

Refs #158, #159 (both issues require this failure-mode classification as their first acceptance criterion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)