### PR TITLE
ci(docs): dispatch docs updates on main merges

### DIFF
--- a/.github/workflows/docs-dispatch.yml
+++ b/.github/workflows/docs-dispatch.yml
@@ -1,0 +1,159 @@
+name: Docs Dispatch
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      base_sha:
+        description: "Base SHA or ref for the docs diff. Defaults to head^."
+        required: false
+      head_sha:
+        description: "Head SHA or ref to document. Defaults to main."
+        required: false
+      reason:
+        description: "Why docs should be audited."
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  check-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_BASE_REF: ${{ inputs.base_sha }}
+          INPUT_HEAD_REF: ${{ inputs.head_sha }}
+          INPUT_REASON: ${{ inputs.reason }}
+          PUSH_BASE_REF: ${{ github.event.before }}
+          PUSH_HEAD_REF: ${{ github.event.after }}
+        run: |
+          ZERO_SHA="0000000000000000000000000000000000000000"
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            HEAD_REF="${INPUT_HEAD_REF:-main}"
+            BASE_REF="$INPUT_BASE_REF"
+            REASON="${INPUT_REASON:-Manual docs dispatch for ${HEAD_REF}}"
+          else
+            HEAD_REF="$PUSH_HEAD_REF"
+            BASE_REF="$PUSH_BASE_REF"
+            REASON="Push to main"
+          fi
+
+          HEAD_SHA=$(git rev-parse "$HEAD_REF")
+
+          if [ -z "$BASE_REF" ]; then
+            if git rev-parse --verify "${HEAD_REF}^" >/dev/null 2>&1; then
+              BASE_REF="${HEAD_REF}^"
+            else
+              BASE_REF=$(git rev-list --max-parents=0 "$HEAD_SHA")
+            fi
+          fi
+
+          if [ "$BASE_REF" = "$ZERO_SHA" ]; then
+            echo "::warning::No previous SHA found, diffing against first commit"
+            BASE_SHA=$(git rev-list --max-parents=0 "$HEAD_SHA")
+          else
+            BASE_SHA=$(git rev-parse "$BASE_REF")
+          fi
+
+          COMMIT_URL="https://github.com/${GITHUB_REPOSITORY}/commit/${HEAD_SHA}"
+          COMPARE_URL="https://github.com/${GITHUB_REPOSITORY}/compare/${BASE_SHA}...${HEAD_SHA}"
+          FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" | jq -R -s -c 'split("\n") | map(select(. != ""))')
+
+          {
+            echo "base_sha=$BASE_SHA"
+            echo "head_sha=$HEAD_SHA"
+            echo "files=$FILES"
+            echo "commit_url=$COMMIT_URL"
+            echo "compare_url=$COMPARE_URL"
+            echo "reason<<EOF"
+            echo "$REASON"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check file-doc mapping
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          CHANGED_FILES: ${{ steps.changed.outputs.files }}
+        run: |
+          if ! MAP=$(curl -fsSL --connect-timeout 10 --max-time 30 --retry 2 --retry-connrefused \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github.raw" \
+            "https://api.github.com/repos/verygoodplugins/automem-website/contents/scripts/file-doc-map.json"); then
+            echo "::warning::Failed to fetch file-doc-map.json, dispatching anyway"
+            echo "affected=unknown" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          REPO_KEY="${GITHUB_REPOSITORY#*/}"
+
+          AFFECTED=$(echo "$MAP" | jq -r --arg repo "$REPO_KEY" --argjson changed "$CHANGED_FILES" '
+            def matches_pattern($file; $pattern):
+              if ($pattern | endswith("/**")) then
+                ($file | startswith($pattern[0:-2]))
+              else
+                $file == $pattern
+              end;
+
+            .[$repo] // {} | to_entries | map(
+              select(.key as $pattern | $changed | any(. as $file | matches_pattern($file; $pattern)))
+            ) | map(.value) | flatten | unique | .[]
+          ')
+
+          if [ -z "$AFFECTED" ]; then
+            echo "No doc pages affected by this change"
+            echo "affected=none" >> "$GITHUB_OUTPUT"
+          else
+            AFFECTED_JSON=$(echo "$AFFECTED" | jq -R -s -c 'split("\n") | map(select(. != ""))')
+            echo "Affected doc pages: $AFFECTED_JSON"
+            echo "affected=$AFFECTED_JSON" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Dispatch to automem-website
+        if: steps.check.outputs.affected != 'none'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          SOURCE_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ steps.changed.outputs.head_sha }}
+          BASE_SHA: ${{ steps.changed.outputs.base_sha }}
+          CHANGED_FILES: ${{ steps.changed.outputs.files }}
+          AFFECTED_DOCS: ${{ steps.check.outputs.affected }}
+          REASON: ${{ steps.changed.outputs.reason }}
+          COMMIT_URL: ${{ steps.changed.outputs.commit_url }}
+          COMPARE_URL: ${{ steps.changed.outputs.compare_url }}
+        run: |
+          jq -n \
+            --arg event_type "docs-update" \
+            --arg source_repo "$SOURCE_REPO" \
+            --arg source_sha "$HEAD_SHA" \
+            --arg base_sha "$BASE_SHA" \
+            --arg head_sha "$HEAD_SHA" \
+            --arg changed_files "$CHANGED_FILES" \
+            --arg affected_docs "$AFFECTED_DOCS" \
+            --arg reason "$REASON" \
+            --arg commit_url "$COMMIT_URL" \
+            --arg compare_url "$COMPARE_URL" \
+            '{
+              event_type: $event_type,
+              client_payload: {
+                source_repo: $source_repo,
+                source_sha: $source_sha,
+                base_sha: $base_sha,
+                head_sha: $head_sha,
+                changed_files: ($changed_files | fromjson),
+                affected_docs: (try ($affected_docs | fromjson) catch $affected_docs),
+                reason: $reason,
+                commit_url: $commit_url,
+                compare_url: $compare_url
+              }
+            }' | gh api repos/verygoodplugins/automem-website/dispatches --input -

