### PR TITLE
feat(eval): recall-quality optimization harness — lab foundation + design

### DIFF
--- a/docs/superpowers/plans/2026-06-16-lab-metric-foundation.md
+++ b/docs/superpowers/plans/2026-06-16-lab-metric-foundation.md
@@ -1,0 +1,1180 @@
+# Lab Metric Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Upgrade the AutoMem Recall Quality Lab so its optimization target is the legible scorecard from the spec — NDCG@10 primary, distractor-precision guardrail, simplicity + latency tiebreakers — with distractor injection, configurable recall params, and a real consolidation step, all unit-tested.
+
+**Architecture:** Extract pure logic from `scripts/lab/run_recall_test.py` into two focused, importable modules — `scripts/lab/lab_metrics.py` (metrics, scorecard, decision rule) and `scripts/lab/lab_corpus.py` (recall-with-params, distractor injection, backdating, consolidation). `run_recall_test.py` becomes thin orchestration that imports both. The matrix harness (Plan B) imports the same modules, so there is one source of truth for scoring.
+
+**Tech Stack:** Python 3.12, `requests`, pytest (pure-Python stats already in-repo, no scipy). HTTP-touching functions take an injectable client (`http_get`/`http_post`) so tests never hit a live server.
+
+## Global Constraints
+
+- Branch: `eval/recall-quality-harness`. **Do NOT stage, commit, stash, or revert** the unrelated pre-existing WIP (`automem/api/memory.py`, `docs/API.md`, `docs/MCP_SSE.md`, `mcp-sse-server/*`, `tests/support/fake_graph.py`, `tests/test_api_endpoints.py`). Only `git add` the exact files each task names.
+- Run tests with plugin autoload disabled: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest <path> -v`.
+- AutoMem `/recall` nests memory fields under `result["memory"]` (e.g. `result["memory"]["content"]`); the existing `r.get("memory", r)` pattern handles both shapes — preserve it.
+- Distractor tag is the bare slug `lab-distractor` (bare-tag convention; no namespace prefix).
+- No secrets in code or fixtures. No new network calls in unit tests.
+- Format with `black .` and lint with `flake8` before each commit.
+- Pure functions only in `lab_metrics.py` (no I/O). All HTTP lives in `lab_corpus.py` behind injectable clients.
+
+---
+
+### Task 1: Extract metrics into `lab_metrics.py` (refactor, no behavior change)
+
+Move the existing pure metric functions out of the CLI script into an importable module, and pin their behavior with characterization tests. No metric math changes in this task.
+
+**Files:**
+- Create: `scripts/lab/lab_metrics.py`
+- Create: `tests/lab/conftest.py`
+- Create: `tests/lab/test_lab_metrics.py`
+- Modify: `scripts/lab/run_recall_test.py` (import from the new module instead of defining locally)
+
+**Interfaces:**
+- Produces: `recall_at_k(retrieved_ids: list[str], expected_ids: list[str], k: int) -> float`, `mrr(retrieved_ids, expected_ids) -> float`, `ndcg_at_k(retrieved_ids, expected_ids, k: int) -> float`, `paired_ttest(a: list[float], b: list[float]) -> dict` — identical signatures/behavior to the current functions in `run_recall_test.py:47-122`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/lab/conftest.py`:
+
+```python
+import sys
+from pathlib import Path
+
+# Make scripts/lab importable without packaging the scripts dir.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "lab"))
+```
+
+Create `tests/lab/test_lab_metrics.py`:
+
+```python
+import lab_metrics as m
+
+
+def test_recall_at_k_counts_hits_in_top_k():
+    assert m.recall_at_k(["a", "b", "c"], ["c"], 5) == 1.0
+    assert m.recall_at_k(["a", "b", "c"], ["c"], 2) == 0.0
+    assert m.recall_at_k([], ["c"], 5) == 0.0
+
+
+def test_mrr_uses_first_hit_rank():
+    assert m.mrr(["a", "b", "c"], ["b"]) == 0.5
+    assert m.mrr(["a", "b", "c"], ["z"]) == 0.0
+
+
+def test_ndcg_at_k_rewards_top_rank():
+    top = m.ndcg_at_k(["x", "a", "b"], ["x"], 10)
+    buried = m.ndcg_at_k(["a", "b", "x"], ["x"], 10)
+    assert top == 1.0
+    assert 0.0 < buried < top
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/lab/test_lab_metrics.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'lab_metrics'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `scripts/lab/lab_metrics.py` by moving the four functions verbatim from `run_recall_test.py`:
+
+```python
+"""Pure scoring functions for the AutoMem Recall Quality Lab.
+
+No I/O lives here — every function is deterministic and unit-testable.
+Imported by run_recall_test.py and by the parallel matrix harness.
+"""
+
+import math
+from typing import Any, Dict, List
+
+
+def recall_at_k(retrieved_ids: List[str], expected_ids: List[str], k: int) -> float:
+    """Fraction of expected IDs found in top-K results."""
+    if not expected_ids:
+        return 0.0
+    top_k = set(retrieved_ids[:k])
+    hits = sum(1 for eid in expected_ids if eid in top_k)
+    return hits / len(expected_ids)
+
+
+def mrr(retrieved_ids: List[str], expected_ids: List[str]) -> float:
+    """Mean Reciprocal Rank — position of first relevant result."""
+    expected_set = set(expected_ids)
+    for i, rid in enumerate(retrieved_ids):
+        if rid in expected_set:
+            return 1.0 / (i + 1)
+    return 0.0
+
+
+def ndcg_at_k(retrieved_ids: List[str], expected_ids: List[str], k: int) -> float:
+    """Normalized Discounted Cumulative Gain at K."""
+    expected_set = set(expected_ids)
+    dcg = 0.0
+    for i, rid in enumerate(retrieved_ids[:k]):
+        if rid in expected_set:
+            dcg += 1.0 / math.log2(i + 2)
+    ideal_dcg = sum(1.0 / math.log2(i + 2) for i in range(min(len(expected_ids), k)))
+    return dcg / ideal_dcg if ideal_dcg > 0 else 0.0
+
+
+def paired_ttest(a: List[float], b: List[float]) -> Dict[str, Any]:
+    """Paired t-test + Cohen's d effect size. Pure Python, no scipy needed."""
+    n = len(a)
+    if n < 2 or n != len(b):
+        return {"p_value": 1.0, "t_stat": 0.0, "effect_size": 0.0, "significant": False}
+
+    diffs = [b[i] - a[i] for i in range(n)]
+    mean_d = sum(diffs) / n
+    var_d = sum((d - mean_d) ** 2 for d in diffs) / (n - 1)
+    std_d = var_d**0.5 if var_d > 0 else 1e-10
+
+    t_stat = mean_d / (std_d / n**0.5)
+    z = abs(t_stat)
+    p_value = 2 * (1 - 0.5 * (1 + math.erf(z / 2**0.5)))
+
+    pooled_std = (
+        (sum((ai - sum(a) / n) ** 2 for ai in a) + sum((bi - sum(b) / n) ** 2 for bi in b))
+        / (2 * n - 2)
+    ) ** 0.5
+    cohens_d = (sum(b) / n - sum(a) / n) / pooled_std if pooled_std > 0 else 0.0
+
+    effect_label = "negligible"
+    if abs(cohens_d) >= 0.8:
+        effect_label = "large"
+    elif abs(cohens_d) >= 0.5:
+        effect_label = "medium"
+    elif abs(cohens_d) >= 0.2:
+        effect_label = "small"
+
+    return {
+        "t_stat": round(t_stat, 4),
+        "p_value": round(p_value, 6),
+        "cohens_d": round(cohens_d, 4),
+        "effect_size": effect_label,
+        "significant": p_value < 0.05,
+        "mean_diff": round(mean_d, 4),
+    }
+```
+
+Then in `scripts/lab/run_recall_test.py`, delete the local definitions of `recall_at_k`, `mrr`, `ndcg_at_k`, `paired_ttest` (lines 47-122) and add an import near the top (after the existing imports, before `API_URL`):
+
+```python
+from lab_metrics import mrr, ndcg_at_k, paired_ttest, recall_at_k  # noqa: E402
+```
+
+Because `run_recall_test.py` runs from `scripts/lab/`, add this just above that import so it resolves when invoked from the repo root:
+
+```python
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/lab/test_lab_metrics.py -v`
+Expected: PASS (3 tests).
+
+Also confirm the CLI still imports cleanly:
+Run: `python scripts/lab/run_recall_test.py --help`
+Expected: argparse help prints, no ImportError.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lab/lab_metrics.py scripts/lab/run_recall_test.py tests/lab/conftest.py tests/lab/test_lab_metrics.py
+git commit -m "refactor(lab): extract pure metrics into lab_metrics module"
+```
+
+---
+
+### Task 2: Add `distractor_rate_at_k` (the precision guardrail)
+
+**Files:**
+- Modify: `scripts/lab/lab_metrics.py`
+- Modify: `tests/lab/test_lab_metrics.py`
+
+**Interfaces:**
+- Produces: `distractor_rate_at_k(retrieved_ids: list[str], distractor_ids: set[str] | list[str], k: int) -> float` — fraction of the top-k results that are known distractors. Lower is better. Returns 0.0 for empty results or k<=0.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/lab/test_lab_metrics.py`:
+
+```python
+def test_distractor_rate_counts_distractors_in_top_k():
+    retrieved = ["good", "d1", "d2", "good2"]
+    distractors = {"d1", "d2"}
+    assert m.distractor_rate_at_k(retrieved, distractors, 4) == 0.5
+    # top-1 is clean -> 0.0
+    assert m.distractor_rate_at_k(retrieved, distractors, 1) == 0.0
+    # all distractors -> 1.0
+    assert m.distractor_rate_at_k(["d1", "d2"], distractors, 10) == 1.0
+    # empties are safe
+    assert m.distractor_rate_at_k([], distractors, 10) == 0.0
+    assert m.distractor_rate_at_k(retrieved, distractors, 0) == 0.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/lab/test_lab_metrics.py::test_distractor_rate_counts_distractors_in_top_k -v`
+Expected: FAIL with `AttributeError: module 'lab_metrics' has no attribute 'distractor_rate_at_k'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `scripts/lab/lab_metrics.py` (update the typing import line to `from typing import Any, Dict, Iterable, List`):
+
+```python
+def distractor_rate_at_k(
+    retrieved_ids: List[str], distractor_ids: Iterable[str], k: int
+) -> float:
+    """Fraction of the top-k results that are known distractors. Lower is better.
+
+    Distractors are memories we injected and labelled as never-relevant, so a
+    result that is a distractor is unambiguous noise. This is the precision
+    guardrail and the only metric that can see the `forget` consolidation mode
+    working (known-item recall is blind to suppression).
+    """
+    if k <= 0:
+        return 0.0
+    top_k = retrieved_ids[:k]
+    if not top_k:
+        return 0.0
+    dset = set(distractor_ids)
+    hits = sum(1 for rid in top_k if rid in dset)
+    return hits / len(top_k)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/lab/test_lab_metrics.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lab/lab_metrics.py tests/lab/test_lab_metrics.py
+git commit -m "feat(lab): add distractor_rate_at_k precision guardrail metric"
+```
+
+---
+
+### Task 3: Add `config_complexity` (the simplicity tiebreaker)
+
+**Files:**
+- Modify: `scripts/lab/lab_metrics.py`
+- Modify: `tests/lab/test_lab_metrics.py`
+
+**Interfaces:**
+- Produces: `config_complexity(config: dict) -> int` — count of "active" knobs. Lower = simpler/more elegant. Rules: a `SEARCH_WEIGHT_*` entry counts if its float value != 0; a known feature flag (`ENRICHMENT_ENABLED`, `JIT_ENRICHMENT_ENABLED`, `ENRICHMENT_ENABLE_SUMMARIES`, `RECALL_RECENCY_BIAS`) counts if not "off/false/0/empty"; a `*_THRESHOLD`/`*_CAP`/`*_GATE` entry counts if its value is > 0 (or, if non-numeric, not "off").
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/lab/test_lab_metrics.py`:
+
+```python
+def test_config_complexity_counts_active_knobs():
+    baseline = {
+        "SEARCH_WEIGHT_VECTOR": "0.35",
+        "SEARCH_WEIGHT_KEYWORD": "0.35",
+        "SEARCH_WEIGHT_RELEVANCE": "0.0",  # off -> not counted
+    }
+    assert m.config_complexity(baseline) == 2
+
+    simpler = {
+        "SEARCH_WEIGHT_VECTOR": "0.35",
+        "SEARCH_WEIGHT_KEYWORD": "0.0",
+        "SEARCH_WEIGHT_RELEVANCE": "0.0",
+    }
+    assert m.config_complexity(simpler) == 1
+
+    flags_and_gates = {
+        "SEARCH_WEIGHT_VECTOR": "0.35",        # +1
+        "ENRICHMENT_ENABLED": "true",          # +1
+        "JIT_ENRICHMENT_ENABLED": "false",     # +0
+        "RECALL_RECENCY_BIAS": "off",          # +0
+        "RECALL_RELEVANCE_GATE": "0.2",        # +1 (gate > 0)
+        "SEARCH_TAG_SCORE_TOKEN_CAP": "0",     # +0
+    }
+    assert m.config_complexity(flags_and_gates) == 3
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/lab/test_lab_metrics.py::test_config_complexity_counts_active_knobs -v`
+Expected: FAIL with `AttributeError: module 'lab_metrics' has no attribute 'config_complexity'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `scripts/lab/lab_metrics.py`:
+
+```python
+_FLAG_KEYS = {
+    "ENRICHMENT_ENABLED",
+    "JIT_ENRICHMENT_ENABLED",
+    "ENRICHMENT_ENABLE_SUMMARIES",
+    "RECALL_RECENCY_BIAS",
+}
+_OFF_VALUES = {"", "0", "0.0", "off", "false", "no", "none"}
+
+
+def _is_off(value: Any) -> bool:
+    return str(value).strip().lower() in _OFF_VALUES
+
+
+def config_complexity(config: Dict[str, Any]) -> int:
+    """Count 'active' knobs in a config. Lower = simpler/more elegant.
+
+    This is the simplicity tiebreaker: among configs within noise on quality,
+    the one with fewer active knobs wins.
+    """
+    count = 0
+    for key, value in config.items():
+        ku = str(key).upper()
+        if ku.startswith("SEARCH_WEIGHT_"):
+            try:
+                if float(value) != 0.0:
+                    count += 1
+            except (TypeError, ValueError):
+                continue
+        elif ku in _FLAG_KEYS:
+            if not _is_off(value):
+                count += 1
+        elif ku.endswith(("_THRESHOLD", "_CAP", "_GATE")):
+            try:
+                if float(value) > 0.0:
+                    count += 1
+            except (TypeError, ValueError):
+                if not _is_off(value):
+                    count += 1
+    return count
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/lab/test_lab_metrics.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lab/lab_metrics.py tests/lab/test_lab_metrics.py
+git commit -m "feat(lab): add config_complexity simplicity metric"
+```
+
+---
+
+### Task 4: Add `pick_winner` (the decision rule)
+
+Encode the one-sentence rule from the spec: *highest NDCG@10 that does not regress distractor-precision; break ties toward fewer knobs and lower latency.*
+
+**Files:**
+- Modify: `scripts/lab/lab_metrics.py`
+- Modify: `tests/lab/test_lab_metrics.py`
+
+**Interfaces:**
+- Produces: `pick_winner(cards: list[dict], *, baseline_name: str, ndcg_tol: float = 0.005, distractor_tol: float = 0.01) -> dict` — each card has keys `name, ndcg_10, distractor_rate_10, latency_ms, complexity`. Returns the winning card augmented with a `reason: str`. Configs whose `distractor_rate_10` exceeds baseline + `distractor_tol` are ineligible (precision regression). Among eligible configs within `ndcg_tol` of the best NDCG@10, pick the lowest complexity, then lowest latency.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/lab/test_lab_metrics.py`:
+
+```python
+def _card(name, ndcg, distractor, latency, complexity):
+    return {
+        "name": name,
+        "ndcg_10": ndcg,
+        "distractor_rate_10": distractor,
+        "latency_ms": latency,
+        "complexity": complexity,
+    }
+
+
+def test_pick_winner_prefers_simpler_within_ndcg_tolerance():
+    cards = [
+        _card("baseline", 0.800, 0.10, 100, 11),
+        _card("complex", 0.803, 0.10, 120, 13),   # tiny ndcg gain, more knobs
+        _card("simple", 0.801, 0.10, 90, 8),       # within tol, fewer knobs + faster
+    ]
+    winner = m.pick_winner(cards, baseline_name="baseline")
+    assert winner["name"] == "simple"
+
+
+def test_pick_winner_rejects_precision_regression():
+    cards = [
+        _card("baseline", 0.800, 0.10, 100, 11),
+        _card("greedy", 0.900, 0.30, 100, 11),  # big ndcg but junk floods results
+    ]
+    winner = m.pick_winner(cards, baseline_name="baseline")
+    assert winner["name"] == "baseline"
+
+
+def test_pick_winner_picks_clear_quality_jump():
+    cards = [
+        _card("baseline", 0.800, 0.10, 100, 11),
+        _card("better", 0.860, 0.09, 100, 11),  # real gain, no regression
+    ]
+    winner = m.pick_winner(cards, baseline_name="baseline")
+    assert winner["name"] == "better"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/lab/test_lab_metrics.py -k pick_winner -v`
+Expected: FAIL with `AttributeError: module 'lab_metrics' has no attribute 'pick_winner'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `scripts/lab/lab_metrics.py`:
+
+```python
+def pick_winner(
+    cards: List[Dict[str, Any]],
+    *,
+    baseline_name: str,
+    ndcg_tol: float = 0.005,
+    distractor_tol: float = 0.01,
+) -> Dict[str, Any]:
+    """Apply the scorecard decision rule and return the winning card + reason.
+
+    Rule: highest NDCG@10 that does not regress distractor-precision vs the
+    baseline; break ties (within ndcg_tol) toward fewer knobs, then lower latency.
+    """
+    baseline = next(c for c in cards if c["name"] == baseline_name)
+    ceiling = baseline["distractor_rate_10"] + distractor_tol
+    eligible = [c for c in cards if c["distractor_rate_10"] <= ceiling]
+    regressed = not eligible
+    if regressed:
+        eligible = [baseline]
+
+    best_ndcg = max(c["ndcg_10"] for c in eligible)
+    contenders = [c for c in eligible if c["ndcg_10"] >= best_ndcg - ndcg_tol]
+    winner = dict(min(contenders, key=lambda c: (c["complexity"], c["latency_ms"])))
+
+    if regressed:
+        winner["reason"] = "all candidates regressed distractor-precision; held baseline"
+    elif winner["name"] == baseline_name:
+        winner["reason"] = "no candidate beat baseline NDCG@10 without precision regression"
+    else:
+        winner["reason"] = (
+            f"best NDCG@10 within tolerance, lowest complexity ({winner['complexity']}) "
+            f"and latency ({winner['latency_ms']:.0f}ms)"
+        )
+    return winner
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/lab/test_lab_metrics.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lab/lab_metrics.py tests/lab/test_lab_metrics.py
+git commit -m "feat(lab): add pick_winner scorecard decision rule"
+```
+
+---
+
+### Task 5: Create `lab_corpus.py` with parameterized recall
+
+**Files:**
+- Create: `scripts/lab/lab_corpus.py`
+- Create: `tests/lab/test_lab_corpus.py`
+
+**Interfaces:**
+- Produces: `recall(api_url: str, headers: dict, query: str, *, limit: int = 20, expand_relations: bool = False, current_only: bool = True, recency_bias: str | None = None, http_get=requests.get) -> dict` — calls `GET /recall` with the given params and returns the parsed JSON. `expand_relations` and `current_only` are serialized as the lowercase strings `"true"`/`"false"`; `recency_bias` is omitted when `None`.
+- Produces: `extract_ids(recall_json: dict) -> list[str]` — pulls memory IDs from a `/recall` response, handling both the nested `result["memory"]["id"]` shape and the flat shape.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/lab/test_lab_corpus.py`:
+
+```python
+import lab_corpus as c
+
+
+class FakeResp:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+def test_recall_serializes_params():
+    captured = {}
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        captured["url"] = url
+        captured["params"] = params
+        return FakeResp({"results": []})
+
+    c.recall(
+        "http://x",
+        {"Authorization": "Bearer t"},
+        "hello",
+        limit=10,
+        expand_relations=True,
+        current_only=False,
+        recency_bias="auto",
+        http_get=fake_get,
+    )
+    assert captured["url"].endswith("/recall")
+    assert captured["params"]["query"] == "hello"
+    assert captured["params"]["limit"] == 10
+    assert captured["params"]["expand_relations"] == "true"
+    assert captured["params"]["current_only"] == "false"
+    assert captured["params"]["recency_bias"] == "auto"
+
+
+def test_recall_omits_recency_bias_when_none():
+    captured = {}
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        captured["params"] = params
+        return FakeResp({"results": []})
+
+    c.recall("http://x", {}, "q", http_get=fake_get)
+    assert "recency_bias" not in captured["params"]
+    assert captured["params"]["current_only"] == "true"
+
+
+def test_extract_ids_handles_nested_and_flat():
+    payload = {
+        "results": [
+            {"memory": {"id": "a", "content": "x"}},
+            {"id": "b", "content": "y"},
+        ]
+    }
+    assert c.extract_ids(payload) == ["a", "b"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/lab/test_lab_corpus.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'lab_corpus'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `scripts/lab/lab_corpus.py`:
+
+```python
+"""Corpus-side helpers for the AutoMem Recall Quality Lab.
+
+All HTTP lives here, behind injectable clients (http_get / http_post) so the
+logic is unit-testable without a live server. Imported by run_recall_test.py
+and the parallel matrix harness.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import requests
+
+
+def recall(
+    api_url: str,
+    headers: Dict[str, str],
+    query: str,
+    *,
+    limit: int = 20,
+    expand_relations: bool = False,
+    current_only: bool = True,
+    recency_bias: Optional[str] = None,
+    http_get=requests.get,
+) -> Dict[str, Any]:
+    """GET /recall with explicit recall parameters; returns parsed JSON."""
+    params: Dict[str, Any] = {"query": query, "limit": limit}
+    if expand_relations:
+        params["expand_relations"] = "true"
+    params["current_only"] = "true" if current_only else "false"
+    if recency_bias is not None:
+        params["recency_bias"] = recency_bias
+    resp = http_get(f"{api_url}/recall", params=params, headers=headers, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def extract_ids(recall_json: Dict[str, Any]) -> List[str]:
+    """Pull memory IDs from a /recall response (nested or flat shape)."""
+    results = recall_json.get("results", recall_json.get("memories", []))
+    ids: List[str] = []
+    for r in results:
+        mem = r.get("memory", r)
+        mid = str(mem.get("id", r.get("id", "")))
+        if mid:
+            ids.append(mid)
+    return ids
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/lab/test_lab_corpus.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lab/lab_corpus.py tests/lab/test_lab_corpus.py
+git commit -m "feat(lab): add lab_corpus with parameterized recall"
+```
+
+---
+
+### Task 6: Add distractor injection + backdating
+
+Inject synthetic, aged, low-importance, labelled distractor memories. These are simultaneously the precision guardrail's "known noise" and the `forget` arm's "should-be-archived" targets — one step serves both.
+
+**Files:**
+- Modify: `scripts/lab/lab_corpus.py`
+- Modify: `tests/lab/test_lab_corpus.py`
+
+**Interfaces:**
+- Produces: `iso_days_ago(days: float) -> str` — UTC ISO-8601 timestamp `days` in the past.
+- Produces: `make_distractor_memories(n: int, *, age_days: float = 180, importance: float = 0.05, tag: str = "lab-distractor") -> list[dict]` — `POST /memory` payloads, each pre-backdated (`timestamp` and `last_accessed`), low-importance, tagged `lab-distractor`, with `metadata.lab_distractor = True`.
+- Produces: `inject_distractors(api_url: str, headers: dict, payloads: list[dict], *, http_post=requests.post) -> list[str]` — POSTs each payload and returns the created memory IDs (reads `memory_id`/`id`/`memory.id`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/lab/test_lab_corpus.py`:
+
+```python
+def test_make_distractor_memories_are_aged_low_importance_and_tagged():
+    payloads = c.make_distractor_memories(3, age_days=200, importance=0.05)
+    assert len(payloads) == 3
+    for p in payloads:
+        assert p["tags"] == ["lab-distractor"]
+        assert p["importance"] == 0.05
+        assert p["timestamp"] == p["last_accessed"]
+        assert p["metadata"]["lab_distractor"] is True
+        assert p["timestamp"].endswith("Z")
+
+
+def test_inject_distractors_returns_created_ids():
+    posted = []
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        posted.append(json)
+        idx = len(posted)
+        return FakeResp({"memory_id": f"id-{idx}"})
+
+    payloads = c.make_distractor_memories(2)
+    ids = c.inject_distractors("http://x", {}, payloads, http_post=fake_post)
+    assert ids == ["id-1", "id-2"]
+    assert len(posted) == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/lab/test_lab_corpus.py -k distractor -v`
+Expected: FAIL with `AttributeError: module 'lab_corpus' has no attribute 'make_distractor_memories'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `scripts/lab/lab_corpus.py` (add `import time` to the imports):
+
+```python
+def iso_days_ago(days: float) -> str:
+    """UTC ISO-8601 timestamp `days` in the past."""
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - days * 86400))
+
+
+def make_distractor_memories(
+    n: int,
+    *,
+    age_days: float = 180,
+    importance: float = 0.05,
+    tag: str = "lab-distractor",
+) -> List[Dict[str, Any]]:
+    """Build n aged, low-importance, labelled distractor /memory payloads.
+
+    Pre-backdated so the `forget` consolidation mode treats them as stale; the
+    `lab-distractor` tag + metadata flag make them unambiguous noise for the
+    distractor-precision metric.
+    """
+    ts = iso_days_ago(age_days)
+    payloads: List[Dict[str, Any]] = []
+    for i in range(n):
+        payloads.append(
+            {
+                "content": (
+                    f"[lab-distractor #{i}] stale unrelated note about "
+                    f"miscellaneous topic {i}; safe to forget."
+                ),
+                "tags": [tag],
+                "importance": importance,
+                "timestamp": ts,
+                "last_accessed": ts,
+                "metadata": {"lab_distractor": True},
+            }
+        )
+    return payloads
+
+
+def inject_distractors(
+    api_url: str,
+    headers: Dict[str, str],
+    payloads: List[Dict[str, Any]],
+    *,
+    http_post=requests.post,
+) -> List[str]:
+    """POST distractor memories; return the created memory IDs."""
+    ids: List[str] = []
+    for payload in payloads:
+        resp = http_post(f"{api_url}/memory", json=payload, headers=headers, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        mid = str(
+            data.get("memory_id")
+            or data.get("id")
+            or (data.get("memory") or {}).get("id")
+            or ""
+        )
+        if mid:
+            ids.append(mid)
+    return ids
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/lab/test_lab_corpus.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lab/lab_corpus.py tests/lab/test_lab_corpus.py
+git commit -m "feat(lab): add aged labelled distractor injection"
+```
+
+---
+
+### Task 7: Add real consolidation pass (`run_consolidation`)
+
+**Files:**
+- Modify: `scripts/lab/lab_corpus.py`
+- Modify: `tests/lab/test_lab_corpus.py`
+
+**Interfaces:**
+- Produces: `CONSOLIDATION_ORDER: list[str]` = `["decay", "creative", "cluster", "forget"]` (decay first so creative/cluster see `relevance_score > 0.3`).
+- Produces: `run_consolidation(api_url: str, headers: dict, modes: list[str] = CONSOLIDATION_ORDER, *, dry_run: bool = False, http_post=requests.post) -> dict[str, dict]` — POSTs `/consolidate {"mode": mode, "dry_run": dry_run}` for each mode **in order**, returns `{mode: response_json}`. `dry_run` defaults to **False** (a real pass) because the endpoint's own default is True (a no-op).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/lab/test_lab_corpus.py`:
+
+```python
+def test_run_consolidation_sends_dry_run_false_in_order():
+    calls = []
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        calls.append(json)
+        return FakeResp({"mode": json["mode"], "steps": {}})
+
+    out = c.run_consolidation("http://x", {}, http_post=fake_post)
+    sent_modes = [call["mode"] for call in calls]
+    assert sent_modes == ["decay", "creative", "cluster", "forget"]
+    assert all(call["dry_run"] is False for call in calls)
+    assert set(out.keys()) == {"decay", "creative", "cluster", "forget"}
+
+
+def test_run_consolidation_respects_explicit_modes():
+    calls = []
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        calls.append(json)
+        return FakeResp({})
+
+    c.run_consolidation("http://x", {}, modes=["forget"], http_post=fake_post)
+    assert [call["mode"] for call in calls] == ["forget"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/lab/test_lab_corpus.py -k consolidation -v`
+Expected: FAIL with `AttributeError: module 'lab_corpus' has no attribute 'run_consolidation'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `scripts/lab/lab_corpus.py`:
+
+```python
+CONSOLIDATION_ORDER = ["decay", "creative", "cluster", "forget"]
+
+
+def run_consolidation(
+    api_url: str,
+    headers: Dict[str, str],
+    modes: Optional[List[str]] = None,
+    *,
+    dry_run: bool = False,
+    http_post=requests.post,
+) -> Dict[str, Dict[str, Any]]:
+    """Run a REAL consolidation pass per mode, in order.
+
+    dry_run defaults to False: the /consolidate endpoint's own default is True,
+    which makes creative/cluster/forget silent no-ops. Decay runs first so
+    creative/cluster see memories with relevance_score > 0.3.
+    """
+    if modes is None:
+        modes = list(CONSOLIDATION_ORDER)
+    out: Dict[str, Dict[str, Any]] = {}
+    for mode in modes:
+        resp = http_post(
+            f"{api_url}/consolidate",
+            json={"mode": mode, "dry_run": dry_run},
+            headers=headers,
+            timeout=120,
+        )
+        resp.raise_for_status()
+        out[mode] = resp.json()
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/lab/test_lab_corpus.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lab/lab_corpus.py tests/lab/test_lab_corpus.py
+git commit -m "feat(lab): add real consolidation pass helper"
+```
+
+---
+
+### Task 8: Wire the scorecard into `run_recall_test.py`
+
+Make the runner compute the scorecard end to end: per-query distractor rate, configurable recall params, config complexity on the run, and a scorecard in the summary/saved JSON. Add CLI flags so a run can inject distractors, set recall params, and optionally consolidate.
+
+**Files:**
+- Modify: `scripts/lab/run_recall_test.py`
+- Create: `tests/lab/test_run_recall_test.py`
+
+**Interfaces:**
+- Consumes: `lab_metrics.distractor_rate_at_k`, `lab_metrics.config_complexity`; `lab_corpus.recall`, `lab_corpus.extract_ids`, `lab_corpus.make_distractor_memories`, `lab_corpus.inject_distractors`, `lab_corpus.run_consolidation`.
+- Produces: `QueryResult.distractor_rate_10: float` field; `TestRunResult.complexity: int` field and `TestRunResult.mean_distractor_rate_10` property; `build_scorecard(result: TestRunResult) -> dict` returning `{config_name, ndcg_10, distractor_rate_10, latency_ms, complexity}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/lab/test_run_recall_test.py`:
+
+```python
+import run_recall_test as rr
+
+
+def test_build_scorecard_reads_the_four_axes():
+    result = rr.TestRunResult(config_name="cfg")
+    result.complexity = 7
+    result.query_results = [
+        rr.QueryResult(
+            query="q1",
+            expected_ids=["a"],
+            retrieved_ids=["a", "d1"],
+            ndcg_10=1.0,
+            distractor_rate_10=0.5,
+            latency_ms=100.0,
+        ),
+        rr.QueryResult(
+            query="q2",
+            expected_ids=["b"],
+            retrieved_ids=["b"],
+            ndcg_10=0.0,
+            distractor_rate_10=0.0,
+            latency_ms=200.0,
+        ),
+    ]
+    card = rr.build_scorecard(result)
+    assert card["config_name"] == "cfg"
+    assert card["ndcg_10"] == 0.5
+    assert card["distractor_rate_10"] == 0.25
+    assert card["latency_ms"] == 150.0
+    assert card["complexity"] == 7
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/lab/test_run_recall_test.py -v`
+Expected: FAIL — `QueryResult.__init__() got an unexpected keyword argument 'distractor_rate_10'` (or `AttributeError: build_scorecard`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `scripts/lab/run_recall_test.py`:
+
+(a) Extend the imports near the top:
+
+```python
+from lab_metrics import (  # noqa: E402
+    config_complexity,
+    distractor_rate_at_k,
+    mrr,
+    ndcg_at_k,
+    paired_ttest,
+    recall_at_k,
+)
+from lab_corpus import (  # noqa: E402
+    extract_ids,
+    inject_distractors,
+    make_distractor_memories,
+    recall,
+    run_consolidation,
+)
+```
+
+(b) Add a field to `QueryResult` (after `ndcg_10`):
+
+```python
+    distractor_rate_10: float = 0.0
+```
+
+(c) Add a field + property to `TestRunResult` (after `timestamp`):
+
+```python
+    complexity: int = 0
+```
+
+```python
+    @property
+    def mean_distractor_rate_10(self) -> float:
+        vals = [q.distractor_rate_10 for q in self.query_results]
+        return sum(vals) / len(vals) if vals else 0.0
+```
+
+(d) Replace `run_single_query` so it uses `lab_corpus.recall`/`extract_ids` and scores distractors. New signature and body:
+
+```python
+def run_single_query(
+    query_data: Dict[str, Any],
+    api_url: str,
+    *,
+    distractor_ids: Optional[set] = None,
+    recall_params: Optional[Dict[str, Any]] = None,
+) -> QueryResult:
+    """Execute a single recall query and compute metrics (incl. distractor rate)."""
+    query = query_data["query"]
+    expected_ids = query_data.get("expected_ids", [])
+    category = query_data.get("category", "unknown")
+    distractor_ids = distractor_ids or set()
+    recall_params = recall_params or {}
+
+    start = time.perf_counter()
+    try:
+        data = recall(api_url, get_headers(), query, **recall_params)
+    except Exception as e:  # noqa: BLE001
+        print(f"  WARNING: Query failed: {query[:50]}... — {e}")
+        return QueryResult(
+            query=query, expected_ids=expected_ids, retrieved_ids=[], category=category
+        )
+
+    latency_ms = (time.perf_counter() - start) * 1000
+    retrieved_ids = extract_ids(data)
+
+    return QueryResult(
+        query=query,
+        expected_ids=expected_ids,
+        retrieved_ids=retrieved_ids,
+        recall_5=recall_at_k(retrieved_ids, expected_ids, 5),
+        recall_10=recall_at_k(retrieved_ids, expected_ids, 10),
+        recall_20=recall_at_k(retrieved_ids, expected_ids, 20),
+        mrr_val=mrr(retrieved_ids, expected_ids),
+        ndcg_10=ndcg_at_k(retrieved_ids, expected_ids, 10),
+        distractor_rate_10=distractor_rate_at_k(retrieved_ids, distractor_ids, 10),
+        latency_ms=latency_ms,
+        category=category,
+    )
+```
+
+(e) Update `run_test` to thread the new args and set complexity:
+
+```python
+def run_test(
+    config_name: str,
+    queries: List[Dict],
+    api_url: str,
+    *,
+    config: Optional[Dict[str, str]] = None,
+    distractor_ids: Optional[set] = None,
+    recall_params: Optional[Dict[str, Any]] = None,
+) -> TestRunResult:
+    """Run all test queries with a specific config."""
+    result = TestRunResult(
+        config_name=config_name, timestamp=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    )
+    result.complexity = config_complexity(config or {})
+
+    for i, q in enumerate(queries):
+        qr = run_single_query(
+            q, api_url, distractor_ids=distractor_ids, recall_params=recall_params
+        )
+        result.query_results.append(qr)
+        hit = "." if qr.recall_10 > 0 else "x"
+        print(hit, end="", flush=True)
+        if (i + 1) % 50 == 0:
+            print(f" [{i + 1}/{len(queries)}]")
+
+    print(f" [{len(queries)}/{len(queries)}]")
+    return result
+```
+
+(f) Add `build_scorecard` near `print_summary`:
+
+```python
+def build_scorecard(result: TestRunResult) -> Dict[str, Any]:
+    """The legible scorecard: NDCG@10 primary, distractor-rate guardrail,
+    latency + complexity tiebreakers."""
+    return {
+        "config_name": result.config_name,
+        "ndcg_10": result.mean_ndcg_10,
+        "distractor_rate_10": result.mean_distractor_rate_10,
+        "latency_ms": result.mean_latency,
+        "complexity": result.complexity,
+    }
+```
+
+(g) Add a scorecard block to `print_summary` (after the NDCG line):
+
+```python
+    print(f"  Distractor@10: {result.mean_distractor_rate_10:.3f} (lower better)")
+    print(f"  Complexity:   {result.complexity} active knobs")
+```
+
+(h) Add the scorecard to the saved JSON in `save_results` (add to the `summary` dict):
+
+```python
+            "distractor_rate_10": result.mean_distractor_rate_10,
+            "complexity": result.complexity,
+```
+
+(i) Add CLI flags in `main` (after the existing `--output-dir` arg):
+
+```python
+    parser.add_argument(
+        "--distractors", type=int, default=0,
+        help="Inject N aged labelled distractor memories before testing",
+    )
+    parser.add_argument("--expand-relations", action="store_true", help="Recall with expand_relations")
+    parser.add_argument(
+        "--no-current-only", action="store_true",
+        help="Recall with current_only=false (include archived)",
+    )
+    parser.add_argument(
+        "--recency-bias", type=str, default=None, choices=["on", "off", "auto"],
+        help="Recall recency_bias override",
+    )
+    parser.add_argument(
+        "--consolidate", action="store_true",
+        help="Run a real consolidation pass (dry_run=false) before recall",
+    )
+```
+
+Then, right after `queries = load_test_set(...)`, build the shared recall params + optional corpus setup:
+
+```python
+    recall_params = {
+        "expand_relations": args.expand_relations,
+        "current_only": not args.no_current_only,
+    }
+    if args.recency_bias is not None:
+        recall_params["recency_bias"] = args.recency_bias
+
+    distractor_ids: set = set()
+    if args.distractors > 0:
+        payloads = make_distractor_memories(args.distractors)
+        distractor_ids = set(inject_distractors(args.api_url, get_headers(), payloads))
+        print(f"Injected {len(distractor_ids)} distractor memories")
+    if args.consolidate:
+        steps = run_consolidation(args.api_url, get_headers())
+        print(f"Consolidation pass complete: {list(steps.keys())}")
+```
+
+Finally, thread `config=...`, `distractor_ids=distractor_ids`, `recall_params=recall_params` into every `run_test(...)` call in `main` (the sweep, compare, and single-config branches). For example the single-config branch becomes:
+
+```python
+        result = run_test(
+            args.config, queries, args.api_url,
+            config=config, distractor_ids=distractor_ids, recall_params=recall_params,
+        )
+```
+
+(Apply the same three kwargs to the `run_test` calls in the sweep loop and both compare-mode calls. In the sweep loop pass `config={param_name: val}`; in compare mode pass `config=config_a` / `config=config_b` respectively.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/lab/ -v`
+Expected: PASS (all lab tests).
+
+Confirm the CLI still parses:
+Run: `python scripts/lab/run_recall_test.py --help`
+Expected: help shows the new `--distractors`, `--expand-relations`, `--no-current-only`, `--recency-bias`, `--consolidate` flags.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lab/run_recall_test.py tests/lab/test_run_recall_test.py
+git commit -m "feat(lab): wire scorecard, distractors, recall params, consolidation into runner"
+```
+
+---
+
+### Task 9: Format, lint, and full-suite green
+
+**Files:** none new (cleanup only).
+
+- [ ] **Step 1: Format**
+
+Run: `black scripts/lab/ tests/lab/`
+Expected: files reformatted or "All done".
+
+- [ ] **Step 2: Lint**
+
+Run: `flake8 scripts/lab/lab_metrics.py scripts/lab/lab_corpus.py scripts/lab/run_recall_test.py tests/lab/`
+Expected: no output (clean). Fix any reported issues inline.
+
+- [ ] **Step 3: Run the full lab suite**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/lab/ -v`
+Expected: all PASS.
+
+- [ ] **Step 4: Confirm no unrelated WIP got staged**
+
+Run: `git status --short`
+Expected: the WIP files from Global Constraints still show as unstaged `M`; nothing under `automem/api/` or `mcp-sse-server/` is staged.
+
+- [ ] **Step 5: Commit (only if black/flake8 changed anything)**
+
+```bash
+git add scripts/lab/ tests/lab/
+git commit -m "style(lab): black + flake8 clean"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Plan A scope = spec §3 metric, §5 arms' knobs, §8 consolidation hooks, §10 lab build items):**
+- NDCG@10 primary → already computed; surfaced in scorecard (Task 8). ✓
+- Distractor-precision guardrail → Task 2 metric + Task 6 injection + Task 8 wiring. ✓
+- Simplicity (knob-count) → Task 3 + Task 8. ✓
+- Latency tiebreaker → existing `mean_latency`, surfaced in scorecard. ✓
+- Decision rule → Task 4 `pick_winner`. ✓
+- Recall params (expand_relations/current_only/recency_bias) → Task 5 + Task 8 flags. ✓
+- Timestamp-backdate → folded into Task 6 (`iso_days_ago` + pre-aged distractors); standalone corpus-aging deferred (YAGNI — the measurable arms inject pre-aged distractors and creative/cluster need only a decay pass, not aged data). Noted as an intentional trim of spec §10.
+- Consolidation-in-loop (dry_run:false, order) → Task 7 + Task 8 `--consolidate`. ✓
+- Matrix-cell wiring, manifest, isolation, funnel runners, AMB work → **Plan B / Plan C** (out of scope here). ✓
+
+**Placeholder scan:** no TBD/TODO; every code step shows complete code. ✓
+
+**Type consistency:** `distractor_rate_at_k(retrieved, distractors, k)`, `config_complexity(config)`, `pick_winner(cards, baseline_name=...)`, `recall(...)→dict`, `extract_ids(json)→list`, `run_consolidation(...)→dict`, `build_scorecard(result)→dict`, `QueryResult.distractor_rate_10`, `TestRunResult.complexity`/`mean_distractor_rate_10` — names used in Task 8 match their definitions in Tasks 2-7. ✓
+
+---
+
+## Execution Handoff
+
+After saving the plan, the orchestrator offers the execution-mode choice (subagent-driven vs inline). Plans B and C are written next, after Plan A's interfaces are real.

--- a/docs/superpowers/plans/2026-06-17-matrix-parallel-harness.md
+++ b/docs/superpowers/plans/2026-06-17-matrix-parallel-harness.md
@@ -1,0 +1,1088 @@
+# Matrix Parallel Harness (Plan B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A parallel "matrix" harness that runs N AutoMem config variants — each in its own isolated Docker stack with the config baked in — against a corpus, scores each with the Plan A scorecard, records a provenance manifest, resumes idempotently, and selects a winner via `pick_winner`.
+
+**Architecture:** Live in an isolated git worktree of `automem-evals` (branch `feat/matrix-parallel-harness` off `main`) so the concurrent BEAM agent's `feat/beam-judged-harness` is never touched. The harness imports the scoring primitives (`lab_metrics`, `lab_corpus`) from the automem repo — one source of truth for scoring (DRY). Pure logic (manifest, cell-keying, compose lint, config→override injection, port algebra, concurrency math, orchestration loop with injected provider/scorer) is unit-tested without Docker; one synthetic-corpus task validates the live path end to end.
+
+**Tech Stack:** Python 3.12, `requests`, `pyyaml` (already used by matrix_stack.py), pytest. Docker Compose for stacks. No new external services.
+
+## Global Constraints
+
+- **Worktree:** all code changes happen in the `automem-evals` worktree at `/Users/jgarturo/Projects/OpenAI/automem-evals.worktrees/matrix-harness` on branch `feat/matrix-parallel-harness` (created off `origin/main`). **Never** check out, rebase, reset, or commit on `feat/beam-judged-harness`, and never touch that repo's primary working tree at `/Users/jgarturo/Projects/OpenAI/automem-evals`.
+- **Scoring is imported, not reimplemented.** Import `lab_metrics` and `lab_corpus` from the automem repo. Resolve the path via env var `AUTOMEM_DIR` (default `/Users/jgarturo/Projects/OpenAI/automem`), appending `AUTOMEM_DIR/scripts/lab` to `sys.path`. Do NOT copy/duplicate any scoring function.
+- **Each config variant = its own stack.** AutoMem reads `SEARCH_WEIGHT_*`/`RECALL_*`/`CONSOLIDATION_*` from env at import time (`automem/config.py`), so config must be baked into the per-stack compose override's `flask-api` `environment:` block at `up` time — never via a shared `.env.bench`.
+- **No `container_name`, no fixed/literal host ports** in any generated compose or override. Internal ports stay fixed (`falkordb:6379`, `qdrant:6333`, api `8001`); only host bindings vary, derived deterministically from the cell index.
+- **Teardown always:** every provisioned stack is torn down with `docker compose -p <project> down -v --remove-orphans` in a `finally` block.
+- **Idempotent resume:** a cell is done iff its result JSON exists; the orchestrator skips done cells.
+- Run tests with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest <path> -v`.
+- Bare-tag convention (`lab-distractor`); no secrets in code or fixtures.
+- Format with `black .`, lint with `flake8` before each commit.
+
+---
+
+### Task 0: Create the isolated worktree (setup, no tests)
+
+**Files:** none committed in this task — environment setup only.
+
+- [ ] **Step 1: Create the worktree off origin/main without disturbing the BEAM branch**
+
+Run (from anywhere; operates on the automem-evals git dir):
+
+```bash
+git -C /Users/jgarturo/Projects/OpenAI/automem-evals fetch origin
+git -C /Users/jgarturo/Projects/OpenAI/automem-evals worktree add -b feat/matrix-parallel-harness /Users/jgarturo/Projects/OpenAI/automem-evals.worktrees/matrix-harness origin/main
+```
+
+Expected: "Preparing worktree ... HEAD is now at <sha>". If the branch already exists, use `git worktree add /Users/jgarturo/Projects/OpenAI/automem-evals.worktrees/matrix-harness feat/matrix-parallel-harness`.
+
+- [ ] **Step 2: Verify isolation**
+
+Run:
+
+```bash
+git -C /Users/jgarturo/Projects/OpenAI/automem-evals.worktrees/matrix-harness branch --show-current
+git -C /Users/jgarturo/Projects/OpenAI/automem-evals branch --show-current
+```
+
+Expected: first prints `feat/matrix-parallel-harness`; second still prints `feat/beam-judged-harness` (the BEAM agent's working tree is untouched).
+
+- [ ] **Step 3: Confirm the lab primitives import from the automem repo**
+
+Run:
+
+```bash
+cd /Users/jgarturo/Projects/OpenAI/automem-evals.worktrees/matrix-harness
+AUTOMEM_DIR=/Users/jgarturo/Projects/OpenAI/automem python -c "import sys; sys.path.insert(0, '/Users/jgarturo/Projects/OpenAI/automem/scripts/lab'); import lab_metrics, lab_corpus; print('ok', lab_metrics.pick_winner.__name__, lab_corpus.recall.__name__)"
+```
+
+Expected: `ok pick_winner recall`. No commit in this task.
+
+All paths below are relative to the worktree root `/Users/jgarturo/Projects/OpenAI/automem-evals.worktrees/matrix-harness`.
+
+---
+
+### Task 1: Cell-keying + provenance manifest
+
+**Files:**
+- Create: `runners/matrix/__init__.py` (empty package marker)
+- Create: `runners/matrix/manifest.py`
+- Create: `tests/matrix/conftest.py`
+- Create: `tests/matrix/test_manifest.py`
+
+**Interfaces:**
+- Produces: `cell_key(config: dict, automem_commit: str, seed: int, snapshot_id: str) -> str` — sha256 hex (16-char prefix) of the canonical JSON of those four inputs; stable across runs (sorted keys).
+- Produces: `ManifestRow` dataclass: `name, key, config, automem_commit, seed, snapshot_id, scorecard (dict), status` and `to_dict()`/`from_dict()`.
+- Produces: `result_path(results_dir: str, key: str) -> Path`, `is_cached(results_dir, key) -> bool`, `save_row(results_dir, row) -> Path` (temp-write + atomic rename), `load_rows(results_dir) -> list[ManifestRow]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/matrix/conftest.py`:
+
+```python
+import sys
+from pathlib import Path
+
+# matrix package importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+# automem lab primitives importable (single source of truth for scoring)
+import os
+automem = os.environ.get("AUTOMEM_DIR", "/Users/jgarturo/Projects/OpenAI/automem")
+sys.path.insert(0, str(Path(automem) / "scripts" / "lab"))
+```
+
+Create `tests/matrix/test_manifest.py`:
+
+```python
+from runners.matrix import manifest as mf
+
+
+def test_cell_key_is_stable_and_order_independent():
+    a = mf.cell_key({"A": "1", "B": "2"}, "abc123", 42, "snap1")
+    b = mf.cell_key({"B": "2", "A": "1"}, "abc123", 42, "snap1")
+    assert a == b
+    assert a != mf.cell_key({"A": "9", "B": "2"}, "abc123", 42, "snap1")
+    assert len(a) == 16
+
+
+def test_round_trip_and_cache(tmp_path):
+    row = mf.ManifestRow(
+        name="baseline",
+        key="deadbeefdeadbeef",
+        config={"SEARCH_WEIGHT_VECTOR": "0.35"},
+        automem_commit="abc123",
+        seed=42,
+        snapshot_id="snap1",
+        scorecard={"name": "baseline", "ndcg_10": 0.8, "distractor_rate_10": 0.1,
+                   "latency_ms": 100.0, "complexity": 5},
+        status="ok",
+    )
+    assert mf.is_cached(str(tmp_path), row.key) is False
+    mf.save_row(str(tmp_path), row)
+    assert mf.is_cached(str(tmp_path), row.key) is True
+    rows = mf.load_rows(str(tmp_path))
+    assert len(rows) == 1
+    assert rows[0].name == "baseline"
+    assert rows[0].scorecard["ndcg_10"] == 0.8
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/matrix/test_manifest.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'runners.matrix'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `runners/matrix/__init__.py` (empty file).
+
+Create `runners/matrix/manifest.py`:
+
+```python
+"""Provenance manifest + cell keying for the parallel matrix harness.
+
+A cell is uniquely identified by (config, automem_commit, seed, snapshot_id).
+Its result JSON is the durable record; existence == done (idempotent resume).
+"""
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def cell_key(config: Dict[str, Any], automem_commit: str, seed: int, snapshot_id: str) -> str:
+    payload = json.dumps(
+        {"config": config, "commit": automem_commit, "seed": seed, "snapshot": snapshot_id},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+@dataclass
+class ManifestRow:
+    name: str
+    key: str
+    config: Dict[str, Any]
+    automem_commit: str
+    seed: int
+    snapshot_id: str
+    scorecard: Dict[str, Any] = field(default_factory=dict)
+    status: str = "ok"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "key": self.key,
+            "config": self.config,
+            "automem_commit": self.automem_commit,
+            "seed": self.seed,
+            "snapshot_id": self.snapshot_id,
+            "scorecard": self.scorecard,
+            "status": self.status,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "ManifestRow":
+        return cls(
+            name=d["name"],
+            key=d["key"],
+            config=d.get("config", {}),
+            automem_commit=d.get("automem_commit", ""),
+            seed=d.get("seed", 0),
+            snapshot_id=d.get("snapshot_id", ""),
+            scorecard=d.get("scorecard", {}),
+            status=d.get("status", "ok"),
+        )
+
+
+def result_path(results_dir: str, key: str) -> Path:
+    return Path(results_dir) / f"{key}.json"
+
+
+def is_cached(results_dir: str, key: str) -> bool:
+    return result_path(results_dir, key).exists()
+
+
+def save_row(results_dir: str, row: ManifestRow) -> Path:
+    Path(results_dir).mkdir(parents=True, exist_ok=True)
+    final = result_path(results_dir, row.key)
+    tmp = final.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(row.to_dict(), indent=2))
+    os.replace(tmp, final)
+    return final
+
+
+def load_rows(results_dir: str) -> List[ManifestRow]:
+    p = Path(results_dir)
+    if not p.exists():
+        return []
+    return [ManifestRow.from_dict(json.loads(f.read_text())) for f in sorted(p.glob("*.json"))]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/matrix/test_manifest.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add runners/matrix/__init__.py runners/matrix/manifest.py tests/matrix/conftest.py tests/matrix/test_manifest.py
+git commit -m "feat(matrix): cell-keying + provenance manifest with idempotent cache"
+```
+
+---
+
+### Task 2: Compose lint (no container_name / fixed host ports)
+
+**Files:**
+- Create: `runners/matrix/compose_lint.py`
+- Create: `tests/matrix/test_compose_lint.py`
+
+**Interfaces:**
+- Produces: `lint_compose(yaml_text: str) -> list[str]` — returns a list of human-readable error strings; empty list means clean. Flags any service with a `container_name`, and any `ports` entry whose host side is a fixed literal (e.g. `"6379:6379"`) rather than a variable (`"${FALKOR_PORT}:6379"`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/matrix/test_compose_lint.py`:
+
+```python
+from runners.matrix.compose_lint import lint_compose
+
+CLEAN = """
+services:
+  falkordb:
+    image: falkordb/falkordb
+    ports:
+      - "${FALKOR_PORT}:6379"
+  flask-api:
+    build: .
+    ports:
+      - "${API_PORT}:8001"
+"""
+
+DIRTY = """
+services:
+  falkordb:
+    container_name: falkordb
+    ports:
+      - "6379:6379"
+  flask-api:
+    ports:
+      - "${API_PORT}:8001"
+"""
+
+
+def test_clean_compose_has_no_errors():
+    assert lint_compose(CLEAN) == []
+
+
+def test_dirty_compose_flags_container_name_and_fixed_port():
+    errors = lint_compose(DIRTY)
+    assert any("container_name" in e for e in errors)
+    assert any("6379:6379" in e for e in errors)
+    assert len(errors) == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/matrix/test_compose_lint.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'runners.matrix.compose_lint'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `runners/matrix/compose_lint.py`:
+
+```python
+"""Lint a docker-compose / override for matrix-isolation anti-patterns:
+fixed container_name (breaks per-cell isolation) and literal host ports
+(breaks parallel stacks). Host ports must be variables like ${API_PORT}.
+"""
+
+import re
+from typing import List
+
+import yaml
+
+_FIXED_HOST_PORT = re.compile(r"^\s*\d+:\d+\s*$")
+
+
+def lint_compose(yaml_text: str) -> List[str]:
+    errors: List[str] = []
+    doc = yaml.safe_load(yaml_text) or {}
+    services = doc.get("services", {}) or {}
+    for svc_name, svc in services.items():
+        if not isinstance(svc, dict):
+            continue
+        if "container_name" in svc:
+            errors.append(f"service '{svc_name}' sets container_name (breaks isolation)")
+        for port in svc.get("ports", []) or []:
+            if isinstance(port, str) and _FIXED_HOST_PORT.match(port):
+                errors.append(f"service '{svc_name}' uses fixed host port '{port}'")
+    return errors
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/matrix/test_compose_lint.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add runners/matrix/compose_lint.py tests/matrix/test_compose_lint.py
+git commit -m "feat(matrix): compose lint for container_name + fixed host ports"
+```
+
+---
+
+### Task 3: Port algebra + RAM-based concurrency
+
+**Files:**
+- Create: `runners/matrix/resources.py`
+- Create: `tests/matrix/test_resources.py`
+
+**Interfaces:**
+- Produces: `cell_ports(index: int, base_api: int = 18001) -> dict` — deterministic host ports for cell `index`: `{"api": base_api+index*10, "falkor": base_api+index*10+1, "falkor_ui": base_api+index*10+2, "qdrant": base_api+index*10+3}`. (Stride 10 leaves headroom and keeps blocks non-overlapping for index < 10 internal offsets.)
+- Produces: `max_concurrency(total_gb: float, per_stack_gb: float, headroom: float = 0.8) -> int` — `max(1, floor(total_gb*headroom / per_stack_gb))`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/matrix/test_resources.py`:
+
+```python
+from runners.matrix import resources as r
+
+
+def test_cell_ports_are_deterministic_and_non_overlapping():
+    p0 = r.cell_ports(0)
+    p1 = r.cell_ports(1)
+    assert p0 == {"api": 18001, "falkor": 18002, "falkor_ui": 18003, "qdrant": 18004}
+    assert p1["api"] == 18011
+    # no overlap between adjacent cells' blocks
+    assert set(p0.values()).isdisjoint(set(p1.values()))
+
+
+def test_max_concurrency_respects_headroom_and_floor():
+    assert r.max_concurrency(80, 5) == 12       # floor(80*0.8/5)=12
+    assert r.max_concurrency(4, 5) == 1          # floor=0 -> floored to 1
+    assert r.max_concurrency(80, 5, headroom=0.5) == 8
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/matrix/test_resources.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'runners.matrix.resources'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `runners/matrix/resources.py`:
+
+```python
+"""Deterministic host-port allocation and RAM-based concurrency for the matrix."""
+
+import math
+from typing import Dict
+
+
+def cell_ports(index: int, base_api: int = 18001) -> Dict[str, int]:
+    base = base_api + index * 10
+    return {"api": base, "falkor": base + 1, "falkor_ui": base + 2, "qdrant": base + 3}
+
+
+def max_concurrency(total_gb: float, per_stack_gb: float, headroom: float = 0.8) -> int:
+    if per_stack_gb <= 0:
+        return 1
+    return max(1, math.floor(total_gb * headroom / per_stack_gb))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/matrix/test_resources.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add runners/matrix/resources.py tests/matrix/test_resources.py
+git commit -m "feat(matrix): deterministic port algebra + RAM concurrency cap"
+```
+
+---
+
+### Task 4: Bake config env into a per-stack compose override
+
+**Files:**
+- Create: `runners/matrix/override.py`
+- Create: `tests/matrix/test_override.py`
+
+**Interfaces:**
+- Produces: `build_override(ports: dict, config: dict) -> dict` — returns a docker-compose override dict that (a) maps host ports via the `ports` dict using variable-free explicit host:container strings derived from `ports` (e.g. `f"{ports['falkor']}:6379"`), and (b) injects every key/value of `config` into the `flask-api` service's `environment:` mapping (values stringified). Internal container ports stay 6379/6333/8001.
+- Produces: `render_override(ports: dict, config: dict) -> str` — YAML text of the override (passes `compose_lint` only for `container_name`; note literal host ports are expected here because this override is per-cell and the lint's fixed-port rule is for the *base* compose — see test).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/matrix/test_override.py`:
+
+```python
+import yaml
+
+from runners.matrix.override import build_override
+
+
+def test_build_override_bakes_config_into_flask_env():
+    ports = {"api": 18011, "falkor": 18012, "falkor_ui": 18013, "qdrant": 18014}
+    config = {"SEARCH_WEIGHT_VECTOR": "0.5", "RECALL_RELEVANCE_GATE": 0.2}
+    ov = build_override(ports, config)
+
+    env = ov["services"]["flask-api"]["environment"]
+    assert env["SEARCH_WEIGHT_VECTOR"] == "0.5"
+    assert env["RECALL_RELEVANCE_GATE"] == "0.2"  # stringified
+
+    # host ports mapped from the ports dict; internal ports fixed
+    assert f"{ports['api']}:8001" in ov["services"]["flask-api"]["ports"]
+    assert f"{ports['falkor']}:6379" in ov["services"]["falkordb"]["ports"]
+    assert f"{ports['qdrant']}:6333" in ov["services"]["qdrant"]["ports"]
+
+    # no container_name anywhere
+    assert "container_name" not in yaml.dump(ov)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/matrix/test_override.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'runners.matrix.override'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `runners/matrix/override.py`:
+
+```python
+"""Per-stack docker-compose override: maps host ports for this cell and bakes
+the cell's config into the flask-api environment (AutoMem reads config at boot).
+"""
+
+from typing import Any, Dict
+
+import yaml
+
+
+def build_override(ports: Dict[str, int], config: Dict[str, Any]) -> Dict[str, Any]:
+    environment = {str(k): str(v) for k, v in config.items()}
+    environment.setdefault("PORT", "8001")
+    return {
+        "services": {
+            "falkordb": {"ports": [f"{ports['falkor']}:6379", f"{ports['falkor_ui']}:3000"]},
+            "qdrant": {"ports": [f"{ports['qdrant']}:6333"]},
+            "flask-api": {
+                "ports": [f"{ports['api']}:8001"],
+                "environment": environment,
+            },
+        }
+    }
+
+
+def render_override(ports: Dict[str, int], config: Dict[str, Any]) -> str:
+    return yaml.safe_dump(build_override(ports, config), sort_keys=False)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/matrix/test_override.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add runners/matrix/override.py tests/matrix/test_override.py
+git commit -m "feat(matrix): per-stack override bakes config env + cell ports"
+```
+
+---
+
+### Task 5: Score a stack (compose lab_corpus + lab_metrics)
+
+**Files:**
+- Create: `runners/matrix/score.py`
+- Create: `tests/matrix/test_score.py`
+
+**Interfaces:**
+- Consumes: `lab_corpus.recall`, `lab_corpus.extract_ids` (imported from automem repo via the conftest path).
+- Consumes: `lab_metrics.ndcg_at_k`, `lab_metrics.distractor_rate_at_k`, `lab_metrics.config_complexity`.
+- Produces: `score_stack(api_url, headers, queries, *, distractor_ids=set(), recall_params=None, config=None, recall_fn=lab_corpus.recall) -> dict` — runs every query through `recall_fn`, computes mean NDCG@10, mean distractor_rate@10, mean latency (wall-clock per call), and `config_complexity(config)`; returns a scorecard dict with keys `name`-less core (`ndcg_10, distractor_rate_10, latency_ms, complexity`). `recall_fn` is injectable for tests. The caller adds `name`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/matrix/test_score.py`:
+
+```python
+from runners.matrix.score import score_stack
+
+
+def make_fake_recall(mapping):
+    """mapping: query -> list of result ids."""
+    def _recall(api_url, headers, query, **kwargs):
+        return {"results": [{"memory": {"id": i}} for i in mapping[query]]}
+    return _recall
+
+
+def test_score_stack_computes_scorecard_axes():
+    queries = [
+        {"query": "q1", "expected_ids": ["a"], "category": "Decision"},
+        {"query": "q2", "expected_ids": ["b"], "category": "Decision"},
+    ]
+    fake = make_fake_recall({"q1": ["a", "d1"], "q2": ["x", "b"]})
+    config = {"SEARCH_WEIGHT_VECTOR": "0.35", "SEARCH_WEIGHT_KEYWORD": "0.0"}
+    card = score_stack(
+        "http://x", {}, queries,
+        distractor_ids={"d1"}, config=config, recall_fn=fake,
+    )
+    # q1: a at rank1 -> ndcg 1.0 ; q2: b at rank2 -> ndcg ~0.63
+    assert 0.7 < card["ndcg_10"] < 0.85
+    # q1 has 1 distractor in top10 of 2 results = 0.5 ; q2 has 0 -> mean 0.25
+    assert card["distractor_rate_10"] == 0.25
+    assert card["complexity"] == 1  # only one nonzero weight
+    assert "latency_ms" in card
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/matrix/test_score.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'runners.matrix.score'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `runners/matrix/score.py`:
+
+```python
+"""Score one configured stack with the Plan A scorecard primitives.
+
+Imports lab_corpus / lab_metrics from the automem repo (single source of truth).
+"""
+
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+import os
+
+_AUTOMEM = os.environ.get("AUTOMEM_DIR", "/Users/jgarturo/Projects/OpenAI/automem")
+sys.path.insert(0, str(Path(_AUTOMEM) / "scripts" / "lab"))
+
+import lab_corpus  # noqa: E402
+import lab_metrics  # noqa: E402
+
+
+def score_stack(
+    api_url: str,
+    headers: Dict[str, str],
+    queries: List[Dict[str, Any]],
+    *,
+    distractor_ids: Optional[Iterable[str]] = None,
+    recall_params: Optional[Dict[str, Any]] = None,
+    config: Optional[Dict[str, Any]] = None,
+    recall_fn=lab_corpus.recall,
+) -> Dict[str, Any]:
+    distractor_ids = set(distractor_ids or set())
+    recall_params = recall_params or {}
+    ndcgs: List[float] = []
+    drates: List[float] = []
+    latencies: List[float] = []
+
+    for q in queries:
+        start = time.perf_counter()
+        data = recall_fn(api_url, headers, q["query"], **recall_params)
+        latencies.append((time.perf_counter() - start) * 1000)
+        retrieved = lab_corpus.extract_ids(data)
+        ndcgs.append(lab_metrics.ndcg_at_k(retrieved, q.get("expected_ids", []), 10))
+        drates.append(lab_metrics.distractor_rate_at_k(retrieved, distractor_ids, 10))
+
+    n = max(len(queries), 1)
+    return {
+        "ndcg_10": sum(ndcgs) / n,
+        "distractor_rate_10": sum(drates) / n,
+        "latency_ms": sum(latencies) / n,
+        "complexity": lab_metrics.config_complexity(config or {}),
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/matrix/test_score.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add runners/matrix/score.py tests/matrix/test_score.py
+git commit -m "feat(matrix): score_stack composing lab_corpus + lab_metrics"
+```
+
+---
+
+### Task 6: Orchestrator loop (resume + winner, provider/scorer injected)
+
+The orchestration logic — iterate configs, skip cached cells, score the rest, save manifest rows, select a winner — is unit-tested with an injected fake provider and fake scorer (no Docker). The real provider (Task 7) plugs into the same interface.
+
+**Files:**
+- Create: `runners/matrix/orchestrator.py`
+- Create: `tests/matrix/test_orchestrator.py`
+
+**Interfaces:**
+- Consumes: `manifest.cell_key`, `manifest.is_cached`, `manifest.save_row`, `manifest.load_rows`, `manifest.ManifestRow`; `lab_metrics.pick_winner`.
+- Produces: `run_matrix(configs, *, results_dir, automem_commit, snapshot_id, seed, baseline_name, provision, score, teardown) -> dict` where:
+  - `configs`: list of `{"name": str, "config": dict}`.
+  - `provision(name, config) -> str` returns an api_url (real impl: up stack + restore); `score(api_url, name, config) -> dict` returns a scorecard core (no `name`); `teardown(name) -> None`. All three are injected.
+  - Behavior: for each config, compute `key`; if `is_cached`, skip (load existing). Else `provision` → `score` → save `ManifestRow` (scorecard gets `name` added) → `teardown` in `finally`. After all, load all rows, build cards (`{**scorecard, "name": name}`), return `{"winner": pick_winner(cards, baseline_name=baseline_name), "rows": [...]}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/matrix/test_orchestrator.py`:
+
+```python
+from runners.matrix.orchestrator import run_matrix
+
+
+def test_run_matrix_scores_resumes_and_picks_winner(tmp_path):
+    configs = [
+        {"name": "baseline", "config": {"SEARCH_WEIGHT_VECTOR": "0.35"}},
+        {"name": "simpler", "config": {"SEARCH_WEIGHT_VECTOR": "0.35"}},
+    ]
+    scores = {
+        "baseline": {"ndcg_10": 0.80, "distractor_rate_10": 0.10, "latency_ms": 100.0, "complexity": 5},
+        "simpler": {"ndcg_10": 0.801, "distractor_rate_10": 0.10, "latency_ms": 90.0, "complexity": 3},
+    }
+    provisioned, torn = [], []
+
+    def provision(name, config):
+        provisioned.append(name)
+        return f"http://stack/{name}"
+
+    def score(api_url, name, config):
+        return scores[name]
+
+    def teardown(name):
+        torn.append(name)
+
+    out = run_matrix(
+        configs, results_dir=str(tmp_path), automem_commit="abc", snapshot_id="snap",
+        seed=42, baseline_name="baseline", provision=provision, score=score, teardown=teardown,
+    )
+    assert out["winner"]["name"] == "simpler"  # within ndcg tol, fewer knobs + faster
+    assert set(torn) == {"baseline", "simpler"}  # always torn down
+
+    # Resume: second run scores nothing (all cached) but still picks winner.
+    provisioned.clear()
+    out2 = run_matrix(
+        configs, results_dir=str(tmp_path), automem_commit="abc", snapshot_id="snap",
+        seed=42, baseline_name="baseline", provision=provision, score=score, teardown=teardown,
+    )
+    assert provisioned == []  # nothing re-provisioned
+    assert out2["winner"]["name"] == "simpler"
+
+
+def test_run_matrix_tears_down_on_score_failure(tmp_path):
+    torn = []
+
+    def provision(name, config):
+        return "http://x"
+
+    def score(api_url, name, config):
+        raise RuntimeError("boom")
+
+    def teardown(name):
+        torn.append(name)
+
+    out = run_matrix(
+        [{"name": "baseline", "config": {}}], results_dir=str(tmp_path),
+        automem_commit="abc", snapshot_id="snap", seed=1, baseline_name="baseline",
+        provision=provision, score=score, teardown=teardown,
+    )
+    assert torn == ["baseline"]  # finally ran despite the failure
+    assert out["rows"][0].status == "error"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/matrix/test_orchestrator.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'runners.matrix.orchestrator'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `runners/matrix/orchestrator.py`:
+
+```python
+"""Sequential matrix orchestrator: provision -> score -> teardown per config,
+idempotent resume via the manifest, winner via lab_metrics.pick_winner.
+
+Concurrency is intentionally left to the caller/runner; this core is sequential
+and deterministic so it is fully unit-testable with injected provider/scorer.
+"""
+
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict, List
+
+import os
+
+from . import manifest as mf
+
+_AUTOMEM = os.environ.get("AUTOMEM_DIR", "/Users/jgarturo/Projects/OpenAI/automem")
+sys.path.insert(0, str(Path(_AUTOMEM) / "scripts" / "lab"))
+import lab_metrics  # noqa: E402
+
+
+def run_matrix(
+    configs: List[Dict[str, Any]],
+    *,
+    results_dir: str,
+    automem_commit: str,
+    snapshot_id: str,
+    seed: int,
+    baseline_name: str,
+    provision: Callable[[str, Dict[str, Any]], str],
+    score: Callable[[str, str, Dict[str, Any]], Dict[str, Any]],
+    teardown: Callable[[str], None],
+) -> Dict[str, Any]:
+    for entry in configs:
+        name, config = entry["name"], entry["config"]
+        key = mf.cell_key(config, automem_commit, seed, snapshot_id)
+        if mf.is_cached(results_dir, key):
+            continue
+        status, scorecard = "ok", {}
+        try:
+            api_url = provision(name, config)
+            scorecard = score(api_url, name, config)
+        except Exception as e:  # noqa: BLE001
+            status = "error"
+            scorecard = {"error": str(e)}
+        finally:
+            try:
+                teardown(name)
+            except Exception:  # noqa: BLE001
+                pass
+        mf.save_row(
+            results_dir,
+            mf.ManifestRow(
+                name=name, key=key, config=config, automem_commit=automem_commit,
+                seed=seed, snapshot_id=snapshot_id,
+                scorecard={**scorecard, "name": name}, status=status,
+            ),
+        )
+
+    rows = mf.load_rows(results_dir)
+    cards = [r.scorecard for r in rows if r.status == "ok" and "ndcg_10" in r.scorecard]
+    winner = lab_metrics.pick_winner(cards, baseline_name=baseline_name) if cards else None
+    return {"winner": winner, "rows": rows}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/matrix/test_orchestrator.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add runners/matrix/orchestrator.py tests/matrix/test_orchestrator.py
+git commit -m "feat(matrix): orchestrator loop with resume + winner selection"
+```
+
+---
+
+### Task 7: Live provider + synthetic-corpus smoke test
+
+Wire the real `provision`/`score`/`teardown` to `matrix_stack.py` + a synthetic corpus, and prove the whole harness works end to end on real Docker WITHOUT needing the production clone. This task is validated by running, not by a pure unit test.
+
+**Files:**
+- Create: `runners/matrix/live.py`
+- Create: `runners/matrix/smoke.py`
+- Create: `tests/matrix/test_live_helpers.py`
+
+**Interfaces:**
+- Consumes: `runners/matrix/resources.cell_ports`, `runners/matrix/override.render_override`, `manifest`, `score.score_stack`.
+- Produces (pure, unit-tested): `compose_up_cmd(project, automem_dir, override_path, ports) -> list[str]` and `compose_down_cmd(project) -> list[str]` — the exact docker compose argv (so the argv construction is testable without Docker).
+- Produces (live, smoke-only): `LiveProvider(automem_dir, base_api).provision/score/teardown`; `smoke.main()` seeds ~10 synthetic memories + 5 distractors into each stack, scores 2 configs (a baseline and a simpler one), and writes a manifest under `data/results/matrix-smoke/`.
+
+- [ ] **Step 1: Write the failing test (pure argv construction)**
+
+Create `tests/matrix/test_live_helpers.py`:
+
+```python
+from runners.matrix.live import compose_up_cmd, compose_down_cmd
+
+
+def test_compose_up_cmd_uses_project_and_both_files():
+    ports = {"api": 18001, "falkor": 18002, "falkor_ui": 18003, "qdrant": 18004}
+    cmd = compose_up_cmd("automem_eval_baseline", "/repo/automem", "/tmp/ov.yml", ports)
+    assert cmd[:2] == ["docker", "compose"]
+    assert "-p" in cmd and "automem_eval_baseline" in cmd
+    assert "/repo/automem/docker-compose.yml" in cmd
+    assert "/tmp/ov.yml" in cmd
+    assert cmd[-2:] == ["up", "-d"]
+
+
+def test_compose_down_cmd_removes_volumes():
+    cmd = compose_down_cmd("automem_eval_baseline")
+    assert "down" in cmd and "-v" in cmd and "--remove-orphans" in cmd
+    assert "automem_eval_baseline" in cmd
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/matrix/test_live_helpers.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'runners.matrix.live'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `runners/matrix/live.py`:
+
+```python
+"""Live provider: provision an isolated AutoMem stack with a baked config,
+score it, tear it down. Used by the matrix orchestrator for real runs.
+"""
+
+import os
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+import requests
+
+from . import override as ov_mod
+from . import resources
+from . import score as score_mod
+
+AUTOMEM_DIR = os.environ.get("AUTOMEM_DIR", "/Users/jgarturo/Projects/OpenAI/automem")
+API_TOKEN = os.environ.get("AUTOMEM_API_TOKEN", "benchmark-token")
+
+
+def _project(name: str) -> str:
+    safe = "".join(c if c.isalnum() else "_" for c in name.lower())
+    return f"automem_eval_{safe}"
+
+
+def compose_up_cmd(project: str, automem_dir: str, override_path: str, ports: Dict[str, int]) -> List[str]:
+    return [
+        "docker", "compose", "-p", project,
+        "-f", str(Path(automem_dir) / "docker-compose.yml"),
+        "-f", override_path,
+        "up", "-d",
+    ]
+
+
+def compose_down_cmd(project: str) -> List[str]:
+    return ["docker", "compose", "-p", project, "down", "-v", "--remove-orphans"]
+
+
+def _headers() -> Dict[str, str]:
+    return {"Authorization": f"Bearer {API_TOKEN}", "Content-Type": "application/json"}
+
+
+class LiveProvider:
+    def __init__(self, automem_dir: str = AUTOMEM_DIR, base_api: int = 18001):
+        self.automem_dir = automem_dir
+        self.base_api = base_api
+        self._ports: Dict[str, Dict[str, int]] = {}
+        self._index = 0
+
+    def provision(self, name: str, config: Dict[str, Any]) -> str:
+        ports = resources.cell_ports(self._index, base_api=self.base_api)
+        self._index += 1
+        self._ports[name] = ports
+        ov_path = Path(tempfile.gettempdir()) / f"matrix-override-{_project(name)}.yml"
+        ov_path.write_text(ov_mod.render_override(ports, config))
+        subprocess.run(
+            compose_up_cmd(_project(name), self.automem_dir, str(ov_path), ports),
+            check=True, capture_output=True, text=True,
+        )
+        url = f"http://localhost:{ports['api']}"
+        self._wait_healthy(url)
+        return url
+
+    def _wait_healthy(self, url: str, timeout: int = 120) -> None:
+        last = None
+        for _ in range(timeout):
+            try:
+                if requests.get(f"{url}/health", timeout=2).status_code == 200:
+                    return
+            except Exception as e:  # noqa: BLE001
+                last = e
+            time.sleep(1)
+        raise TimeoutError(f"stack at {url} never became healthy: {last}")
+
+    def score(self, api_url: str, name: str, config: Dict[str, Any], queries=None,
+              distractor_ids=None, recall_params=None) -> Dict[str, Any]:
+        return score_mod.score_stack(
+            api_url, _headers(), queries or [],
+            distractor_ids=distractor_ids, recall_params=recall_params, config=config,
+        )
+
+    def teardown(self, name: str) -> None:
+        subprocess.run(compose_down_cmd(_project(name)), check=False, capture_output=True, text=True)
+```
+
+Create `runners/matrix/smoke.py`:
+
+```python
+"""End-to-end smoke: 2 stacks on a tiny synthetic corpus, no production clone.
+
+Run:
+  AUTOMEM_DIR=/Users/jgarturo/Projects/OpenAI/automem \
+  python -m runners.matrix.smoke
+"""
+
+import sys
+from pathlib import Path
+
+import os
+
+from . import live as live_mod
+from . import orchestrator
+from . import score as score_mod
+
+_AUTOMEM = os.environ.get("AUTOMEM_DIR", "/Users/jgarturo/Projects/OpenAI/automem")
+sys.path.insert(0, str(Path(_AUTOMEM) / "scripts" / "lab"))
+import lab_corpus  # noqa: E402
+
+SYNTH_MEMORIES = [
+    {"content": f"Synthetic memory {i}: project alpha decision about topic {i}.",
+     "tags": ["smoke"], "importance": 0.6} for i in range(10)
+]
+
+
+def _seed(api_url, headers):
+    ids = []
+    for m in SYNTH_MEMORIES:
+        r = lab_corpus.requests.post(f"{api_url}/memory", json=m, headers=headers, timeout=30)
+        r.raise_for_status()
+        d = r.json()
+        ids.append(str(d.get("memory_id") or d.get("id") or (d.get("memory") or {}).get("id")))
+    return ids
+
+
+def main() -> int:
+    headers = live_mod._headers()
+    provider = live_mod.LiveProvider(automem_dir=_AUTOMEM, base_api=18001)
+    results_dir = "data/results/matrix-smoke"
+
+    # Build queries + distractors lazily per stack inside score.
+    def provision(name, config):
+        url = provider.provision(name, config)
+        seeded = _seed(url, headers)
+        distractors = set(lab_corpus.inject_distractors(
+            url, headers, lab_corpus.make_distractor_memories(5)))
+        provider._smoke = {"queries": [
+            {"query": SYNTH_MEMORIES[i]["content"][:40], "expected_ids": [seeded[i]],
+             "category": "smoke"} for i in range(len(seeded))],
+            "distractors": distractors}
+        return url
+
+    def score(api_url, name, config):
+        s = provider._smoke
+        return score_mod.score_stack(api_url, headers, s["queries"],
+                                     distractor_ids=s["distractors"], config=config)
+
+    out = orchestrator.run_matrix(
+        [
+            {"name": "baseline", "config": {"SEARCH_WEIGHT_VECTOR": "0.35", "SEARCH_WEIGHT_KEYWORD": "0.35"}},
+            {"name": "simpler", "config": {"SEARCH_WEIGHT_VECTOR": "0.35", "SEARCH_WEIGHT_KEYWORD": "0.0"}},
+        ],
+        results_dir=results_dir, automem_commit="smoke", snapshot_id="synthetic",
+        seed=42, baseline_name="baseline",
+        provision=provision, score=score, teardown=provider.teardown,
+    )
+    print("WINNER:", out["winner"])
+    print("ROWS:", [(r.name, r.status, r.scorecard.get("ndcg_10")) for r in out["rows"]])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run the pure test, then the live smoke**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/matrix/test_live_helpers.py -v`
+Expected: PASS (2 tests).
+
+Then the live smoke (requires Docker; uses synthetic data only):
+
+Run: `AUTOMEM_DIR=/Users/jgarturo/Projects/OpenAI/automem python -m runners.matrix.smoke`
+Expected: two stacks come up on ports 18001/18011 blocks, seed + score, print a `WINNER:` line with a `name` and a `reason`, and `ROWS:` showing both configs with non-null `ndcg_10`. A manifest appears under `data/results/matrix-smoke/`. Both stacks are torn down (verify `docker ps` shows no `automem_eval_*` containers afterward).
+
+If the smoke reveals an integration issue (port collision, health timeout, env not applied), fix it in `live.py`/`override.py` and re-run until the WINNER line prints and `docker ps` is clean. Report the exact `WINNER:`/`ROWS:` output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add runners/matrix/live.py runners/matrix/smoke.py tests/matrix/test_live_helpers.py
+git commit -m "feat(matrix): live provider + synthetic-corpus end-to-end smoke"
+```
+
+---
+
+### Task 8: Format, lint, full-suite green, and a runnable entrypoint doc
+
+**Files:**
+- Create: `runners/matrix/README.md`
+
+- [ ] **Step 1: Format + lint**
+
+Run:
+```bash
+black runners/matrix/ tests/matrix/
+flake8 runners/matrix/ tests/matrix/
+```
+Expected: black "All done"/unchanged; flake8 no output. Fix any issue inline.
+
+- [ ] **Step 2: Full matrix suite green**
+
+Run: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/matrix/ -v`
+Expected: all PASS (manifest, compose_lint, resources, override, score, orchestrator, live_helpers).
+
+- [ ] **Step 3: Write the entrypoint doc**
+
+Create `runners/matrix/README.md` documenting: the worktree it lives in; that scoring is imported from `AUTOMEM_DIR`; how to run the smoke (`python -m runners.matrix.smoke`); the manifest/resume model (delete `data/results/<dir>/<key>.json` to force a re-run of one cell); the isolation rules (config baked into the override env; ports via `cell_ports`); and the path to a future full-corpus run (swap the synthetic `_seed` for `clone_production.sh --restore-only` into each stack, supply the real query set from `create_test_queries.py`, and set a real `automem_commit`/`snapshot_id`). Note explicitly that the full-corpus run needs production backup access and is a separate, supervised step.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add runners/matrix/README.md
+git commit -m "docs(matrix): entrypoint, isolation model, path to full-corpus run"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Plan B scope = spec §2 funnel Tier-1, §7 orchestration):**
+- Isolated stacks, project naming, dynamic ports, no container_name/fixed ports → Task 3 (ports) + Task 4 (override) + Task 2 (lint) + Task 7 (live). ✓
+- Config baked per stack (boot-time env) → Task 4 + Task 7. ✓
+- Provenance manifest (config+commit+seed+snapshot) → Task 1. ✓
+- Idempotent resume → Task 1 (`is_cached`) + Task 6 (skip logic, tested). ✓
+- RAM-based concurrency cap → Task 3 (`max_concurrency`); applied by the runner/caller (the orchestrator core is sequential by design; the concurrency cap is a pure helper the live runner uses to bound waves). Noted: wave-parallel execution is a thin wrapper over the sequential core, deferred to the full-corpus run where it matters.
+- Scoring via lab primitives (one source of truth) → Task 5. ✓
+- Winner via pick_winner → Task 6. ✓
+- Teardown always → Task 6 (`finally`, tested) + Task 7 (`down -v --remove-orphans`). ✓
+- Tier-2 usefulness gate + Tier-3 benchmark confirm → out of scope (later plan / Plan C). ✓
+- Worktree isolation from the BEAM agent → Task 0. ✓
+
+**Placeholder scan:** no TBD/TODO; pure-logic steps show complete code; the live step gives exact run commands + expected output. ✓
+
+**Type consistency:** `cell_ports`→dict consumed by `build_override`/`compose_up_cmd`; `score_stack`→dict (no `name`) consumed by `run_matrix` which adds `name` before `pick_winner` (which reads `name`) — matches the Plan A contract fixed in commit "align scorecard key contract". `provision/score/teardown` signatures in Task 6 tests match `LiveProvider` in Task 7. ✓
+
+**Scope check:** one coherent deliverable — a parallel corpus-sweep harness that runs configs and picks a winner, smoke-validated on synthetic data. Full-corpus run and the upper funnel tiers are explicitly deferred.
+
+---
+
+## Execution Handoff
+
+Execute via subagent-driven-development in the worktree. Task 0 (worktree) and Task 7-Step-4 (live smoke) are the only steps touching real Docker; all other steps are pure-unit-testable. After Plan B is green, the remaining work is the supervised full-corpus Tier-1 run and Plan C (AMB submission integrity).

--- a/docs/superpowers/specs/2026-06-16-recall-quality-optimization-harness-design.md
+++ b/docs/superpowers/specs/2026-06-16-recall-quality-optimization-harness-design.md
@@ -1,0 +1,229 @@
+# AutoMem Recall-Quality Optimization Harness — Design Spec
+
+- **Date:** 2026-06-16
+- **Status:** Draft for review
+- **Owner:** Jack Arturo (with Claude Code)
+- **Branch:** `eval/recall-quality-harness`
+
+---
+
+## 1. Goal & non-goals
+
+**Goal.** Improve AutoMem's recall quality measured against Jack's *real production
+corpus*, then confirm the gains on public benchmarks (AMB / BEAM / PersonaMem) and
+publish. The optimization target is intrinsic service quality, not benchmark score.
+
+**North star (operator's words):** *elegant, efficient, easy to understand, effective.*
+This governs both the service changes we accept and the evaluation harness we build.
+
+**Non-goals.**
+- Optimizing directly for a benchmark (overfitting to the eval).
+- Adding machinery for marginal wins. A change that improves quality but adds
+  complexity loses to one that matches quality with less.
+- Net-new tools/endpoints unless an existing one can't be extended.
+
+## 2. Guiding principle: tune on the corpus, confirm on the benchmark
+
+We optimize configs against the cloned production corpus (the *validation* surface),
+then run only the internal winners against the public benchmarks (the *holdout/test*
+surface). Because the corpus and the benchmark share no data, every published
+benchmark number is genuinely out-of-sample — this is the validation→test discipline,
+with a more realistic validation set than a benchmark slice.
+
+## 3. The quality metric — a legible scorecard, not a composite
+
+A weighted blend of five sub-metrics is precise but not *understandable*. We use one
+primary number, one guardrail, and two tiebreakers. Anyone can read why a config won.
+
+| Role | Metric | Why |
+|---|---|---|
+| **Primary (effective)** | **NDCG@10** on known-item queries | One standard IR metric that rewards *finding* the right memory **and** *ranking it high*. Burying or missing the answer drops it — no separate recall/precision math. |
+| **Guardrail (effective)** | **Distractor-precision** — share of top-10 results that are known-irrelevant (lower is better), measured against a salted distractor query set | Junk must not crowd out relevant results. Also the only metric that can *see* the forget/dreaming arm working (known-item recall is blind to suppression). |
+| **Tiebreaker (efficient)** | **Recall latency / result-economy** | Faster, tighter result sets win. |
+| **Tiebreaker (elegant)** | **Enabled-knob count** | Among configs within noise, the *simpler* one wins. Encodes "simplify if possible." |
+
+**Decision rule (one sentence):** *pick the highest NDCG@10 that does not regress
+distractor-precision; break ties toward fewer knobs and lower latency.*
+
+Why NDCG@10 over the current Recall@20: Recall@20 has no precision term — a config
+that returns the target at rank 20 under 19 junk results scores 100%. Optimizing it
+rewards casting wider nets (more complexity, the opposite of the goal) and is blind to
+forgetting. NDCG@10 fixes all three and is already computed at
+`scripts/lab/run_recall_test.py:47`.
+
+## 4. The three-tier funnel
+
+Each tier is more expensive and runs on fewer configs. The slow Gemini-3-Pro
+benchmark only ever sees configs that already won on Jack's data.
+
+| Tier | Surface | Configs | Cost | Purpose |
+|---|---|---|---|---|
+| **1 — Sweep** | Scorecard (§3) on cloned corpus | all ~10–14 | cheap, deterministic, parallel | rank every config + simplification arm |
+| **2 — Usefulness gate** | LLM-judged "is this recall actually useful?" on the corpus | top ~3 | moderate | catch what synthetic known-item retrieval misses (relevant-but-not-source) |
+| **3 — Publish** | AMB (ByteRover-matched) + BEAM + PersonaMem/32k | 1–2 finalists | expensive | out-of-sample confirmation → leaderboard PR |
+
+## 5. Experiment arms (the ~10–14 configs)
+
+OFAT: each arm perturbs **one factor** off a fixed, pinned baseline (current
+production defaults). The baseline config and the win condition are pre-registered
+(§6) before any numbers are seen.
+
+- **Additive** (PR #194 knobs, currently off by default): relevance-gate,
+  tag-score-token cap, recency-bias on/auto, min_score, recall-k.
+- **Subtractive / simplify**: enrichment off, JIT-enrichment off, zeroed/collapsed
+  search weights (do we need all 11?), recency-bias off. Goal: find what we can
+  remove without quality loss.
+- **Dreaming (labeled experimental)**: backdate timestamps → `/consolidate
+  {mode, dry_run:false}` → measure scorecard delta, especially distractor-precision.
+  See §8.
+
+## 6. Statistical methodology
+
+- **Validation = corpus, test = benchmark.** Sweep on the corpus; open each benchmark
+  surface once, for the frozen winner only.
+- **Paired comparisons, fixed item set.** Same queries across all configs; store
+  per-query outcome per config. The lab already does paired t-test + Cohen's d on
+  per-query IR metrics (`run_recall_test.py:81`). For binary correct/incorrect
+  (benchmark tier) use **McNemar (mid-p)**.
+- **Confidence intervals:** BCa bootstrap on items (≥10k resamples for any published
+  number; 1k during the sweep). Accuracies sit near the ceiling, where percentile CIs
+  mis-cover.
+- **Seeds:** 3 per config on the sweep/usefulness tiers, 5 on the published test runs;
+  report mean ± 95% CI, never a single run.
+- **Multiple comparisons:** Benjamini-Hochberg (q=0.10) to *screen* on validation;
+  Bonferroni across the published surfaces for the headline (α≈0.0167 for 3 surfaces).
+- **Power reality:** at corpus/benchmark item counts a +2–3pt single-surface gap is
+  likely underpowered. Mitigations: pool across surfaces for the primary decision;
+  exploit pairing (McNemar power depends on discordant count). If still underpowered,
+  **report "within noise" — do not declare a winner.**
+- **Pre-registration:** a one-pager fixed before numbers: baseline config, primary
+  surface+metric, win condition, split/seed, repeats, judge model+temperature, the
+  declared family of comparisons.
+
+## 7. Orchestration & isolation
+
+Worktrees isolate *code*, not *runtime* — each config needs its own FalkorDB+Qdrant or
+results bleed across cells.
+
+- **One stack per cell** via `matrix_stack.py`: `COMPOSE_PROJECT_NAME=lab-<config>-<commit8>-<seed>`,
+  dynamic host ports derived deterministically from the cell id (so a resumed cell
+  re-lands on identical ports).
+- **No fixed `container_name`, no literal host ports, no shared DB volumes.** Add a
+  lint that fails a matrix compose file containing either. Add a CI/precheck.
+- **Shared model cache, read-only:** pre-download FastEmbed `bge-base-en-v1.5` once,
+  mount `:ro` with `HF_HUB_OFFLINE=1` → byte-identical weights, no download races.
+- **Concurrency = RAM, not CPU.** Measure one cell's peak RSS; `max ≈ floor(0.8·80GB /
+  peak)`. Pin `mem_limit`+`cpus` per service so one OOM kills only its cell. Admit via
+  semaphore with a 5–15s stagger (cold-start I/O is the real contention).
+- **Provenance manifest:** one row per cell keyed on a content hash of
+  `{config, git_commit, seed, corpus_snapshot_id, embedding_model+version,
+  image_digest, answer/judge model+version, temperature}`. Pin the corpus snapshot;
+  do not re-clone live prod mid-sweep.
+- **Idempotent resume:** a cell is done iff `results/<hash>.json` exists (temp +
+  atomic rename). A crashed run re-runs the identical command and converges on only
+  the missing cells.
+- **Shared API keys → global token bucket** across the matrix (not per-cell backoff),
+  retry only transient 429/5xx with jittered backoff honoring Retry-After.
+- **Teardown:** `down -v --remove-orphans` in a finally block; a labeled reaper for
+  stacks whose process died.
+
+## 8. Consolidation ("dreaming") arm
+
+Experimental, kept identical to the no-dream baseline except one inserted step, so any
+delta is attributable to consolidation alone.
+
+- **Force a real pass:** `dry_run` defaults to **true** (`automem/api/consolidation.py:26`).
+  Send `{"mode": <mode>, "dry_run": false}` or creative/cluster/forget are no-ops.
+- **Time compression by backdating timestamps, not looping cycles.** Decay relevance
+  is a pure function of age (`consolidation.py:243`), recomputed wholesale each call —
+  N cycles ≠ N intervals. To represent "6 months old," ingest with a backdated
+  `timestamp` and run decay once. (Single `POST /memory` accepts backdated
+  `timestamp`/`last_accessed`/`t_valid`; batch accepts only `timestamp`.)
+- **Order:** ingest (backdated) → drain enrichment → decay → creative → cluster →
+  forget. One real pass per mode (idempotent on age).
+- **Gotchas:** creative & cluster only sample `relevance_score > 0.3`, which store does
+  *not* set — run decay first or they see zero candidates. Enrichment SIMILAR_TO edges
+  suppress creative on high-similarity pairs — for a clean ablation compare
+  enrich-then-consolidate vs consolidate-only. The HTTP forget endpoint uses class
+  defaults that forget **more aggressively than prod** — state this or call the
+  scheduler builder in-process to match prod. Don't recall before the measured pass
+  (recall bumps `last_accessed`, resetting decay).
+- **Observability:** only **forget** changes default recall; decay is invisible
+  (`SEARCH_WEIGHT_RELEVANCE=0.0`); creative/cluster surface only with
+  `expand_relations=true`. So measure the dreaming arm via distractor-precision
+  (forget) and multi-hop recall with `expand_relations` (creative/cluster).
+
+## 9. AMB submission integrity (publish tier)
+
+- **Verbatim board judge/answer prompts.** Zero custom judge prompt, equivalence
+  rules, or dataset-specific answer instructions. All tuning lives in the recall path.
+  (The Mem0 −19.6pt reproduction scandal was custom judge rules.)
+- **Comparability anchor: ByteRover 2.0** — Gemini 3 Flash (curate/retrieve/judge) +
+  Gemini 3 Pro (justify). Set `OMB_ANSWER_LLM`/`OMB_ANSWER_MODEL` **explicitly** (the
+  default is buggy — `OMB_ANSWER_LLM` defaults to `groq`, issue #15).
+- **Fix two harness bugs before publishing:** (a) the groq answer-model default;
+  (b) `gemini.py:74-76` returns `correct=<last_text>` (truthy) on judge parse failure
+  — a silently fabricated "correct." Make parse-failure abstain/error. Land these as a
+  small upstream PR (helps the whole board, strengthens our credibility).
+- **Baselines through the identical pipeline:** bm25, full-context, closed-book
+  (no-memory), oracle (gold-docs). The AutoMem delta must sit *above* the closed-book
+  parametric-knowledge floor.
+- **Contamination caveat** on LoCoMo/LongMemEval (predate the answer model). Lead with
+  PersonaMem MCQ (deterministic, judge-free) and BEAM long-context where "dump
+  everything in context" can't win.
+- **Reproducibility:** response-cache artifact (cached answer/judge responses so the
+  maintainer re-judges identically) + mean±std. Hosted APIs aren't byte-reproducible;
+  this is the pragmatic, elegant choice (no self-hosting).
+- **Run full splits** (drop `--query-limit`); normalize **k** across providers; report
+  all four AMB axes (accuracy, retrieval latency, ingestion time, token cost). Current
+  committed outputs are smoke tests (locomo 152/1540, longmemeval 30/500, personamem
+  absent) and are **not** publishable.
+
+## 10. Build vs reuse
+
+**Reuse:** corpus clone (`scripts/lab/clone_production.sh`), known-item query gen
+(`create_test_queries.py`), IR metrics + paired stats (`run_recall_test.py`), isolated
+stacks (`automem-evals/scripts/matrix_stack.py`), AMB self-spinning provider
+(`agent-memory-benchmark/.../memory/automem.py`).
+
+**Build (small):** distractor metric + distractor query set; timestamp-backdate
+utility; consolidation step inside the recall loop; simplicity (knob-count) score;
+matrix-compose lint.
+
+**Build (the one real lift):** wire the lab recall test to run as a *matrix cell* —
+accept `endpoint + config` and drop the docker-restart coupling
+(`run_recall_test.py:158`) so the sweep runs in parallel across isolated stacks.
+
+## 11. Repo placement (per `CLAUDE.md` benchmark-ownership)
+
+- **Exploratory sweep orchestration + scorecard runner → `automem-evals`** (ruleset
+  sweeps, seeded corpora are explicitly its domain).
+- **Lab metric changes (NDCG objective, distractor metric, backdate util,
+  consolidation-in-loop, lab-as-matrix-cell) → `automem/scripts/lab`.**
+- **AMB provider, results, submission PR → `agent-memory-benchmark`.**
+- **Any official release-gating benchmark flow → `automem`.**
+
+## 12. Risks & open items
+
+- **Synthetic known-item ground truth.** Queries are GPT-generated, one source memory
+  = the only "relevant" doc; blind to relevant-but-not-source. Mitigated by the Tier-2
+  usefulness gate and the benchmark holdout — a config must win on all three to be
+  declared a winner.
+- **Concurrency constraints (carried, not re-litigated):** automem `main` has unrelated
+  uncommitted WIP — do not stash/checkout over it. Don't run two judged runs against
+  the same stack. Keep external LLM calls out of the AutoMem service path; no secrets
+  in images.
+- **`:8001` dev-instance data loss** (separate from this work) — recover via
+  `scripts/recover_from_qdrant.py` or dismiss; tracked outside this spec.
+
+## 13. Success criteria
+
+One of:
+- A config that beats baseline on **NDCG@10** with **no distractor-precision
+  regression**, is **simpler and/or faster**, and confirms on ≥1 benchmark surface
+  with significance after correction; **or**
+- A defensible "current config is near-optimal; here is exactly what we can safely
+  *remove* to make it more elegant/efficient without quality loss."
+
+Either outcome ships: a tuned-and-simplified service, plus an honest, reproducible AMB
+leaderboard submission with baselines and caveats.

--- a/docs/superpowers/specs/2026-06-16-recall-quality-optimization-harness-design.md
+++ b/docs/superpowers/specs/2026-06-16-recall-quality-optimization-harness-design.md
@@ -48,8 +48,8 @@ distractor-precision; break ties toward fewer knobs and lower latency.*
 Why NDCG@10 over the current Recall@20: Recall@20 has no precision term — a config
 that returns the target at rank 20 under 19 junk results scores 100%. Optimizing it
 rewards casting wider nets (more complexity, the opposite of the goal) and is blind to
-forgetting. NDCG@10 fixes all three and is already computed at
-`scripts/lab/run_recall_test.py:47`.
+forgetting. NDCG@10 fixes all three and is computed by `lab_metrics.ndcg_at_k`,
+which `run_single_query` records per query.
 
 ## 4. The three-tier funnel
 
@@ -83,7 +83,8 @@ production defaults). The baseline config and the win condition are pre-register
   surface once, for the frozen winner only.
 - **Paired comparisons, fixed item set.** Same queries across all configs; store
   per-query outcome per config. The lab already does paired t-test + Cohen's d on
-  per-query IR metrics (`run_recall_test.py:81`). For binary correct/incorrect
+  per-query IR metrics via `lab_metrics.paired_ttest`, formatted by
+  `print_comparison`. For binary correct/incorrect
   (benchmark tier) use **McNemar (mid-p)**.
 - **Confidence intervals:** BCa bootstrap on items (≥10k resamples for any published
   number; 1k during the sweep). Accuracies sit near the ceiling, where percentile CIs
@@ -191,8 +192,8 @@ utility; consolidation step inside the recall loop; simplicity (knob-count) scor
 matrix-compose lint.
 
 **Build (the one real lift):** wire the lab recall test to run as a *matrix cell* —
-accept `endpoint + config` and drop the docker-restart coupling
-(`run_recall_test.py:158`) so the sweep runs in parallel across isolated stacks.
+accept `endpoint + config` and drop the docker-restart coupling in
+`restart_api_with_config` so the sweep runs in parallel across isolated stacks.
 
 ## 11. Repo placement (per `CLAUDE.md` benchmark-ownership)
 

--- a/scripts/lab/lab_corpus.py
+++ b/scripts/lab/lab_corpus.py
@@ -1,0 +1,45 @@
+"""Corpus-side helpers for the AutoMem Recall Quality Lab.
+
+All HTTP lives here, behind injectable clients (http_get / http_post) so the
+logic is unit-testable without a live server. Imported by run_recall_test.py
+and the parallel matrix harness.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import requests
+
+
+def recall(
+    api_url: str,
+    headers: Dict[str, str],
+    query: str,
+    *,
+    limit: int = 20,
+    expand_relations: bool = False,
+    current_only: bool = True,
+    recency_bias: Optional[str] = None,
+    http_get=requests.get,
+) -> Dict[str, Any]:
+    """GET /recall with explicit recall parameters; returns parsed JSON."""
+    params: Dict[str, Any] = {"query": query, "limit": limit}
+    if expand_relations:
+        params["expand_relations"] = "true"
+    params["current_only"] = "true" if current_only else "false"
+    if recency_bias is not None:
+        params["recency_bias"] = recency_bias
+    resp = http_get(f"{api_url}/recall", params=params, headers=headers, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def extract_ids(recall_json: Dict[str, Any]) -> List[str]:
+    """Pull memory IDs from a /recall response (nested or flat shape)."""
+    results = recall_json.get("results", recall_json.get("memories", []))
+    ids: List[str] = []
+    for r in results:
+        mem = r.get("memory", r)
+        mid = str(mem.get("id", r.get("id", "")))
+        if mid:
+            ids.append(mid)
+    return ids

--- a/scripts/lab/lab_corpus.py
+++ b/scripts/lab/lab_corpus.py
@@ -5,6 +5,7 @@ logic is unit-testable without a live server. Imported by run_recall_test.py
 and the parallel matrix harness.
 """
 
+import time
 from typing import Any, Dict, List, Optional
 
 import requests
@@ -31,6 +32,64 @@ def recall(
     resp = http_get(f"{api_url}/recall", params=params, headers=headers, timeout=30)
     resp.raise_for_status()
     return resp.json()
+
+
+def iso_days_ago(days: float) -> str:
+    """UTC ISO-8601 timestamp `days` in the past."""
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - days * 86400))
+
+
+def make_distractor_memories(
+    n: int,
+    *,
+    age_days: float = 180,
+    importance: float = 0.05,
+    tag: str = "lab-distractor",
+) -> List[Dict[str, Any]]:
+    """Build n aged, low-importance, labelled distractor /memory payloads.
+
+    Pre-backdated so the `forget` consolidation mode treats them as stale; the
+    `lab-distractor` tag + metadata flag make them unambiguous noise for the
+    distractor-precision metric.
+    """
+    ts = iso_days_ago(age_days)
+    payloads: List[Dict[str, Any]] = []
+    for i in range(n):
+        payloads.append(
+            {
+                "content": (
+                    f"[lab-distractor #{i}] stale unrelated note about "
+                    f"miscellaneous topic {i}; safe to forget."
+                ),
+                "tags": [tag],
+                "importance": importance,
+                "timestamp": ts,
+                "last_accessed": ts,
+                "metadata": {"lab_distractor": True},
+            }
+        )
+    return payloads
+
+
+def inject_distractors(
+    api_url: str,
+    headers: Dict[str, str],
+    payloads: List[Dict[str, Any]],
+    *,
+    http_post=requests.post,
+) -> List[str]:
+    """POST distractor memories; return the created memory IDs."""
+    ids: List[str] = []
+    for payload in payloads:
+        resp = http_post(f"{api_url}/memory", json=payload, headers=headers, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        mid = str(
+            data.get("memory_id") or data.get("id") or (data.get("memory") or {}).get("id") or ""
+        )
+        if mid:
+            ids.append(mid)
+    return ids
 
 
 def extract_ids(recall_json: Dict[str, Any]) -> List[str]:

--- a/scripts/lab/lab_corpus.py
+++ b/scripts/lab/lab_corpus.py
@@ -102,3 +102,35 @@ def extract_ids(recall_json: Dict[str, Any]) -> List[str]:
         if mid:
             ids.append(mid)
     return ids
+
+
+CONSOLIDATION_ORDER = ["decay", "creative", "cluster", "forget"]
+
+
+def run_consolidation(
+    api_url: str,
+    headers: Dict[str, str],
+    modes: Optional[List[str]] = None,
+    *,
+    dry_run: bool = False,
+    http_post=requests.post,
+) -> Dict[str, Dict[str, Any]]:
+    """Run a REAL consolidation pass per mode, in order.
+
+    dry_run defaults to False: the /consolidate endpoint's own default is True,
+    which makes creative/cluster/forget silent no-ops. Decay runs first so
+    creative/cluster see memories with relevance_score > 0.3.
+    """
+    if modes is None:
+        modes = list(CONSOLIDATION_ORDER)
+    out: Dict[str, Dict[str, Any]] = {}
+    for mode in modes:
+        resp = http_post(
+            f"{api_url}/consolidate",
+            json={"mode": mode, "dry_run": dry_run},
+            headers=headers,
+            timeout=120,
+        )
+        resp.raise_for_status()
+        out[mode] = resp.json()
+    return out

--- a/scripts/lab/lab_metrics.py
+++ b/scripts/lab/lab_metrics.py
@@ -5,7 +5,7 @@ Imported by run_recall_test.py and by the parallel matrix harness.
 """
 
 import math
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable, List
 
 
 def recall_at_k(retrieved_ids: List[str], expected_ids: List[str], k: int) -> float:
@@ -35,6 +35,24 @@ def ndcg_at_k(retrieved_ids: List[str], expected_ids: List[str], k: int) -> floa
             dcg += 1.0 / math.log2(i + 2)
     ideal_dcg = sum(1.0 / math.log2(i + 2) for i in range(min(len(expected_ids), k)))
     return dcg / ideal_dcg if ideal_dcg > 0 else 0.0
+
+
+def distractor_rate_at_k(retrieved_ids: List[str], distractor_ids: Iterable[str], k: int) -> float:
+    """Fraction of the top-k results that are known distractors. Lower is better.
+
+    Distractors are memories we injected and labelled as never-relevant, so a
+    result that is a distractor is unambiguous noise. This is the precision
+    guardrail and the only metric that can see the `forget` consolidation mode
+    working (known-item recall is blind to suppression).
+    """
+    if k <= 0:
+        return 0.0
+    top_k = retrieved_ids[:k]
+    if not top_k:
+        return 0.0
+    dset = set(distractor_ids)
+    hits = sum(1 for rid in top_k if rid in dset)
+    return hits / len(top_k)
 
 
 def paired_ttest(a: List[float], b: List[float]) -> Dict[str, Any]:

--- a/scripts/lab/lab_metrics.py
+++ b/scripts/lab/lab_metrics.py
@@ -92,3 +92,44 @@ def paired_ttest(a: List[float], b: List[float]) -> Dict[str, Any]:
         "significant": p_value < 0.05,
         "mean_diff": round(mean_d, 4),
     }
+
+
+_FLAG_KEYS = {
+    "ENRICHMENT_ENABLED",
+    "JIT_ENRICHMENT_ENABLED",
+    "ENRICHMENT_ENABLE_SUMMARIES",
+    "RECALL_RECENCY_BIAS",
+}
+_OFF_VALUES = {"", "0", "0.0", "off", "false", "no", "none"}
+
+
+def _is_off(value: Any) -> bool:
+    return str(value).strip().lower() in _OFF_VALUES
+
+
+def config_complexity(config: Dict[str, Any]) -> int:
+    """Count 'active' knobs in a config. Lower = simpler/more elegant.
+
+    This is the simplicity tiebreaker: among configs within noise on quality,
+    the one with fewer active knobs wins.
+    """
+    count = 0
+    for key, value in config.items():
+        ku = str(key).upper()
+        if ku.startswith("SEARCH_WEIGHT_"):
+            try:
+                if float(value) != 0.0:
+                    count += 1
+            except (TypeError, ValueError):
+                continue
+        elif ku in _FLAG_KEYS:
+            if not _is_off(value):
+                count += 1
+        elif ku.endswith(("_THRESHOLD", "_CAP", "_GATE")):
+            try:
+                if float(value) > 0.0:
+                    count += 1
+            except (TypeError, ValueError):
+                if not _is_off(value):
+                    count += 1
+    return count

--- a/scripts/lab/lab_metrics.py
+++ b/scripts/lab/lab_metrics.py
@@ -133,3 +133,38 @@ def config_complexity(config: Dict[str, Any]) -> int:
                 if not _is_off(value):
                     count += 1
     return count
+
+
+def pick_winner(
+    cards: List[Dict[str, Any]],
+    *,
+    baseline_name: str,
+    ndcg_tol: float = 0.005,
+    distractor_tol: float = 0.01,
+) -> Dict[str, Any]:
+    """Apply the scorecard decision rule and return the winning card + reason.
+
+    Rule: highest NDCG@10 that does not regress distractor-precision vs the
+    baseline; break ties (within ndcg_tol) toward fewer knobs, then lower latency.
+    """
+    baseline = next(c for c in cards if c["name"] == baseline_name)
+    ceiling = baseline["distractor_rate_10"] + distractor_tol
+    eligible = [c for c in cards if c["distractor_rate_10"] <= ceiling]
+    regressed = not eligible
+    if regressed:
+        eligible = [baseline]
+
+    best_ndcg = max(c["ndcg_10"] for c in eligible)
+    contenders = [c for c in eligible if c["ndcg_10"] >= best_ndcg - ndcg_tol]
+    winner = dict(min(contenders, key=lambda c: (c["complexity"], c["latency_ms"])))
+
+    if regressed:
+        winner["reason"] = "all candidates regressed distractor-precision; held baseline"
+    elif winner["name"] == baseline_name:
+        winner["reason"] = "no candidate beat baseline NDCG@10 without precision regression"
+    else:
+        winner["reason"] = (
+            f"best NDCG@10 within tolerance, lowest complexity ({winner['complexity']}) "
+            f"and latency ({winner['latency_ms']:.0f}ms)"
+        )
+    return winner

--- a/scripts/lab/lab_metrics.py
+++ b/scripts/lab/lab_metrics.py
@@ -147,20 +147,19 @@ def pick_winner(
     Rule: highest NDCG@10 that does not regress distractor-precision vs the
     baseline; break ties (within ndcg_tol) toward fewer knobs, then lower latency.
     """
-    baseline = next(c for c in cards if c["name"] == baseline_name)
+    baseline = next((c for c in cards if c["name"] == baseline_name), None)
+    if baseline is None:
+        raise ValueError(f"baseline_name {baseline_name!r} not found among cards")
+    # The baseline is always eligible against itself (distractor_tol >= 0), so
+    # `eligible` is never empty and the max() below is always safe.
     ceiling = baseline["distractor_rate_10"] + distractor_tol
     eligible = [c for c in cards if c["distractor_rate_10"] <= ceiling]
-    regressed = not eligible
-    if regressed:
-        eligible = [baseline]
 
     best_ndcg = max(c["ndcg_10"] for c in eligible)
     contenders = [c for c in eligible if c["ndcg_10"] >= best_ndcg - ndcg_tol]
     winner = dict(min(contenders, key=lambda c: (c["complexity"], c["latency_ms"])))
 
-    if regressed:
-        winner["reason"] = "all candidates regressed distractor-precision; held baseline"
-    elif winner["name"] == baseline_name:
+    if winner["name"] == baseline_name:
         winner["reason"] = "no candidate beat baseline NDCG@10 without precision regression"
     else:
         winner["reason"] = (

--- a/scripts/lab/lab_metrics.py
+++ b/scripts/lab/lab_metrics.py
@@ -59,7 +59,14 @@ def paired_ttest(a: List[float], b: List[float]) -> Dict[str, Any]:
     """Paired t-test + Cohen's d effect size. Pure Python, no scipy needed."""
     n = len(a)
     if n < 2 or n != len(b):
-        return {"p_value": 1.0, "t_stat": 0.0, "effect_size": 0.0, "significant": False}
+        return {
+            "t_stat": 0.0,
+            "p_value": 1.0,
+            "cohens_d": 0.0,
+            "effect_size": "negligible",
+            "significant": False,
+            "mean_diff": 0.0,
+        }
 
     diffs = [b[i] - a[i] for i in range(n)]
     mean_d = sum(diffs) / n

--- a/scripts/lab/lab_metrics.py
+++ b/scripts/lab/lab_metrics.py
@@ -1,0 +1,76 @@
+"""Pure scoring functions for the AutoMem Recall Quality Lab.
+
+No I/O lives here — every function is deterministic and unit-testable.
+Imported by run_recall_test.py and by the parallel matrix harness.
+"""
+
+import math
+from typing import Any, Dict, List
+
+
+def recall_at_k(retrieved_ids: List[str], expected_ids: List[str], k: int) -> float:
+    """Fraction of expected IDs found in top-K results."""
+    if not expected_ids:
+        return 0.0
+    top_k = set(retrieved_ids[:k])
+    hits = sum(1 for eid in expected_ids if eid in top_k)
+    return hits / len(expected_ids)
+
+
+def mrr(retrieved_ids: List[str], expected_ids: List[str]) -> float:
+    """Mean Reciprocal Rank — position of first relevant result."""
+    expected_set = set(expected_ids)
+    for i, rid in enumerate(retrieved_ids):
+        if rid in expected_set:
+            return 1.0 / (i + 1)
+    return 0.0
+
+
+def ndcg_at_k(retrieved_ids: List[str], expected_ids: List[str], k: int) -> float:
+    """Normalized Discounted Cumulative Gain at K."""
+    expected_set = set(expected_ids)
+    dcg = 0.0
+    for i, rid in enumerate(retrieved_ids[:k]):
+        if rid in expected_set:
+            dcg += 1.0 / math.log2(i + 2)
+    ideal_dcg = sum(1.0 / math.log2(i + 2) for i in range(min(len(expected_ids), k)))
+    return dcg / ideal_dcg if ideal_dcg > 0 else 0.0
+
+
+def paired_ttest(a: List[float], b: List[float]) -> Dict[str, Any]:
+    """Paired t-test + Cohen's d effect size. Pure Python, no scipy needed."""
+    n = len(a)
+    if n < 2 or n != len(b):
+        return {"p_value": 1.0, "t_stat": 0.0, "effect_size": 0.0, "significant": False}
+
+    diffs = [b[i] - a[i] for i in range(n)]
+    mean_d = sum(diffs) / n
+    var_d = sum((d - mean_d) ** 2 for d in diffs) / (n - 1)
+    std_d = var_d**0.5 if var_d > 0 else 1e-10
+
+    t_stat = mean_d / (std_d / n**0.5)
+    z = abs(t_stat)
+    p_value = 2 * (1 - 0.5 * (1 + math.erf(z / 2**0.5)))
+
+    pooled_std = (
+        (sum((ai - sum(a) / n) ** 2 for ai in a) + sum((bi - sum(b) / n) ** 2 for bi in b))
+        / (2 * n - 2)
+    ) ** 0.5
+    cohens_d = (sum(b) / n - sum(a) / n) / pooled_std if pooled_std > 0 else 0.0
+
+    effect_label = "negligible"
+    if abs(cohens_d) >= 0.8:
+        effect_label = "large"
+    elif abs(cohens_d) >= 0.5:
+        effect_label = "medium"
+    elif abs(cohens_d) >= 0.2:
+        effect_label = "small"
+
+    return {
+        "t_stat": round(t_stat, 4),
+        "p_value": round(p_value, 6),
+        "cohens_d": round(cohens_d, 4),
+        "effect_size": effect_label,
+        "significant": p_value < 0.05,
+        "mean_diff": round(mean_d, 4),
+    }

--- a/scripts/lab/run_recall_test.py
+++ b/scripts/lab/run_recall_test.py
@@ -20,7 +20,6 @@ Usage:
 
 import argparse
 import json
-import math
 import os
 import subprocess
 import sys
@@ -31,6 +30,9 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from lab_metrics import mrr, ndcg_at_k, paired_ttest, recall_at_k  # noqa: E402
+
 API_URL = os.getenv("AUTOMEM_TEST_BASE_URL", "http://localhost:8001")
 API_TOKEN = os.getenv("AUTOMEM_API_TOKEN", "test-token")
 CONFIGS_DIR = Path(__file__).parent / "configs"
@@ -39,87 +41,6 @@ RESULTS_DIR = Path("lab/results")
 
 def get_headers() -> dict:
     return {"Authorization": f"Bearer {API_TOKEN}", "Content-Type": "application/json"}
-
-
-# ---------- Metrics ----------
-
-
-def recall_at_k(retrieved_ids: List[str], expected_ids: List[str], k: int) -> float:
-    """Fraction of expected IDs found in top-K results."""
-    if not expected_ids:
-        return 0.0
-    top_k = set(retrieved_ids[:k])
-    hits = sum(1 for eid in expected_ids if eid in top_k)
-    return hits / len(expected_ids)
-
-
-def mrr(retrieved_ids: List[str], expected_ids: List[str]) -> float:
-    """Mean Reciprocal Rank — position of first relevant result."""
-    expected_set = set(expected_ids)
-    for i, rid in enumerate(retrieved_ids):
-        if rid in expected_set:
-            return 1.0 / (i + 1)
-    return 0.0
-
-
-def ndcg_at_k(retrieved_ids: List[str], expected_ids: List[str], k: int) -> float:
-    """Normalized Discounted Cumulative Gain at K."""
-    expected_set = set(expected_ids)
-    dcg = 0.0
-    for i, rid in enumerate(retrieved_ids[:k]):
-        if rid in expected_set:
-            dcg += 1.0 / math.log2(i + 2)  # i+2 because log2(1) = 0
-
-    # Ideal DCG: all relevant docs at top
-    ideal_dcg = sum(1.0 / math.log2(i + 2) for i in range(min(len(expected_ids), k)))
-    return dcg / ideal_dcg if ideal_dcg > 0 else 0.0
-
-
-# ---------- Statistical Comparison ----------
-
-
-def paired_ttest(a: List[float], b: List[float]) -> Dict[str, Any]:
-    """Paired t-test + Cohen's d effect size. Pure Python, no scipy needed."""
-    n = len(a)
-    if n < 2 or n != len(b):
-        return {"p_value": 1.0, "t_stat": 0.0, "effect_size": 0.0, "significant": False}
-
-    diffs = [b[i] - a[i] for i in range(n)]
-    mean_d = sum(diffs) / n
-    var_d = sum((d - mean_d) ** 2 for d in diffs) / (n - 1)
-    std_d = var_d**0.5 if var_d > 0 else 1e-10
-
-    t_stat = mean_d / (std_d / n**0.5)
-
-    # Approximate p-value using normal distribution for large n
-    # For n >= 30 this is reasonable; for smaller n it's conservative
-    z = abs(t_stat)
-    # Approximation of 2-tailed p from standard normal
-    p_value = 2 * (1 - 0.5 * (1 + math.erf(z / 2**0.5)))
-
-    # Cohen's d
-    pooled_std = (
-        (sum((ai - sum(a) / n) ** 2 for ai in a) + sum((bi - sum(b) / n) ** 2 for bi in b))
-        / (2 * n - 2)
-    ) ** 0.5
-    cohens_d = (sum(b) / n - sum(a) / n) / pooled_std if pooled_std > 0 else 0.0
-
-    effect_label = "negligible"
-    if abs(cohens_d) >= 0.8:
-        effect_label = "large"
-    elif abs(cohens_d) >= 0.5:
-        effect_label = "medium"
-    elif abs(cohens_d) >= 0.2:
-        effect_label = "small"
-
-    return {
-        "t_stat": round(t_stat, 4),
-        "p_value": round(p_value, 6),
-        "cohens_d": round(cohens_d, 4),
-        "effect_size": effect_label,
-        "significant": p_value < 0.05,
-        "mean_diff": round(mean_d, 4),
-    }
 
 
 # ---------- Config Management ----------

--- a/scripts/lab/run_recall_test.py
+++ b/scripts/lab/run_recall_test.py
@@ -303,7 +303,7 @@ def build_scorecard(result: TestRunResult) -> Dict[str, Any]:
     """The legible scorecard: NDCG@10 primary, distractor-rate guardrail,
     latency + complexity tiebreakers."""
     return {
-        "config_name": result.config_name,
+        "name": result.config_name,
         "ndcg_10": result.mean_ndcg_10,
         "distractor_rate_10": result.mean_distractor_rate_10,
         "latency_ms": result.mean_latency,

--- a/scripts/lab/run_recall_test.py
+++ b/scripts/lab/run_recall_test.py
@@ -31,6 +31,13 @@ from typing import Any, Dict, List, Optional, Tuple
 import requests
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+from lab_corpus import (  # noqa: E402
+    extract_ids,
+    inject_distractors,
+    make_distractor_memories,
+    recall,
+    run_consolidation,
+)
 from lab_metrics import (  # noqa: E402
     config_complexity,
     distractor_rate_at_k,
@@ -38,13 +45,6 @@ from lab_metrics import (  # noqa: E402
     ndcg_at_k,
     paired_ttest,
     recall_at_k,
-)
-from lab_corpus import (  # noqa: E402
-    extract_ids,
-    inject_distractors,
-    make_distractor_memories,
-    recall,
-    run_consolidation,
 )
 
 API_URL = os.getenv("AUTOMEM_TEST_BASE_URL", "http://localhost:8001")
@@ -403,6 +403,7 @@ def save_results(result: TestRunResult, output_dir: Path) -> Path:
                 "recall_10": q.recall_10,
                 "mrr": q.mrr_val,
                 "ndcg_10": q.ndcg_10,
+                "distractor_rate_10": q.distractor_rate_10,
                 "latency_ms": round(q.latency_ms, 1),
                 "category": q.category,
             }

--- a/scripts/lab/run_recall_test.py
+++ b/scripts/lab/run_recall_test.py
@@ -31,7 +31,21 @@ from typing import Any, Dict, List, Optional, Tuple
 import requests
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from lab_metrics import mrr, ndcg_at_k, paired_ttest, recall_at_k  # noqa: E402
+from lab_metrics import (  # noqa: E402
+    config_complexity,
+    distractor_rate_at_k,
+    mrr,
+    ndcg_at_k,
+    paired_ttest,
+    recall_at_k,
+)
+from lab_corpus import (  # noqa: E402
+    extract_ids,
+    inject_distractors,
+    make_distractor_memories,
+    recall,
+    run_consolidation,
+)
 
 API_URL = os.getenv("AUTOMEM_TEST_BASE_URL", "http://localhost:8001")
 API_TOKEN = os.getenv("AUTOMEM_API_TOKEN", "test-token")
@@ -150,6 +164,7 @@ class QueryResult:
     recall_20: float = 0.0
     mrr_val: float = 0.0
     ndcg_10: float = 0.0
+    distractor_rate_10: float = 0.0
     latency_ms: float = 0.0
     category: str = ""
 
@@ -160,6 +175,12 @@ class TestRunResult:  # noqa: pytest will skip due to __init__
     config_name: str
     query_results: List[QueryResult] = field(default_factory=list)
     timestamp: str = ""
+    complexity: int = 0
+
+    @property
+    def mean_distractor_rate_10(self) -> float:
+        vals = [q.distractor_rate_10 for q in self.query_results]
+        return sum(vals) / len(vals) if vals else 0.0
 
     @property
     def mean_recall_5(self) -> float:
@@ -208,37 +229,31 @@ class TestRunResult:  # noqa: pytest will skip due to __init__
         }
 
 
-def run_single_query(query_data: Dict[str, Any], api_url: str) -> QueryResult:
-    """Execute a single recall query and compute metrics."""
+def run_single_query(
+    query_data: Dict[str, Any],
+    api_url: str,
+    *,
+    distractor_ids: Optional[set] = None,
+    recall_params: Optional[Dict[str, Any]] = None,
+) -> QueryResult:
+    """Execute a single recall query and compute metrics (incl. distractor rate)."""
     query = query_data["query"]
     expected_ids = query_data.get("expected_ids", [])
     category = query_data.get("category", "unknown")
+    distractor_ids = distractor_ids or set()
+    recall_params = recall_params or {}
 
     start = time.perf_counter()
     try:
-        resp = requests.get(
-            f"{api_url}/recall",
-            params={"query": query, "limit": 20},
-            headers=get_headers(),
-            timeout=30,
-        )
-        resp.raise_for_status()
-        data = resp.json()
-    except Exception as e:
+        data = recall(api_url, get_headers(), query, **recall_params)
+    except Exception as e:  # noqa: BLE001
         print(f"  WARNING: Query failed: {query[:50]}... — {e}")
         return QueryResult(
             query=query, expected_ids=expected_ids, retrieved_ids=[], category=category
         )
 
     latency_ms = (time.perf_counter() - start) * 1000
-
-    results = data.get("results", data.get("memories", []))
-    retrieved_ids = []
-    for r in results:
-        mem = r.get("memory", r)
-        mid = str(mem.get("id", r.get("id", "")))
-        if mid:
-            retrieved_ids.append(mid)
+    retrieved_ids = extract_ids(data)
 
     return QueryResult(
         query=query,
@@ -249,21 +264,32 @@ def run_single_query(query_data: Dict[str, Any], api_url: str) -> QueryResult:
         recall_20=recall_at_k(retrieved_ids, expected_ids, 20),
         mrr_val=mrr(retrieved_ids, expected_ids),
         ndcg_10=ndcg_at_k(retrieved_ids, expected_ids, 10),
+        distractor_rate_10=distractor_rate_at_k(retrieved_ids, distractor_ids, 10),
         latency_ms=latency_ms,
         category=category,
     )
 
 
-def run_test(config_name: str, queries: List[Dict], api_url: str) -> TestRunResult:
+def run_test(
+    config_name: str,
+    queries: List[Dict],
+    api_url: str,
+    *,
+    config: Optional[Dict[str, str]] = None,
+    distractor_ids: Optional[set] = None,
+    recall_params: Optional[Dict[str, Any]] = None,
+) -> TestRunResult:
     """Run all test queries with a specific config."""
     result = TestRunResult(
         config_name=config_name, timestamp=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     )
+    result.complexity = config_complexity(config or {})
 
     for i, q in enumerate(queries):
-        qr = run_single_query(q, api_url)
+        qr = run_single_query(
+            q, api_url, distractor_ids=distractor_ids, recall_params=recall_params
+        )
         result.query_results.append(qr)
-        # Progress dot
         hit = "." if qr.recall_10 > 0 else "x"
         print(hit, end="", flush=True)
         if (i + 1) % 50 == 0:
@@ -271,6 +297,18 @@ def run_test(config_name: str, queries: List[Dict], api_url: str) -> TestRunResu
 
     print(f" [{len(queries)}/{len(queries)}]")
     return result
+
+
+def build_scorecard(result: TestRunResult) -> Dict[str, Any]:
+    """The legible scorecard: NDCG@10 primary, distractor-rate guardrail,
+    latency + complexity tiebreakers."""
+    return {
+        "config_name": result.config_name,
+        "ndcg_10": result.mean_ndcg_10,
+        "distractor_rate_10": result.mean_distractor_rate_10,
+        "latency_ms": result.mean_latency,
+        "complexity": result.complexity,
+    }
 
 
 def print_summary(result: TestRunResult) -> None:
@@ -281,6 +319,8 @@ def print_summary(result: TestRunResult) -> None:
     print(f"  Recall@20:  {result.mean_recall_20:.3f}")
     print(f"  MRR:        {result.mean_mrr:.3f}")
     print(f"  NDCG@10:    {result.mean_ndcg_10:.3f}")
+    print(f"  Distractor@10: {result.mean_distractor_rate_10:.3f} (lower better)")
+    print(f"  Complexity:   {result.complexity} active knobs")
     print(f"  Latency:    {result.mean_latency:.0f}ms avg")
 
     cats = result.by_category()
@@ -351,6 +391,8 @@ def save_results(result: TestRunResult, output_dir: Path) -> Path:
             "mrr": result.mean_mrr,
             "ndcg_10": result.mean_ndcg_10,
             "latency_ms": result.mean_latency,
+            "distractor_rate_10": result.mean_distractor_rate_10,
+            "complexity": result.complexity,
         },
         "by_category": result.by_category(),
         "queries": [
@@ -395,6 +437,32 @@ def main() -> None:
     )
     parser.add_argument("--api-url", type=str, default=API_URL, help="AutoMem API URL")
     parser.add_argument("--output-dir", type=str, default=str(RESULTS_DIR), help="Results dir")
+    parser.add_argument(
+        "--distractors",
+        type=int,
+        default=0,
+        help="Inject N aged labelled distractor memories before testing",
+    )
+    parser.add_argument(
+        "--expand-relations", action="store_true", help="Recall with expand_relations"
+    )
+    parser.add_argument(
+        "--no-current-only",
+        action="store_true",
+        help="Recall with current_only=false (include archived)",
+    )
+    parser.add_argument(
+        "--recency-bias",
+        type=str,
+        default=None,
+        choices=["on", "off", "auto"],
+        help="Recall recency_bias override",
+    )
+    parser.add_argument(
+        "--consolidate",
+        action="store_true",
+        help="Run a real consolidation pass (dry_run=false) before recall",
+    )
     args = parser.parse_args()
 
     # Load test set
@@ -413,6 +481,22 @@ def main() -> None:
     queries = load_test_set(args.test_set)
     print(f"Loaded {len(queries)} test queries from {args.test_set}")
 
+    recall_params = {
+        "expand_relations": args.expand_relations,
+        "current_only": not args.no_current_only,
+    }
+    if args.recency_bias is not None:
+        recall_params["recency_bias"] = args.recency_bias
+
+    distractor_ids: set = set()
+    if args.distractors > 0:
+        payloads = make_distractor_memories(args.distractors)
+        distractor_ids = set(inject_distractors(args.api_url, get_headers(), payloads))
+        print(f"Injected {len(distractor_ids)} distractor memories")
+    if args.consolidate:
+        steps = run_consolidation(args.api_url, get_headers())
+        print(f"Consolidation pass complete: {list(steps.keys())}")
+
     output_dir = Path(args.output_dir)
 
     if args.sweep:
@@ -430,7 +514,14 @@ def main() -> None:
             restart_api_with_config(config, api_url=args.api_url)
             time.sleep(2)
 
-            result = run_test(config_name, queries, args.api_url)
+            result = run_test(
+                config_name,
+                queries,
+                args.api_url,
+                config=config,
+                distractor_ids=distractor_ids,
+                recall_params=recall_params,
+            )
             all_results.append(result)
             print_summary(result)
             save_results(result, output_dir)
@@ -456,14 +547,28 @@ def main() -> None:
         print(f"\n--- Running baseline: {args.compare} ---")
         restart_api_with_config(config_a, api_url=args.api_url)
         time.sleep(2)
-        result_a = run_test(args.compare, queries, args.api_url)
+        result_a = run_test(
+            args.compare,
+            queries,
+            args.api_url,
+            config=config_a,
+            distractor_ids=distractor_ids,
+            recall_params=recall_params,
+        )
         print_summary(result_a)
         save_results(result_a, output_dir)
 
         print(f"\n--- Running candidate: {args.config} ---")
         restart_api_with_config(config_b, api_url=args.api_url)
         time.sleep(2)
-        result_b = run_test(args.config, queries, args.api_url)
+        result_b = run_test(
+            args.config,
+            queries,
+            args.api_url,
+            config=config_b,
+            distractor_ids=distractor_ids,
+            recall_params=recall_params,
+        )
         print_summary(result_b)
         save_results(result_b, output_dir)
 
@@ -476,7 +581,14 @@ def main() -> None:
         restart_api_with_config(config, api_url=args.api_url)
         time.sleep(2)
 
-        result = run_test(args.config, queries, args.api_url)
+        result = run_test(
+            args.config,
+            queries,
+            args.api_url,
+            config=config,
+            distractor_ids=distractor_ids,
+            recall_params=recall_params,
+        )
         print_summary(result)
         save_results(result, output_dir)
 

--- a/tests/lab/conftest.py
+++ b/tests/lab/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Make scripts/lab importable without packaging the scripts dir.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "lab"))

--- a/tests/lab/test_lab_corpus.py
+++ b/tests/lab/test_lab_corpus.py
@@ -1,0 +1,62 @@
+import lab_corpus as c
+
+
+class FakeResp:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+def test_recall_serializes_params():
+    captured = {}
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        captured["url"] = url
+        captured["params"] = params
+        return FakeResp({"results": []})
+
+    c.recall(
+        "http://x",
+        {"Authorization": "Bearer t"},
+        "hello",
+        limit=10,
+        expand_relations=True,
+        current_only=False,
+        recency_bias="auto",
+        http_get=fake_get,
+    )
+    assert captured["url"].endswith("/recall")
+    assert captured["params"]["query"] == "hello"
+    assert captured["params"]["limit"] == 10
+    assert captured["params"]["expand_relations"] == "true"
+    assert captured["params"]["current_only"] == "false"
+    assert captured["params"]["recency_bias"] == "auto"
+
+
+def test_recall_omits_recency_bias_when_none():
+    captured = {}
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        captured["params"] = params
+        return FakeResp({"results": []})
+
+    c.recall("http://x", {}, "q", http_get=fake_get)
+    assert "recency_bias" not in captured["params"]
+    assert captured["params"]["current_only"] == "true"
+
+
+def test_extract_ids_handles_nested_and_flat():
+    payload = {
+        "results": [
+            {"memory": {"id": "a", "content": "x"}},
+            {"id": "b", "content": "y"},
+        ]
+    }
+    assert c.extract_ids(payload) == ["a", "b"]

--- a/tests/lab/test_lab_corpus.py
+++ b/tests/lab/test_lab_corpus.py
@@ -60,3 +60,28 @@ def test_extract_ids_handles_nested_and_flat():
         ]
     }
     assert c.extract_ids(payload) == ["a", "b"]
+
+
+def test_make_distractor_memories_are_aged_low_importance_and_tagged():
+    payloads = c.make_distractor_memories(3, age_days=200, importance=0.05)
+    assert len(payloads) == 3
+    for p in payloads:
+        assert p["tags"] == ["lab-distractor"]
+        assert p["importance"] == 0.05
+        assert p["timestamp"] == p["last_accessed"]
+        assert p["metadata"]["lab_distractor"] is True
+        assert p["timestamp"].endswith("Z")
+
+
+def test_inject_distractors_returns_created_ids():
+    posted = []
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        posted.append(json)
+        idx = len(posted)
+        return FakeResp({"memory_id": f"id-{idx}"})
+
+    payloads = c.make_distractor_memories(2)
+    ids = c.inject_distractors("http://x", {}, payloads, http_post=fake_post)
+    assert ids == ["id-1", "id-2"]
+    assert len(posted) == 2

--- a/tests/lab/test_lab_corpus.py
+++ b/tests/lab/test_lab_corpus.py
@@ -85,3 +85,28 @@ def test_inject_distractors_returns_created_ids():
     ids = c.inject_distractors("http://x", {}, payloads, http_post=fake_post)
     assert ids == ["id-1", "id-2"]
     assert len(posted) == 2
+
+
+def test_run_consolidation_sends_dry_run_false_in_order():
+    calls = []
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        calls.append(json)
+        return FakeResp({"mode": json["mode"], "steps": {}})
+
+    out = c.run_consolidation("http://x", {}, http_post=fake_post)
+    sent_modes = [call["mode"] for call in calls]
+    assert sent_modes == ["decay", "creative", "cluster", "forget"]
+    assert all(call["dry_run"] is False for call in calls)
+    assert set(out.keys()) == {"decay", "creative", "cluster", "forget"}
+
+
+def test_run_consolidation_respects_explicit_modes():
+    calls = []
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        calls.append(json)
+        return FakeResp({})
+
+    c.run_consolidation("http://x", {}, modes=["forget"], http_post=fake_post)
+    assert [call["mode"] for call in calls] == ["forget"]

--- a/tests/lab/test_lab_metrics.py
+++ b/tests/lab/test_lab_metrics.py
@@ -32,6 +32,19 @@ def test_distractor_rate_counts_distractors_in_top_k():
     assert m.distractor_rate_at_k(retrieved, distractors, 0) == 0.0
 
 
+def test_paired_ttest_degenerate_shape_matches_normal_result():
+    stats = m.paired_ttest([0.5], [0.7])
+
+    assert stats == {
+        "t_stat": 0.0,
+        "p_value": 1.0,
+        "cohens_d": 0.0,
+        "effect_size": "negligible",
+        "significant": False,
+        "mean_diff": 0.0,
+    }
+
+
 def test_config_complexity_counts_active_knobs():
     baseline = {
         "SEARCH_WEIGHT_VECTOR": "0.35",

--- a/tests/lab/test_lab_metrics.py
+++ b/tests/lab/test_lab_metrics.py
@@ -30,3 +30,29 @@ def test_distractor_rate_counts_distractors_in_top_k():
     # empties are safe
     assert m.distractor_rate_at_k([], distractors, 10) == 0.0
     assert m.distractor_rate_at_k(retrieved, distractors, 0) == 0.0
+
+
+def test_config_complexity_counts_active_knobs():
+    baseline = {
+        "SEARCH_WEIGHT_VECTOR": "0.35",
+        "SEARCH_WEIGHT_KEYWORD": "0.35",
+        "SEARCH_WEIGHT_RELEVANCE": "0.0",  # off -> not counted
+    }
+    assert m.config_complexity(baseline) == 2
+
+    simpler = {
+        "SEARCH_WEIGHT_VECTOR": "0.35",
+        "SEARCH_WEIGHT_KEYWORD": "0.0",
+        "SEARCH_WEIGHT_RELEVANCE": "0.0",
+    }
+    assert m.config_complexity(simpler) == 1
+
+    flags_and_gates = {
+        "SEARCH_WEIGHT_VECTOR": "0.35",  # +1
+        "ENRICHMENT_ENABLED": "true",  # +1
+        "JIT_ENRICHMENT_ENABLED": "false",  # +0
+        "RECALL_RECENCY_BIAS": "off",  # +0
+        "RECALL_RELEVANCE_GATE": "0.2",  # +1 (gate > 0)
+        "SEARCH_TAG_SCORE_TOKEN_CAP": "0",  # +0
+    }
+    assert m.config_complexity(flags_and_gates) == 3

--- a/tests/lab/test_lab_metrics.py
+++ b/tests/lab/test_lab_metrics.py
@@ -17,3 +17,16 @@ def test_ndcg_at_k_rewards_top_rank():
     buried = m.ndcg_at_k(["a", "b", "x"], ["x"], 10)
     assert top == 1.0
     assert 0.0 < buried < top
+
+
+def test_distractor_rate_counts_distractors_in_top_k():
+    retrieved = ["good", "d1", "d2", "good2"]
+    distractors = {"d1", "d2"}
+    assert m.distractor_rate_at_k(retrieved, distractors, 4) == 0.5
+    # top-1 is clean -> 0.0
+    assert m.distractor_rate_at_k(retrieved, distractors, 1) == 0.0
+    # all distractors -> 1.0
+    assert m.distractor_rate_at_k(["d1", "d2"], distractors, 10) == 1.0
+    # empties are safe
+    assert m.distractor_rate_at_k([], distractors, 10) == 0.0
+    assert m.distractor_rate_at_k(retrieved, distractors, 0) == 0.0

--- a/tests/lab/test_lab_metrics.py
+++ b/tests/lab/test_lab_metrics.py
@@ -56,3 +56,41 @@ def test_config_complexity_counts_active_knobs():
         "SEARCH_TAG_SCORE_TOKEN_CAP": "0",  # +0
     }
     assert m.config_complexity(flags_and_gates) == 3
+
+
+def _card(name, ndcg, distractor, latency, complexity):
+    return {
+        "name": name,
+        "ndcg_10": ndcg,
+        "distractor_rate_10": distractor,
+        "latency_ms": latency,
+        "complexity": complexity,
+    }
+
+
+def test_pick_winner_prefers_simpler_within_ndcg_tolerance():
+    cards = [
+        _card("baseline", 0.800, 0.10, 100, 11),
+        _card("complex", 0.803, 0.10, 120, 13),  # tiny ndcg gain, more knobs
+        _card("simple", 0.801, 0.10, 90, 8),  # within tol, fewer knobs + faster
+    ]
+    winner = m.pick_winner(cards, baseline_name="baseline")
+    assert winner["name"] == "simple"
+
+
+def test_pick_winner_rejects_precision_regression():
+    cards = [
+        _card("baseline", 0.800, 0.10, 100, 11),
+        _card("greedy", 0.900, 0.30, 100, 11),  # big ndcg but junk floods results
+    ]
+    winner = m.pick_winner(cards, baseline_name="baseline")
+    assert winner["name"] == "baseline"
+
+
+def test_pick_winner_picks_clear_quality_jump():
+    cards = [
+        _card("baseline", 0.800, 0.10, 100, 11),
+        _card("better", 0.860, 0.09, 100, 11),  # real gain, no regression
+    ]
+    winner = m.pick_winner(cards, baseline_name="baseline")
+    assert winner["name"] == "better"

--- a/tests/lab/test_lab_metrics.py
+++ b/tests/lab/test_lab_metrics.py
@@ -1,0 +1,19 @@
+import lab_metrics as m
+
+
+def test_recall_at_k_counts_hits_in_top_k():
+    assert m.recall_at_k(["a", "b", "c"], ["c"], 5) == 1.0
+    assert m.recall_at_k(["a", "b", "c"], ["c"], 2) == 0.0
+    assert m.recall_at_k([], ["c"], 5) == 0.0
+
+
+def test_mrr_uses_first_hit_rank():
+    assert m.mrr(["a", "b", "c"], ["b"]) == 0.5
+    assert m.mrr(["a", "b", "c"], ["z"]) == 0.0
+
+
+def test_ndcg_at_k_rewards_top_rank():
+    top = m.ndcg_at_k(["x", "a", "b"], ["x"], 10)
+    buried = m.ndcg_at_k(["a", "b", "x"], ["x"], 10)
+    assert top == 1.0
+    assert 0.0 < buried < top

--- a/tests/lab/test_run_recall_test.py
+++ b/tests/lab/test_run_recall_test.py
@@ -1,0 +1,30 @@
+import run_recall_test as rr
+
+
+def test_build_scorecard_reads_the_four_axes():
+    result = rr.TestRunResult(config_name="cfg")
+    result.complexity = 7
+    result.query_results = [
+        rr.QueryResult(
+            query="q1",
+            expected_ids=["a"],
+            retrieved_ids=["a", "d1"],
+            ndcg_10=1.0,
+            distractor_rate_10=0.5,
+            latency_ms=100.0,
+        ),
+        rr.QueryResult(
+            query="q2",
+            expected_ids=["b"],
+            retrieved_ids=["b"],
+            ndcg_10=0.0,
+            distractor_rate_10=0.0,
+            latency_ms=200.0,
+        ),
+    ]
+    card = rr.build_scorecard(result)
+    assert card["config_name"] == "cfg"
+    assert card["ndcg_10"] == 0.5
+    assert card["distractor_rate_10"] == 0.25
+    assert card["latency_ms"] == 150.0
+    assert card["complexity"] == 7

--- a/tests/lab/test_run_recall_test.py
+++ b/tests/lab/test_run_recall_test.py
@@ -23,8 +23,30 @@ def test_build_scorecard_reads_the_four_axes():
         ),
     ]
     card = rr.build_scorecard(result)
-    assert card["config_name"] == "cfg"
+    assert card["name"] == "cfg"
     assert card["ndcg_10"] == 0.5
     assert card["distractor_rate_10"] == 0.25
     assert card["latency_ms"] == 150.0
     assert card["complexity"] == 7
+
+
+def test_build_scorecard_output_feeds_pick_winner():
+    """The producer/consumer key contract: build_scorecard cards must be
+    directly consumable by pick_winner (the path Plan B's matrix harness uses)."""
+    import lab_metrics as m
+
+    result = rr.TestRunResult(config_name="baseline")
+    result.complexity = 5
+    result.query_results = [
+        rr.QueryResult(
+            query="q",
+            expected_ids=["a"],
+            retrieved_ids=["a"],
+            ndcg_10=0.8,
+            distractor_rate_10=0.1,
+            latency_ms=100.0,
+        ),
+    ]
+    card = rr.build_scorecard(result)
+    winner = m.pick_winner([card], baseline_name="baseline")
+    assert winner["name"] == "baseline"

--- a/tests/lab/test_run_recall_test.py
+++ b/tests/lab/test_run_recall_test.py
@@ -1,3 +1,5 @@
+import json
+
 import run_recall_test as rr
 
 
@@ -50,3 +52,25 @@ def test_build_scorecard_output_feeds_pick_winner():
     card = rr.build_scorecard(result)
     winner = m.pick_winner([card], baseline_name="baseline")
     assert winner["name"] == "baseline"
+
+
+def test_save_results_keeps_query_distractor_rate(tmp_path):
+    result = rr.TestRunResult(config_name="cfg", timestamp="2026-06-17T00:00:00Z")
+    result.query_results = [
+        rr.QueryResult(
+            query="q",
+            expected_ids=["a"],
+            retrieved_ids=["d1", "a"],
+            recall_10=1.0,
+            mrr_val=0.5,
+            ndcg_10=0.75,
+            distractor_rate_10=0.5,
+            latency_ms=12.34,
+            category="known_item",
+        )
+    ]
+
+    output_path = rr.save_results(result, tmp_path)
+    data = json.loads(output_path.read_text())
+
+    assert data["queries"][0]["distractor_rate_10"] == 0.5


### PR DESCRIPTION
## Recall-Quality Optimization Harness — lab foundation + design

Optimize AutoMem recall quality on a real corpus, then confirm on public benchmarks.

**Design docs** (`docs/superpowers/`): spec (corpus-tuned → benchmark-confirmed funnel; NDCG@10 primary + distractor-precision guardrail + simplicity/latency tiebreakers; labelled consolidation arm), Plan A (lab foundation), Plan B (parallel matrix harness — code lives in automem-evals).

**Plan A code** (`scripts/lab/`):
- `lab_metrics.py` — NDCG@10, distractor_rate@10, config_complexity, `pick_winner` decision rule
- `lab_corpus.py` — parameterized recall, aged labelled distractor injection, real consolidation pass (`dry_run=false`)
- `run_recall_test.py` — scorecard wired into the runner (distractors, recall params, consolidation)

17/17 unit tests pass; black + flake8 clean. Does not touch the unrelated in-flight WIP in the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)