### PR TITLE
fix(embedding): fall back to per-item real embeddings before placeholders in batch path

### DIFF
--- a/automem/embedding/runtime_helpers.py
+++ b/automem/embedding/runtime_helpers.py
@@ -105,18 +105,52 @@ def generate_real_embeddings_batch(
         logger.debug("No embedding provider available, falling back to placeholder embeddings")
         return [placeholder_embedding(c) for c in contents]
 
+    provider = state.embedding_provider
+    provider_name = provider.provider_name()
     expected_dim = state.effective_vector_size
     try:
-        embeddings = state.embedding_provider.generate_embeddings_batch(contents)
-        if not embeddings or any(
-            not isinstance(e, list) or len(e) != expected_dim for e in embeddings
+        embeddings = provider.generate_embeddings_batch(contents)
+        if (
+            not isinstance(embeddings, list)
+            or len(embeddings) != len(contents)
+            or any(not isinstance(e, list) or len(e) != expected_dim for e in embeddings)
         ):
-            logger.warning(
-                "Provider %s returned invalid dims in batch; using placeholders",
-                state.embedding_provider.provider_name() if state.embedding_provider else "unknown",
+            raise ValueError(
+                f"invalid batch result: expected {len(contents)} embeddings "
+                f"of {expected_dim} dims"
             )
-            return [placeholder_embedding(c) for c in contents]
         return embeddings
     except Exception as exc:
-        logger.warning("Failed to generate batch embeddings: %s", str(exc))
-        return [placeholder_embedding(c) for c in contents]
+        logger.warning(
+            "Batch embedding via provider %s failed (%s); "
+            "falling back to per-item embedding calls",
+            provider_name,
+            exc,
+        )
+
+    # Per-item fallback: single-input calls may succeed even when the batch
+    # endpoint fails (e.g. Voyage hanging on multi-input requests).
+    results: List[List[float]] = []
+    placeholder_count = 0
+    for content in contents:
+        try:
+            embedding = provider.generate_embedding(content)
+            if not isinstance(embedding, list) or len(embedding) != expected_dim:
+                raise ValueError(
+                    f"expected {expected_dim} dims, got "
+                    f"{len(embedding) if isinstance(embedding, list) else 'invalid'}"
+                )
+            results.append(embedding)
+        except Exception as exc:
+            logger.debug("Per-item embedding failed (%s); using placeholder", exc)
+            results.append(placeholder_embedding(content))
+            placeholder_count += 1
+
+    if placeholder_count:
+        logger.warning(
+            "%d/%d items fell back to placeholder embeddings — these will be "
+            "invisible to semantic search until re-embedded",
+            placeholder_count,
+            len(contents),
+        )
+    return results

--- a/automem/embedding/runtime_helpers.py
+++ b/automem/embedding/runtime_helpers.py
@@ -106,7 +106,10 @@ def generate_real_embeddings_batch(
         return [placeholder_embedding(c) for c in contents]
 
     provider = state.embedding_provider
-    provider_name = provider.provider_name()
+    try:
+        provider_name = provider.provider_name()
+    except Exception:
+        provider_name = provider.__class__.__name__ or "unknown"
     expected_dim = state.effective_vector_size
     try:
         embeddings = provider.generate_embeddings_batch(contents)

--- a/tests/test_embedding_runtime_helpers.py
+++ b/tests/test_embedding_runtime_helpers.py
@@ -153,6 +153,26 @@ def test_batch_wrong_dims_single_works_uses_real_embeddings(caplog):
     assert _placeholder("x") not in result
 
 
+def test_missing_provider_name_still_falls_back_to_single_embeddings(caplog):
+    """A custom provider without provider_name() should not bypass fallback."""
+
+    class Provider:
+        def generate_embeddings_batch(self, contents):
+            raise RuntimeError("read timeout")
+
+        def generate_embedding(self, content):
+            return _real_vector(content)
+
+    contents = ["alpha", "bravo!"]
+    result = _run(contents, Provider(), caplog)
+
+    assert result == [_real_vector(c) for c in contents]
+    warnings = _warning_messages(caplog)
+    assert len(warnings) == 1, f"expected exactly one warning, got: {warnings}"
+    assert "Provider" in warnings[0]
+    assert "read timeout" in warnings[0]
+
+
 # ==================== Batch and singles both fail ====================
 
 

--- a/tests/test_embedding_runtime_helpers.py
+++ b/tests/test_embedding_runtime_helpers.py
@@ -1,0 +1,247 @@
+"""Tests for automem.embedding.runtime_helpers batch embedding fallback logic.
+
+Regression coverage for the silent-placeholder bug: when the provider's
+batch endpoint fails (e.g. Voyage hanging on multi-input requests), the
+helper must fall back to per-item real embedding calls before resorting
+to placeholder (hash-based) embeddings, which are invisible to semantic
+search.
+"""
+
+import logging
+
+import pytest
+
+from automem.embedding.runtime_helpers import generate_real_embeddings_batch
+
+DIM = 4
+
+logger = logging.getLogger("test_embedding_runtime_helpers")
+
+
+def _placeholder(content: str) -> list:
+    """Sentinel placeholder vector, distinguishable from real embeddings."""
+    return [-1.0] * DIM
+
+
+def _real_vector(content: str) -> list:
+    """Deterministic per-content 'real' embedding."""
+    return [float(len(content))] * DIM
+
+
+class _State:
+    def __init__(self, provider):
+        self.embedding_provider = provider
+        self.effective_vector_size = DIM
+
+
+def _run(contents, provider, caplog):
+    with caplog.at_level(logging.DEBUG):
+        return generate_real_embeddings_batch(
+            contents,
+            init_embedding_provider=lambda: None,
+            state=_State(provider),
+            logger=logger,
+            placeholder_embedding=_placeholder,
+        )
+
+
+def _warning_messages(caplog):
+    return [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+# ==================== Happy path ====================
+
+
+def test_batch_success_returns_batch_result(caplog):
+    """When the provider batch call succeeds, its result is returned as-is."""
+
+    class Provider:
+        single_calls = 0
+
+        def provider_name(self):
+            return "voyage:voyage-4"
+
+        def generate_embeddings_batch(self, contents):
+            return [_real_vector(c) for c in contents]
+
+        def generate_embedding(self, content):
+            Provider.single_calls += 1
+            return _real_vector(content)
+
+    contents = ["alpha", "bravo!", "charlie7"]
+    result = _run(contents, Provider(), caplog)
+
+    assert result == [_real_vector(c) for c in contents]
+    assert Provider.single_calls == 0, "per-item fallback should not run on success"
+    assert _warning_messages(caplog) == []
+
+
+# ==================== Batch failure, singles work ====================
+
+
+def test_batch_raises_single_works_uses_real_embeddings(caplog):
+    """Batch call raises (Voyage multi-input hang): fall back to per-item
+    real embeddings — never placeholders."""
+
+    class Provider:
+        def provider_name(self):
+            return "voyage:voyage-4"
+
+        def generate_embeddings_batch(self, contents):
+            raise RuntimeError("read timeout")
+
+        def generate_embedding(self, content):
+            return _real_vector(content)
+
+    contents = ["alpha", "bravo!", "charlie7"]
+    result = _run(contents, Provider(), caplog)
+
+    assert len(result) == len(contents)
+    assert result == [_real_vector(c) for c in contents]
+    assert _placeholder("x") not in result, "no item should fall back to placeholder"
+
+    warnings = _warning_messages(caplog)
+    assert len(warnings) == 1, f"expected exactly one warning, got: {warnings}"
+    assert "voyage:voyage-4" in warnings[0]
+    assert "read timeout" in warnings[0]
+
+
+def test_batch_wrong_count_single_works_uses_real_embeddings(caplog):
+    """Batch returns the wrong number of vectors: fall back to per-item
+    real embeddings."""
+
+    class Provider:
+        def provider_name(self):
+            return "voyage:voyage-4"
+
+        def generate_embeddings_batch(self, contents):
+            return [_real_vector(contents[0])]  # 1 vector for 3 contents
+
+        def generate_embedding(self, content):
+            return _real_vector(content)
+
+    contents = ["alpha", "bravo!", "charlie7"]
+    result = _run(contents, Provider(), caplog)
+
+    assert len(result) == len(contents)
+    assert result == [_real_vector(c) for c in contents]
+    assert _placeholder("x") not in result
+
+    warnings = _warning_messages(caplog)
+    assert len(warnings) == 1, f"expected exactly one warning, got: {warnings}"
+    assert "voyage:voyage-4" in warnings[0]
+
+
+def test_batch_wrong_dims_single_works_uses_real_embeddings(caplog):
+    """Batch returns vectors with wrong dimensions: fall back to per-item
+    real embeddings."""
+
+    class Provider:
+        def provider_name(self):
+            return "voyage:voyage-4"
+
+        def generate_embeddings_batch(self, contents):
+            return [[0.5] * (DIM + 1) for _ in contents]
+
+        def generate_embedding(self, content):
+            return _real_vector(content)
+
+    contents = ["alpha", "bravo!"]
+    result = _run(contents, Provider(), caplog)
+
+    assert result == [_real_vector(c) for c in contents]
+    assert _placeholder("x") not in result
+
+
+# ==================== Batch and singles both fail ====================
+
+
+def test_batch_and_single_fail_uses_placeholders_with_summary_warning(caplog):
+    """Only when both batch AND per-item calls fail do we use placeholders,
+    and we must log a loud summary warning about semantic-search invisibility."""
+
+    class Provider:
+        def provider_name(self):
+            return "voyage:voyage-4"
+
+        def generate_embeddings_batch(self, contents):
+            raise RuntimeError("read timeout")
+
+        def generate_embedding(self, content):
+            raise RuntimeError("connection refused")
+
+    contents = ["alpha", "bravo!", "charlie7"]
+    result = _run(contents, Provider(), caplog)
+
+    assert result == [_placeholder(c) for c in contents]
+
+    warnings = _warning_messages(caplog)
+    summary = [w for w in warnings if "placeholder" in w]
+    assert summary, f"expected a placeholder summary warning, got: {warnings}"
+    assert "3/3" in summary[0]
+    assert "invisible to semantic search" in summary[0]
+
+
+def test_partial_single_failure_only_failed_items_get_placeholders(caplog):
+    """Items whose individual call fails get placeholders; the rest keep
+    real embeddings. Summary warning counts only the fallbacks."""
+
+    class Provider:
+        def provider_name(self):
+            return "voyage:voyage-4"
+
+        def generate_embeddings_batch(self, contents):
+            raise RuntimeError("read timeout")
+
+        def generate_embedding(self, content):
+            if content == "bravo!":
+                raise RuntimeError("transient failure")
+            return _real_vector(content)
+
+    contents = ["alpha", "bravo!", "charlie7"]
+    result = _run(contents, Provider(), caplog)
+
+    assert result == [
+        _real_vector("alpha"),
+        _placeholder("bravo!"),
+        _real_vector("charlie7"),
+    ]
+
+    summary = [w for w in _warning_messages(caplog) if "placeholder" in w]
+    assert summary, "expected a placeholder summary warning"
+    assert "1/3" in summary[0]
+    assert "invisible to semantic search" in summary[0]
+
+
+# ==================== Contract ====================
+
+
+def test_empty_contents_returns_empty_list(caplog):
+    class Provider:
+        def provider_name(self):
+            return "voyage:voyage-4"
+
+        def generate_embeddings_batch(self, contents):
+            raise AssertionError("should not be called")
+
+        def generate_embedding(self, content):
+            raise AssertionError("should not be called")
+
+    assert _run([], Provider(), caplog) == []
+
+
+def test_no_provider_uses_placeholders(caplog):
+    """No provider configured at all: placeholders (pre-existing behavior)."""
+    with caplog.at_level(logging.DEBUG):
+        result = generate_real_embeddings_batch(
+            ["alpha", "bravo!"],
+            init_embedding_provider=lambda: None,
+            state=_State(None),
+            logger=logger,
+            placeholder_embedding=_placeholder,
+        )
+    assert result == [_placeholder("alpha"), _placeholder("bravo!")]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

`generate_real_embeddings_batch` silently returned **placeholder (hash-based) embeddings for ALL items** whenever the provider's batch call raised or returned an invalid count/dims — and reported it as success. `POST /memory/batch` would respond `200` / `"qdrant: stored (N)"` while every memory in the batch got a garbage vector, making them **permanently invisible to semantic search**. The individual-embedding fallback inside `store_batch` was dead code, because the helper swallowed all failures upstream of it.

This was discovered during release verification on 2026-06-11, when a live Voyage API incident (multi-input embeddings requests hang to read-timeout; verified with bare raw API calls — n=1 returns in ~0.3s, n≥2 times out through all retries, ~92s per batch call) silently corrupted a LongMemEval seeding run and broke the recall@5 floor. Any client using `/memory/batch` during a provider outage hits the same corruption. (Production Railway logs have been checked — no Voyage errors there, so the production corpus appears unaffected by this incident.)

## Fix

When the provider's batch call raises or returns a wrong count/dims:

1. Fall back to **per-item `generate_embedding()` calls** (single-input calls kept working against Voyage throughout the incident).
2. Only items whose individual call *also* fails get a placeholder — never the whole batch.
3. The batch failure logs a WARNING with provider name and reason.
4. Any placeholder fallback logs a summary WARNING: `"N/M items fell back to placeholder embeddings — these will be invisible to semantic search until re-embedded"`, so the failure mode is observable instead of silent.

Retry policy and the single-embedding path are unchanged.

## Tests

8 new tests in `tests/test_embedding_runtime_helpers.py` (TDD'd against the bug first):

- batch raises → per-item fallback produces real embeddings
- batch returns wrong count → per-item fallback
- batch returns wrong dims → per-item fallback, single warning
- batch AND per-item fail → placeholders with `"3/3"` summary warning
- partial per-item failure → only failed item placeholdered (`"1/3"`)
- happy path unchanged, empty input, no-provider passthrough

Full suite green.

## Follow-ups (not in this PR)

- An embedding-fallback **metric** (extending the fallback-rate pattern from #188) so a spike is alertable, not just greppable.
- Unbounded keyword score component (`keyword=11.0` observed) — separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)