--- a/.github/workflows/docs-dispatch.yml
+++ b/.github/workflows/docs-dispatch.yml
@@ -54,13 +54,13 @@ jobs:
             if git rev-parse --verify "${HEAD_REF}^" >/dev/null 2>&1; then
               BASE_REF="${HEAD_REF}^"
             else
-              BASE_REF=$(git rev-list --max-parents=0 "$HEAD_SHA")
+              BASE_REF=$(git rev-list --max-parents=0 --max-count=1 "$HEAD_SHA")
             fi
           fi
 
           if [ "$BASE_REF" = "$ZERO_SHA" ]; then
             echo "::warning::No previous SHA found, diffing against first commit"
-            BASE_SHA=$(git rev-list --max-parents=0 "$HEAD_SHA")
+            BASE_SHA=$(git rev-list --max-parents=0 --max-count=1 "$HEAD_SHA")
           else
             BASE_SHA=$(git rev-parse "$BASE_REF")
           fi
@@ -91,7 +91,8 @@ jobs:
             -H "Accept: application/vnd.github.raw" \
             "https://api.github.com/repos/verygoodplugins/automem-website/contents/scripts/file-doc-map.json"); then
             echo "::warning::Failed to fetch file-doc-map.json, dispatching anyway"
-            echo "affected=unknown" >> "$GITHUB_OUTPUT"
+            echo "affected=[]" >> "$GITHUB_OUTPUT"
+            echo "mapping_status=unknown" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -112,15 +113,17 @@ jobs:
 
           if [ -z "$AFFECTED" ]; then
             echo "No doc pages affected by this change"
-            echo "affected=none" >> "$GITHUB_OUTPUT"
+            echo "affected=[]" >> "$GITHUB_OUTPUT"
+            echo "mapping_status=none" >> "$GITHUB_OUTPUT"
           else
             AFFECTED_JSON=$(echo "$AFFECTED" | jq -R -s -c 'split("\n") | map(select(. != ""))')
             echo "Affected doc pages: $AFFECTED_JSON"
             echo "affected=$AFFECTED_JSON" >> "$GITHUB_OUTPUT"
+            echo "mapping_status=matched" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Dispatch to automem-website
-        if: steps.check.outputs.affected != 'none'
+        if: steps.check.outputs.mapping_status != 'none'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           SOURCE_REPO: ${{ github.repository }}
@@ -128,6 +131,7 @@ jobs:
           BASE_SHA: ${{ steps.changed.outputs.base_sha }}
           CHANGED_FILES: ${{ steps.changed.outputs.files }}
           AFFECTED_DOCS: ${{ steps.check.outputs.affected }}
+          MAPPING_STATUS: ${{ steps.check.outputs.mapping_status }}
           REASON: ${{ steps.changed.outputs.reason }}
           COMMIT_URL: ${{ steps.changed.outputs.commit_url }}
           COMPARE_URL: ${{ steps.changed.outputs.compare_url }}
@@ -140,6 +144,7 @@ jobs:
             --arg head_sha "$HEAD_SHA" \
             --arg changed_files "$CHANGED_FILES" \
             --arg affected_docs "$AFFECTED_DOCS" \
+            --arg mapping_status "$MAPPING_STATUS" \
             --arg reason "$REASON" \
             --arg commit_url "$COMMIT_URL" \
             --arg compare_url "$COMPARE_URL" \
@@ -151,7 +156,8 @@ jobs:
                 base_sha: $base_sha,
                 head_sha: $head_sha,
                 changed_files: ($changed_files | fromjson),
