### PR TITLE
fix(recall): normalize graph keyword scores into the 0-1 component range

### DIFF
--- a/automem/search/runtime_recall_helpers.py
+++ b/automem/search/runtime_recall_helpers.py
@@ -634,6 +634,10 @@ def _graph_keyword_search(
 
         if keywords:
             params.update({"keywords": keywords, "phrase": phrase})
+            # Raw Cypher maximum: content (+2) and tag (+1) per keyword, plus
+            # the whole-phrase bonus (+2 content, +1 tag). Used to normalize
+            # scores into 0-1 so the keyword channel blends with the others.
+            max_raw_score = 3 * len(keywords) + (3 if phrase else 0)
             query = f"""
                 MATCH (m:Memory)
                 WHERE {where_clause}
@@ -656,6 +660,7 @@ def _graph_keyword_search(
             result = graph.query(query, params)
         elif phrase:
             params.update({"phrase": phrase})
+            max_raw_score = 3
             query = f"""
                 MATCH (m:Memory)
                 WHERE {where_clause}
@@ -690,6 +695,8 @@ def _graph_keyword_search(
     for row in getattr(result, "result_set", []) or []:
         node = row[0]
         score = row[1] if len(row) > 1 else None
+        if score is not None and max_raw_score > 0:
+            score = min(1.0, float(score) / max_raw_score)
         record = _format_graph_result(graph, node, score, "keyword", seen_ids)
         if record is None:
             continue

--- a/automem/utils/scoring.py
+++ b/automem/utils/scoring.py
@@ -159,7 +159,10 @@ def _compute_metadata_score(
     )
     keyword_component = 0.0
     if result.get("match_type") in {"keyword", "trending"}:
-        keyword_component = result.get("match_score", 0.0)
+        # Producers normalize, but no channel may exceed the 0-1 component
+        # contract (issue #190) — an unclamped score also defeats the
+        # RECALL_RELEVANCE_GATE evidence check.
+        keyword_component = min(1.0, float(result.get("match_score", 0.0) or 0.0))
     elif tokens:
         content_lower = str(memory.get("content") or "").lower()
         if content_lower:

--- a/tests/test_keyword_score_normalization.py
+++ b/tests/test_keyword_score_normalization.py
@@ -13,13 +13,33 @@ from types import SimpleNamespace
 
 import pytest
 
-from automem.search.runtime_recall_helpers import (
-    _graph_keyword_search,
-    configure_recall_helpers,
-)
+import automem.search.runtime_recall_helpers as recall_helpers
+from automem.search.runtime_recall_helpers import _graph_keyword_search, configure_recall_helpers
 from automem.utils.scoring import _compute_metadata_score
 from automem.utils.text import _extract_keywords
 from tests.support.fake_graph import FakeNode, FakeResult
+
+_HELPER_STATE_ATTRS = (
+    "_parse_iso_datetime",
+    "_prepare_tag_filters",
+    "_build_graph_tag_predicate",
+    "_build_qdrant_tag_filter",
+    "_serialize_node",
+    "_fetch_relations",
+    "_extract_keywords",
+    "_coerce_embedding",
+    "_generate_real_embedding",
+    "_logger",
+    "_collection_name",
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_recall_helper_state():
+    previous = {name: getattr(recall_helpers, name) for name in _HELPER_STATE_ATTRS}
+    yield
+    for name, value in previous.items():
+        setattr(recall_helpers, name, value)
 
 
 class _ScriptedGraph:

--- a/tests/test_keyword_score_normalization.py
+++ b/tests/test_keyword_score_normalization.py
@@ -1,0 +1,138 @@
+"""Regression tests for issue #190: keyword scores must stay within 0-1.
+
+The graph keyword search Cypher returns a raw additive score (up to
+3 * len(keywords) + 3 with a phrase bonus). That raw value must be
+normalized before it reaches score blending, where every other channel
+(vector cosine, metadata, trending importance) lives in 0-1.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from automem.search.runtime_recall_helpers import (
+    _graph_keyword_search,
+    configure_recall_helpers,
+)
+from automem.utils.scoring import _compute_metadata_score
+from automem.utils.text import _extract_keywords
+from tests.support.fake_graph import FakeNode, FakeResult
+
+
+class _ScriptedGraph:
+    """Graph stub returning preset [node, raw_score] rows for any query."""
+
+    def __init__(self, rows):
+        self._rows = rows
+        self.queries = []
+
+    def query(self, query, params=None):
+        self.queries.append((query, params))
+        return FakeResult(self._rows)
+
+
+def _configure_helpers() -> None:
+    configure_recall_helpers(
+        parse_iso_datetime=lambda value: (
+            datetime.fromisoformat(str(value).replace("Z", "+00:00")) if value else None
+        ),
+        prepare_tag_filters=lambda tags: [
+            str(tag).strip().lower() for tag in (tags or []) if isinstance(tag, str) and tag.strip()
+        ],
+        build_graph_tag_predicate=lambda _mode, _match: "true",
+        build_qdrant_tag_filter=lambda *_args, **_kwargs: None,
+        serialize_node=lambda node: dict(getattr(node, "properties", node)),
+        fetch_relations=lambda *_args, **_kwargs: [],
+        extract_keywords=_extract_keywords,
+        coerce_embedding=lambda _value: None,
+        generate_real_embedding=lambda _text: [0.1, 0.2, 0.3],
+        logger=SimpleNamespace(exception=lambda *_args, **_kwargs: None),
+        collection_name="memories",
+    )
+
+
+def _node(memory_id: str) -> FakeNode:
+    return FakeNode(
+        {
+            "id": memory_id,
+            "content": f"content for {memory_id}",
+            "tags": ["automem"],
+            "importance": 0.5,
+            "timestamp": "2026-06-11T00:00:00+00:00",
+        }
+    )
+
+
+def test_keyword_scores_are_normalized_to_unit_range() -> None:
+    _configure_helpers()
+    query_text = "automem keyword scoring"
+    keywords = _extract_keywords(query_text.strip().lower())
+    assert keywords, "fixture query must extract keywords"
+    # Raw Cypher maximum: content (+2) and tag (+1) per keyword, plus the
+    # whole-phrase bonus (+2 content, +1 tag).
+    max_raw = 3 * len(keywords) + 3
+
+    graph = _ScriptedGraph(
+        [
+            [_node("mem-max"), max_raw],
+            [_node("mem-partial"), 2],
+        ]
+    )
+    results = _graph_keyword_search(graph, query_text, limit=10, seen_ids=set())
+
+    assert [r["id"] for r in results] == ["mem-max", "mem-partial"]
+    by_id = {r["id"]: r for r in results}
+    assert by_id["mem-max"]["match_score"] == pytest.approx(1.0)
+    assert by_id["mem-partial"]["match_score"] == pytest.approx(2 / max_raw)
+    for record in results:
+        assert 0.0 <= record["match_score"] <= 1.0
+        assert record["score"] == record["match_score"]
+
+
+def test_keyword_score_observed_repro_stays_below_one() -> None:
+    """The production repro: 3 keywords fully matched + phrase hit = raw 11."""
+    _configure_helpers()
+    query_text = "automem keyword scoring"
+    keywords = _extract_keywords(query_text.strip().lower())
+    assert len(keywords) == 3
+    graph = _ScriptedGraph([[_node("mem-repro"), 11]])
+
+    results = _graph_keyword_search(graph, query_text, limit=10, seen_ids=set())
+
+    assert results[0]["match_score"] == pytest.approx(11 / 12)
+
+
+def test_phrase_only_query_normalizes_against_phrase_maximum() -> None:
+    _configure_helpers()
+    # Stop-word-only query: no keywords extracted, phrase branch used.
+    query_text = "from the with"
+    assert _extract_keywords(query_text) == []
+    graph = _ScriptedGraph([[_node("mem-phrase"), 2]])
+
+    results = _graph_keyword_search(graph, query_text, limit=10, seen_ids=set())
+
+    assert results[0]["match_score"] == pytest.approx(2 / 3)
+
+
+def test_consumer_clamps_keyword_component_to_one() -> None:
+    """Even if a producer misbehaves, the blend must never see keyword > 1."""
+    result = {
+        "match_type": "keyword",
+        "match_score": 11.0,
+        "memory": {
+            "id": "mem-1",
+            "content": "automem keyword scoring memory",
+            "tags": ["automem"],
+            "importance": 0.9,
+            "timestamp": "2026-06-11T00:00:00+00:00",
+        },
+    }
+    final, components = _compute_metadata_score(
+        result, "automem keyword scoring", ["automem", "keyword", "scoring"]
+    )
+
+    assert components["keyword"] == pytest.approx(1.0)
+    assert final < 2.0


### PR DESCRIPTION
Fixes #190.

## Problem

`_graph_keyword_search` returned the **raw Cypher additive score** — +2 per keyword contained in content, +1 per keyword in any tag, summed over all extracted keywords, plus a +2/+1 whole-phrase bonus — so a K-keyword query can score up to **3K+3** while every other channel (vector cosine, metadata, trending importance) lives in 0–1.

Observed during the 2026-06-11 production forensics: a tag-scoped exact-content match returned `keyword=11.0`, `final_score=4.03`. Consequences:

- `SEARCH_WEIGHT_KEYWORD (0.35) × 11 = 3.85` — a keyword hit trumps any vector/metadata/importance combination, scaling with *query length* rather than match quality.
- Defeats `RECALL_RELEVANCE_GATE` semantics (PR #186): `evidence = max(vector, keyword, metadata, exact)` assumes 0–1 components; `evidence = 11` sails past any gate.

## Fix

1. **Producer**: normalize the raw score by its per-query maximum (`3·len(keywords) + 3` when a phrase is present; `3` in the phrase-only branch) before it leaves `_graph_keyword_search`. This is a monotone per-query transform — within-channel ordering (and the Cypher `ORDER BY`) is unchanged; only cross-channel blending changes, which is the point.
2. **Consumer**: defensively clamp the keyword component to `min(1.0, …)` in `_compute_metadata_score`, so no future producer can break the 0–1 contract or the gate again.

## Verification

- 4 new tests in `tests/test_keyword_score_normalization.py` (TDD'd against the bug, including the literal `keyword=11.0` repro). Full suite: **503 passed**.
- **Production-corpus lab A/B** (10,142-memory snapshot, 200 queries, vs the pooled 3-run parity baseline from the 2026-06-11 release sweep):
  - Recall@5 −0.2pp, Recall@10 −0.7pp, MRR −0.008, NDCG@10 −0.007 (all within baseline run-to-run variance; paired t-test p=0.32)
  - Per-query: **196/197 unchanged**, 0 improved, 1 regressed
  - The single flip is the intended behavior change made visible: the expected memory held rank 1 *only* via the inflated keyword score (ranks 2–5 identical before/after). It's in the fallback-typed `Memory` cohort (MRR 0.15 baseline — the known data-quality cohort from #188's classification incident).

## Notes

- This lands on main independently of the #182–#187 chain; #186's gate evidence check is the main beneficiary once the chain rebases over it.
- Trending (`importance`), metadata (capped), and vector (cosine) channels were verified already bounded; the graph keyword channel was the only unbounded producer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)