-                affected_docs: (try ($affected_docs | fromjson) catch $affected_docs),
+                affected_docs: ($affected_docs | fromjson),
+                mapping_status: $mapping_status,
                 reason: $reason,
                 commit_url: $commit_url,
                 compare_url: $compare_url

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,8 @@
 #    - Updates version in pyproject.toml/setup.py
 #    - Updates CHANGELOG.md
 #    - Creates a GitHub Release with tag (v0.9.3, etc.)
-#    - The release triggers the docs-dispatch job below
+#
+# Docs dispatch is handled separately by docs-dispatch.yml on main pushes.
 #
 # Commit message format:
 #   feat: add new feature          → minor version bump (0.9.0 → 0.10.0)
@@ -41,90 +42,3 @@ jobs:
         with:
           release-type: python
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-
-  # Dispatch docs update to automem-website when a release is created
-  docs-dispatch:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Get changed files since last release
-        id: changed
-        run: |
-          CURR_TAG="${{ needs.release-please.outputs.tag_name }}"
-          # Get the tag before the current one
-          PREV_TAG=$(git tag --sort=-version:refname | grep -F -x -v -- "$CURR_TAG" | head -1)
-
-          if [ -z "$PREV_TAG" ]; then
-            echo "::warning::No previous tag found, diffing against first commit"
-            PREV_TAG=$(git rev-list --max-parents=0 HEAD)
-          fi
-
-          echo "Diffing $PREV_TAG..$CURR_TAG"
-          FILES=$(git diff --name-only "$PREV_TAG" "$CURR_TAG" | jq -R -s -c 'split("\n") | map(select(. != ""))')
-          echo "files=$FILES" >> $GITHUB_OUTPUT
-
-      - name: Check file-doc mapping
-        id: check
-        env:
-          CHANGED_FILES: ${{ steps.changed.outputs.files }}
-        run: |
-          if ! MAP=$(curl -sf --connect-timeout 10 --max-time 30 --retry 2 --retry-connrefused \
-            -H "Authorization: token ${{ secrets.RELEASE_PLEASE_TOKEN }}" \
-            "https://raw.githubusercontent.com/verygoodplugins/automem-website/main/scripts/file-doc-map.json"); then
-            echo "::warning::Failed to fetch file-doc-map.json, dispatching anyway"
-            echo "affected=unknown" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          REPO_KEY="${{ github.event.repository.name }}"
-          CHANGED="$CHANGED_FILES"
-
-          AFFECTED=$(echo "$MAP" | jq -r --arg repo "$REPO_KEY" --argjson changed "$CHANGED" '
-            def matches_pattern($file; $pattern):
-              if ($pattern | endswith("/**")) then
-                ($file | startswith($pattern[0:-2]))
-              else
-                $file == $pattern
-              end;
-
-            .[$repo] // {} | to_entries | map(
-              select(.key as $pattern | $changed | any(. as $file | matches_pattern($file; $pattern)))
-            ) | map(.value) | flatten | unique | .[]
-          ')
-
-          if [ -z "$AFFECTED" ]; then
-            echo "No doc pages affected by this release"
-            echo "affected=none" >> $GITHUB_OUTPUT
-          else
-            AFFECTED_JSON=$(echo "$AFFECTED" | jq -R -s -c 'split("\n") | map(select(. != ""))')
-            echo "Affected doc pages: $AFFECTED_JSON"
-            echo "affected=$AFFECTED_JSON" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Dispatch to automem-website
-        if: steps.check.outputs.affected != 'none'
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-        run: |
-          jq -n \
-            --arg event_type "docs-update" \
-            --arg source_repo "${{ github.event.repository.full_name }}" \
-            --arg source_sha "${{ needs.release-please.outputs.tag_name }}" \
-            --arg changed_files '${{ steps.changed.outputs.files }}' \
-            --arg affected_docs '${{ steps.check.outputs.affected }}' \
-            --arg reason "Release ${{ needs.release-please.outputs.tag_name }}" \
-            '{
-              event_type: $event_type,
-              client_payload: {
-                source_repo: $source_repo,
-                source_sha: $source_sha,
-                changed_files: ($changed_files | fromjson),
-                affected_docs: (try ($affected_docs | fromjson) catch $affected_docs),
-                reason: $reason
-              }
-            }' | gh api repos/verygoodplugins/automem-website/dispatches --input -


### PR DESCRIPTION
## Summary
- add a standalone docs-dispatch workflow that runs on main pushes and manual backfills
- dispatch docs-update payloads with changed_files and affected_docs preserved as JSON arrays
- remove the release-please docs dispatch job so releases do not batch docs audits

## Breaking changes
None.

## Related issues
None.

## Tests
- Ruby YAML parse for all changed workflows
- actionlint for all changed workflows
- fixture checks for push diff ranges, /** mapping, JSON payload shape, and auto-merge guard wording
- git diff --check