### PR TITLE
feat(api): support bulk memory associations

### DIFF
--- a/automem/api/memory.py
+++ b/automem/api/memory.py
@@ -214,8 +214,18 @@ def _create_association_batch(
                     {"rows": rows},
                 )
             except Exception:
-                logger.exception("Failed to create association batch")
-                abort_fn(500, description="Failed to create association batch")
+                logger.exception(
+                    "Failed to create association batch for relation type %s",
+                    relation_type,
+                )
+                for row in rows:
+                    failed.append(
+                        _association_failure(
+                            row["index"],
+                            f"Failed to create association batch for relation type {relation_type}",
+                        )
+                    )
+                continue
 
             created_indexes = set()
             for result_row in list(getattr(result, "result_set", []) or []):

--- a/automem/api/memory.py
+++ b/automem/api/memory.py
@@ -26,6 +26,226 @@ def _validate_memory_id(memory_id: str) -> None:
         abort(400, description="memory_id must be a valid UUID")
 
 
+def _uuid_error(memory_id: str, field_name: str) -> Optional[str]:
+    try:
+        uuid.UUID(memory_id)
+    except ValueError:
+        return f"'{field_name}' must be a valid UUID"
+    return None
+
+
+def _association_summary(created_count: int, total_count: int) -> str:
+    return f"{created_count}/{total_count} associations created successfully"
+
+
+def _association_failure(index: int, reason: str) -> Dict[str, Any]:
+    return {"index": index, "reason": reason}
+
+
+def _association_success(
+    *,
+    index: int,
+    memory1_id: str,
+    memory2_id: str,
+    relation_type: str,
+    strength: float,
+) -> Dict[str, Any]:
+    return {
+        "index": index,
+        "memory1_id": memory1_id,
+        "memory2_id": memory2_id,
+        "relation_type": relation_type,
+        "strength": strength,
+    }
+
+
+def _prepare_association_props(
+    *,
+    payload: Dict[str, Any],
+    relation_type: str,
+    strength: float,
+    timestamp: str,
+    relationship_types: Dict[str, Dict[str, Any]],
+) -> Dict[str, Any]:
+    relationship_props = {"strength": strength, "updated_at": timestamp}
+    relation_config = relationship_types.get(relation_type, {})
+    for prop in relation_config.get("properties", []):
+        if prop in payload and prop not in relationship_props:
+            relationship_props[prop] = payload[prop]
+    return relationship_props
+
+
+def _parse_association_item(
+    *,
+    item: Any,
+    index: int,
+    authorable_relations: Set[str],
+    relationship_types: Dict[str, Dict[str, Any]],
+    coerce_importance_fn: Callable[[Any], float],
+    timestamp: str,
+) -> tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    if not isinstance(item, dict):
+        return None, _association_failure(index, "Association item must be an object")
+
+    memory1_id = str(item.get("memory1_id") or "").strip()
+    memory2_id = str(item.get("memory2_id") or "").strip()
+    relation_type = str(item.get("type") or "RELATES_TO").strip().upper()
+    strength = coerce_importance_fn(item.get("strength", 0.5))
+
+    if not memory1_id or not memory2_id:
+        return None, _association_failure(index, "'memory1_id' and 'memory2_id' are required")
+
+    for field_name, value in (("memory1_id", memory1_id), ("memory2_id", memory2_id)):
+        error = _uuid_error(value, field_name)
+        if error:
+            return None, _association_failure(index, error)
+
+    if memory1_id == memory2_id:
+        return None, _association_failure(index, "Cannot associate a memory with itself")
+
+    if relation_type not in authorable_relations:
+        return None, _association_failure(
+            index,
+            f"Relation type must be one of {sorted(authorable_relations)}",
+        )
+
+    return (
+        {
+            "index": index,
+            "memory1_id": memory1_id,
+            "memory2_id": memory2_id,
+            "type": relation_type,
+            "strength": strength,
+            "props": _prepare_association_props(
+                payload=item,
+                relation_type=relation_type,
+                strength=strength,
+                timestamp=timestamp,
+                relationship_types=relationship_types,
+            ),
+        },
+        None,
+    )
+
+
+def _batch_association_response(
+    *,
+    succeeded: List[Dict[str, Any]],
+    failed: List[Dict[str, Any]],
+    total_count: int,
+    jsonify_fn: Callable[[Any], Any],
+) -> Any:
+    created_count = len(succeeded)
+    failed_count = len(failed)
+    status_code = 201 if failed_count == 0 else 207
+    status = "success" if failed_count == 0 else "partial_success"
+    return (
+        jsonify_fn(
+            {
+                "status": status,
+                "created_count": created_count,
+                "failed_count": failed_count,
+                "succeeded": sorted(succeeded, key=lambda item: item["index"]),
+                "failed": sorted(failed, key=lambda item: item["index"]),
+                "summary": _association_summary(created_count, total_count),
+            }
+        ),
+        status_code,
+    )
+
+
+def _create_association_batch(
+    *,
+    payload: Dict[str, Any],
+    coerce_importance_fn: Callable[[Any], float],
+    get_memory_graph_fn: Callable[[], Any],
+    authorable_relations: Set[str],
+    relationship_types: Dict[str, Dict[str, Any]],
+    utc_now_fn: Callable[[], str],
+    abort_fn: Callable[..., Any],
+    jsonify_fn: Callable[[Any], Any],
+    logger: Any,
+) -> Any:
+    associations = payload.get("associations")
+    if not isinstance(associations, list) or len(associations) == 0:
+        abort_fn(400, description="'associations' must be a non-empty array")
+    if len(associations) > 500:
+        abort_fn(400, description="Batch size limit is 500 associations per request")
+
+    timestamp = utc_now_fn()
+    valid_rows: List[Dict[str, Any]] = []
+    failed: List[Dict[str, Any]] = []
+    for index, item in enumerate(associations):
+        row, failure = _parse_association_item(
+            item=item,
+            index=index,
+            authorable_relations=authorable_relations,
+            relationship_types=relationship_types,
+            coerce_importance_fn=coerce_importance_fn,
+            timestamp=timestamp,
+        )
+        if failure:
+            failed.append(failure)
+        elif row:
+            valid_rows.append(row)
+
+    succeeded: List[Dict[str, Any]] = []
+    if valid_rows:
+        graph = get_memory_graph_fn()
+        if graph is None:
+            abort_fn(503, description="FalkorDB is unavailable")
+
+        rows_by_index = {row["index"]: row for row in valid_rows}
+        rows_by_type: Dict[str, List[Dict[str, Any]]] = {}
+        for row in valid_rows:
+            rows_by_type.setdefault(row["type"], []).append(row)
+
+        for relation_type, rows in rows_by_type.items():
+            try:
+                result = graph.query(
+                    f"""
+                    UNWIND $rows AS row
+                    MATCH (m1:Memory {{id: row.memory1_id}})
+                    MATCH (m2:Memory {{id: row.memory2_id}})
+                    MERGE (m1)-[r:{relation_type}]->(m2)
+                    SET r += row.props
+                    RETURN row.index, row.memory1_id, row.memory2_id
+                    """,
+                    {"rows": rows},
+                )
+            except Exception:
+                logger.exception("Failed to create association batch")
+                abort_fn(500, description="Failed to create association batch")
+
+            created_indexes = set()
+            for result_row in list(getattr(result, "result_set", []) or []):
+                index = int(result_row[0])
+                created_indexes.add(index)
+                source = rows_by_index[index]
+                succeeded.append(
+                    _association_success(
+                        index=index,
+                        memory1_id=source["memory1_id"],
+                        memory2_id=source["memory2_id"],
+                        relation_type=source["type"],
+                        strength=source["strength"],
+                    )
+                )
+
+            for row in rows:
+                if row["index"] not in created_indexes:
+                    failed.append(
+                        _association_failure(row["index"], "One or both memories do not exist")
+                    )
+
+    return _batch_association_response(
+        succeeded=succeeded,
+        failed=failed,
+        total_count=len(associations),
+        jsonify_fn=jsonify_fn,
+    )
+
+
 def _parse_by_tag_request(
     *,
     request_args: Any,
@@ -767,6 +987,18 @@ def create_memory_blueprint_full(
         payload = request.get_json(silent=True)
         if not isinstance(payload, dict):
             abort(400, description="JSON body is required")
+        if "associations" in payload:
+            return _create_association_batch(
+                payload=payload,
+                coerce_importance_fn=coerce_importance,
+                get_memory_graph_fn=get_memory_graph,
+                authorable_relations=set(authorable_relations),
+                relationship_types=relation_types,
+                utc_now_fn=utc_now,
+                abort_fn=abort,
+                jsonify_fn=jsonify,
+                logger=logger,
+            )
 
         memory1_id = (payload.get("memory1_id") or "").strip()
         memory2_id = (payload.get("memory2_id") or "").strip()
@@ -791,12 +1023,14 @@ def create_memory_blueprint_full(
 
         timestamp = utc_now()
 
-        relationship_props = {"strength": strength, "updated_at": timestamp}
+        relationship_props = _prepare_association_props(
+            payload=payload,
+            relation_type=relation_type,
+            strength=strength,
+            timestamp=timestamp,
+            relationship_types=relation_types,
+        )
         relation_config = relation_types.get(relation_type, {})
-        if "properties" in relation_config:
-            for prop in relation_config["properties"]:
-                if prop in payload:
-                    relationship_props[prop] = payload[prop]
 
         set_clauses = [f"r.{key} = ${key}" for key in relationship_props]
         set_clause = ", ".join(set_clauses)

--- a/automem/api/memory.py
+++ b/automem/api/memory.py
@@ -987,7 +987,7 @@ def create_memory_blueprint_full(
         payload = request.get_json(silent=True)
         if not isinstance(payload, dict):
             abort(400, description="JSON body is required")
-        if "associations" in payload:
+        if isinstance(payload.get("associations"), list):
             return _create_association_batch(
                 payload=payload,
                 coerce_importance_fn=coerce_importance,

--- a/docs/API.md
+++ b/docs/API.md
@@ -43,7 +43,7 @@ Memory
   - Body: `{ "memory1_id": "...", "memory2_id": "...", "type": "RELATES_TO", "strength": 0.9 }`
   - Batch body: `{ "associations": [{ "memory1_id": "...", "memory2_id": "...", "type": "RELATES_TO", "strength": 0.9 }] }` (max 500)
   - Single response: `{ "status": "success", ... }`
-  - Batch response: `{ "status": "success"|"partial_success", "created_count": N, "failed_count": N, "succeeded": [...], "failed": [...], "summary": "N/M associations created successfully" }`
+  - Batch response: `{ "status": "success"|"partial_success", "created_count": C, "failed_count": F, "succeeded": [...], "failed": [...], "summary": "C/M associations created successfully" }`
   - Batch requests return `201` when every item succeeds and `207` when one or more items fail validation or reference missing memories.
   - `type` accepts only the 11 authorable semantic relationship types. System-generated labels such as `SIMILAR_TO`, `PRECEDED_BY`, and `DISCOVERED` are readable/filterable but cannot be created via this endpoint.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -41,7 +41,10 @@ Memory
 
 - POST `/associate`
   - Body: `{ "memory1_id": "...", "memory2_id": "...", "type": "RELATES_TO", "strength": 0.9 }`
-  - Response: `{ "status": "success", ... }`
+  - Batch body: `{ "associations": [{ "memory1_id": "...", "memory2_id": "...", "type": "RELATES_TO", "strength": 0.9 }] }` (max 500)
+  - Single response: `{ "status": "success", ... }`
+  - Batch response: `{ "status": "success"|"partial_success", "created_count": N, "failed_count": N, "succeeded": [...], "failed": [...], "summary": "N/M associations created successfully" }`
+  - Batch requests return `201` when every item succeeds and `207` when one or more items fail validation or reference missing memories.
   - `type` accepts only the 11 authorable semantic relationship types. System-generated labels such as `SIMILAR_TO`, `PRECEDED_BY`, and `DISCOVERED` are readable/filterable but cannot be created via this endpoint.
 
 Recall

--- a/docs/MCP_SSE.md
+++ b/docs/MCP_SSE.md
@@ -155,7 +155,33 @@ The MCP bridge exposes these MCP tools:
 
 ## Recall Ordering
 
-`associate_memories` accepts only the 11 authorable semantic relationship types. Auto-generated labels such as `SIMILAR_TO`, `PRECEDED_BY`, and `DISCOVERED` remain readable on recall surfaces but are not exposed as authoring choices in the MCP schema.
+`associate_memories` accepts either a single association:
+
+```json
+{
+  "memory1_id": "...",
+  "memory2_id": "...",
+  "type": "RELATES_TO",
+  "strength": 0.9
+}
+```
+
+or a batch of up to 500 associations:
+
+```json
+{
+  "associations": [
+    {
+      "memory1_id": "...",
+      "memory2_id": "...",
+      "type": "RELATES_TO",
+      "strength": 0.9
+    }
+  ]
+}
+```
+
+Batch calls return a concise summary and item-indexed failures when only some associations succeed. `associate_memories` accepts only the 11 authorable semantic relationship types. Auto-generated labels such as `SIMILAR_TO`, `PRECEDED_BY`, and `DISCOVERED` remain readable on recall surfaces but are not exposed as authoring choices in the MCP schema.
 
 `recall_memory` defaults to relevance ranking (`sort: "score"`). For chronological recaps (e.g. “what happened since X”), set:
 

--- a/mcp-sse-server/server.js
+++ b/mcp-sse-server/server.js
@@ -65,16 +65,22 @@ function stripUndefinedValues(obj) {
   return Object.fromEntries(Object.entries(obj).filter(([, value]) => value !== undefined));
 }
 
+const ASSOCIATION_FAILURE_DETAIL_LIMIT = 5;
+
 function formatAssociationResultMessage(data) {
   if (!data?.summary) {
     return data?.message || 'Association created successfully';
   }
 
   const failures = Array.isArray(data.failed) ? data.failed : [];
-  const failureText = failures
+  const visibleFailures = failures.slice(0, ASSOCIATION_FAILURE_DETAIL_LIMIT);
+  const failureParts = visibleFailures
     .map((item) => `failed index ${item.index}: ${item.reason || 'unknown error'}`)
-    .join('; ');
-  return failureText ? `${data.summary}; ${failureText}` : data.summary;
+  const omittedCount = failures.length - visibleFailures.length;
+  if (omittedCount > 0) {
+    failureParts.push(`${omittedCount} more failure${omittedCount === 1 ? '' : 's'} omitted`);
+  }
+  return failureParts.length ? `${data.summary}; ${failureParts.join('; ')}` : data.summary;
 }
 
 function isRetryableFetchError(error) {

--- a/mcp-sse-server/server.js
+++ b/mcp-sse-server/server.js
@@ -61,6 +61,22 @@ function summarizeUpstreamErrorBody(status, data) {
   return message ? String(message) : `HTTP ${status}`;
 }
 
+function stripUndefinedValues(obj) {
+  return Object.fromEntries(Object.entries(obj).filter(([, value]) => value !== undefined));
+}
+
+function formatAssociationResultMessage(data) {
+  if (!data?.summary) {
+    return data?.message || 'Association created successfully';
+  }
+
+  const failures = Array.isArray(data.failed) ? data.failed : [];
+  const failureText = failures
+    .map((item) => `failed index ${item.index}: ${item.reason || 'unknown error'}`)
+    .join('; ');
+  return failureText ? `${data.summary}; ${failureText}` : data.summary;
+}
+
 function isRetryableFetchError(error) {
   if (!error) return false;
   const name = error.name || '';
@@ -318,14 +334,13 @@ export class AutoMemClient {
     const r = await this._request('GET', path, undefined, options);
     return r;
   }
-  async associateMemories(args, options) {
-    const r = await this._request('POST', 'associate', {
-      memory1_id: args.memory1_id,
-      memory2_id: args.memory2_id,
-      type: args.type,
-      strength: args.strength
-    }, options);
-    return { success: true, message: r.message || 'Association created successfully' };
+  async associateMemories(args = {}, options) {
+    const { associations, ...singleAssociation } = args;
+    const body = Array.isArray(associations)
+      ? { associations }
+      : stripUndefinedValues(singleAssociation);
+    const r = await this._request('POST', 'associate', body, options);
+    return { success: true, message: formatAssociationResultMessage(r), response: r };
   }
   async updateMemory(args, options) {
     const { memory_id, ...updates } = args;
@@ -509,7 +524,7 @@ export function buildMcpServer(client) {
     },
     {
       name: 'associate_memories',
-      description: 'Create an association between two memories with a relationship type and strength',
+      description: 'Create one association or a batch of associations between memories',
       annotations: { readOnlyHint: false, destructiveHint: false },
       inputSchema: {
         type: 'object',
@@ -522,8 +537,38 @@ export function buildMcpServer(client) {
             description: 'Relationship type between the two memories',
           },
           strength: { type: 'number', minimum: 0, maximum: 1, description: 'Relationship strength (0-1)' },
+          associations: {
+            type: 'array',
+            minItems: 1,
+            maxItems: 500,
+            description: 'Batch of associations to create. Each item uses memory1_id, memory2_id, type, and strength.',
+            items: {
+              type: 'object',
+              properties: {
+                memory1_id: { type: 'string', description: 'ID of the source memory' },
+                memory2_id: { type: 'string', description: 'ID of the target memory' },
+                type: {
+                  type: 'string',
+                  enum: RELATION_TYPES,
+                  description: 'Relationship type between the two memories',
+                },
+                strength: {
+                  type: 'number',
+                  minimum: 0,
+                  maximum: 1,
+                  description: 'Relationship strength (0-1)',
+                },
+              },
+              required: ['memory1_id', 'memory2_id', 'type', 'strength'],
+              additionalProperties: true,
+            },
+          },
         },
-        required: ['memory1_id', 'memory2_id', 'type', 'strength']
+        anyOf: [
+          { required: ['memory1_id', 'memory2_id', 'type', 'strength'] },
+          { required: ['associations'] },
+        ],
+        additionalProperties: true,
       }
     },
     {

--- a/mcp-sse-server/test/server.test.js
+++ b/mcp-sse-server/test/server.test.js
@@ -305,6 +305,146 @@ test("AutoMemClient._request retries transient upstream errors", async () => {
   }
 });
 
+test("AutoMemClient.associateMemories forwards batch associations", async () => {
+  const client = new AutoMemClient({
+    endpoint: "http://example.test",
+    apiKey: "k",
+  });
+
+  let capturedMethod = "";
+  let capturedPath = "";
+  let capturedBody = null;
+  client._request = async (method, path, body) => {
+    capturedMethod = method;
+    capturedPath = path;
+    capturedBody = body;
+    return {
+      summary: "1/2 associations created successfully",
+      created_count: 1,
+      failed_count: 1,
+      succeeded: [{ index: 0 }],
+      failed: [{ index: 1, reason: "One or both memories do not exist" }],
+    };
+  };
+
+  const result = await client.associateMemories({
+    associations: [
+      {
+        memory1_id: "11111111-1111-1111-1111-111111111111",
+        memory2_id: "22222222-2222-2222-2222-222222222222",
+        type: "RELATES_TO",
+        strength: 0.8,
+      },
+      {
+        memory1_id: "11111111-1111-1111-1111-111111111111",
+        memory2_id: "33333333-3333-3333-3333-333333333333",
+        type: "RELATES_TO",
+        strength: 0.8,
+      },
+    ],
+  });
+
+  assert.equal(capturedMethod, "POST");
+  assert.equal(capturedPath, "associate");
+  assert.deepEqual(capturedBody.associations, [
+    {
+      memory1_id: "11111111-1111-1111-1111-111111111111",
+      memory2_id: "22222222-2222-2222-2222-222222222222",
+      type: "RELATES_TO",
+      strength: 0.8,
+    },
+    {
+      memory1_id: "11111111-1111-1111-1111-111111111111",
+      memory2_id: "33333333-3333-3333-3333-333333333333",
+      type: "RELATES_TO",
+      strength: 0.8,
+    },
+  ]);
+  assert.equal(result.message, "1/2 associations created successfully; failed index 1: One or both memories do not exist");
+});
+
+test("associate_memories tool returns partial success text without throwing", async () => {
+  const prevToken = process.env.AUTOMEM_API_TOKEN;
+  const prevEndpoint = process.env.AUTOMEM_API_URL;
+  process.env.AUTOMEM_API_TOKEN = "test-token";
+  process.env.AUTOMEM_API_URL = "http://upstream.test";
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, options) => {
+    if (String(url) === "http://upstream.test/health") {
+      return new Response(JSON.stringify({ status: "healthy" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (String(url) === "http://upstream.test/associate") {
+      const body = JSON.parse(options.body);
+      assert.equal(body.associations.length, 2);
+      return new Response(
+        JSON.stringify({
+          status: "partial_success",
+          summary: "1/2 associations created successfully",
+          created_count: 1,
+          failed_count: 1,
+          succeeded: [{ index: 0 }],
+          failed: [{ index: 1, reason: "One or both memories do not exist" }],
+        }),
+        { status: 207, headers: { "content-type": "application/json" } },
+      );
+    }
+    return originalFetch(url, options);
+  };
+
+  try {
+    const app = createApp();
+    await withServer(app, async (port) => {
+      const res = await originalFetch(`http://127.0.0.1:${port}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          Authorization: "Bearer test-token",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "associate_memories",
+            arguments: {
+              associations: [
+                {
+                  memory1_id: "11111111-1111-1111-1111-111111111111",
+                  memory2_id: "22222222-2222-2222-2222-222222222222",
+                  type: "RELATES_TO",
+                  strength: 0.8,
+                },
+                {
+                  memory1_id: "11111111-1111-1111-1111-111111111111",
+                  memory2_id: "33333333-3333-3333-3333-333333333333",
+                  type: "RELATES_TO",
+                  strength: 0.8,
+                },
+              ],
+            },
+          },
+        }),
+      });
+
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.equal(
+        body.result.content[0].text,
+        "1/2 associations created successfully; failed index 1: One or both memories do not exist",
+      );
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+    process.env.AUTOMEM_API_TOKEN = prevToken;
+    process.env.AUTOMEM_API_URL = prevEndpoint;
+  }
+});
+
 // =============================================================================
 // Streamable HTTP Transport Tests (MCP 2025-03-26)
 // =============================================================================

--- a/mcp-sse-server/test/server.test.js
+++ b/mcp-sse-server/test/server.test.js
@@ -363,6 +363,32 @@ test("AutoMemClient.associateMemories forwards batch associations", async () => 
   assert.equal(result.message, "1/2 associations created successfully; failed index 1: One or both memories do not exist");
 });
 
+test("AutoMemClient.associateMemories caps partial failure text", async () => {
+  const client = new AutoMemClient({
+    endpoint: "http://example.test",
+    apiKey: "k",
+  });
+
+  client._request = async () => ({
+    summary: "0/12 associations created successfully",
+    created_count: 0,
+    failed_count: 12,
+    succeeded: [],
+    failed: Array.from({ length: 12 }, (_, index) => ({
+      index,
+      reason: `failure ${index}`,
+    })),
+  });
+
+  const result = await client.associateMemories({ associations: [] });
+
+  assert.equal(
+    result.message,
+    "0/12 associations created successfully; failed index 0: failure 0; failed index 1: failure 1; failed index 2: failure 2; failed index 3: failure 3; failed index 4: failure 4; 7 more failures omitted",
+  );
+  assert.ok(!result.message.includes("failed index 5"));
+});
+
 test("associate_memories tool returns partial success text without throwing", async () => {
   const prevToken = process.env.AUTOMEM_API_TOKEN;
   const prevEndpoint = process.env.AUTOMEM_API_URL;

--- a/tests/support/fake_graph.py
+++ b/tests/support/fake_graph.py
@@ -46,6 +46,7 @@ class FakeGraph:
         self.memories: Dict[str, Dict[str, Any]] = {}
         self.nodes: set[str] = set()
         self.relationships: List[Dict[str, Any]] = []
+        self.association_error_types: set[str] = set()
 
         # Enrichment tracking
         self.temporal_calls: List[Dict[str, Any]] = []
@@ -436,6 +437,8 @@ class FakeGraph:
             match = re.search(r"MERGE \(m1\)-\[r:([A-Z_]+)\]->\(m2\)", query)
             if match:
                 relation_type = match.group(1)
+            if relation_type in self.association_error_types:
+                raise RuntimeError(f"simulated association error for {relation_type}")
             result_rows = []
             for row in params.get("rows") or []:
                 memory1_id = str(row.get("memory1_id") or "")
@@ -443,12 +446,13 @@ class FakeGraph:
                 if memory1_id not in self.memories or memory2_id not in self.memories:
                     continue
                 props = row.get("props") if isinstance(row.get("props"), dict) else {}
+                strength = props.get("strength")
                 self.relationships.append(
                     {
                         "id1": memory1_id,
                         "id2": memory2_id,
                         "type": relation_type,
-                        "strength": float(props.get("strength") or 0.5),
+                        "strength": float(0.5 if strength is None else strength),
                         "context": props.get("context"),
                         "reason": props.get("reason"),
                         "kind": props.get("kind"),
@@ -472,12 +476,13 @@ class FakeGraph:
             match = re.search(r"MERGE \(m1\)-\[r:([A-Z_]+)\]->\(m2\)", query)
             if match:
                 relation_type = match.group(1)
+            strength = params.get("strength")
             self.relationships.append(
                 {
                     "id1": memory1_id,
                     "id2": memory2_id,
                     "type": relation_type,
-                    "strength": float(params.get("strength") or 0.5),
+                    "strength": float(0.5 if strength is None else strength),
                     "context": params.get("context"),
                     "reason": params.get("reason"),
                     "kind": params.get("kind"),

--- a/tests/support/fake_graph.py
+++ b/tests/support/fake_graph.py
@@ -427,6 +427,41 @@ class FakeGraph:
 
         # Association creation
         if (
+            "UNWIND $rows AS row" in query
+            and "MATCH (m1:Memory" in query
+            and "MATCH (m2:Memory" in query
+            and "MERGE (m1)-[r:" in query
+        ):
+            relation_type = "RELATES_TO"
+            match = re.search(r"MERGE \(m1\)-\[r:([A-Z_]+)\]->\(m2\)", query)
+            if match:
+                relation_type = match.group(1)
+            result_rows = []
+            for row in params.get("rows") or []:
+                memory1_id = str(row.get("memory1_id") or "")
+                memory2_id = str(row.get("memory2_id") or "")
+                if memory1_id not in self.memories or memory2_id not in self.memories:
+                    continue
+                props = row.get("props") if isinstance(row.get("props"), dict) else {}
+                self.relationships.append(
+                    {
+                        "id1": memory1_id,
+                        "id2": memory2_id,
+                        "type": relation_type,
+                        "strength": float(props.get("strength") or 0.5),
+                        "context": props.get("context"),
+                        "reason": props.get("reason"),
+                        "kind": props.get("kind"),
+                        "origin": props.get("origin"),
+                        "confidence": props.get("confidence"),
+                        "similarity": props.get("similarity"),
+                        "updated_at": props.get("updated_at"),
+                    }
+                )
+                result_rows.append([row.get("index"), memory1_id, memory2_id])
+            return FakeResult(result_rows)
+
+        if (
             "MATCH (m1:Memory" in query
             and "MATCH (m2:Memory" in query
             and "MERGE (m1)-[r:" in query

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -3191,6 +3191,157 @@ def test_create_association_with_properties(client, mock_state, auth_headers):
     assert data["context"] == "Production environment"
 
 
+def test_create_association_batch_all_success(client, mock_state, auth_headers):
+    """Batch association should create valid relationships in one request."""
+    mem_ids = [
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+        "33333333-3333-3333-3333-333333333333",
+    ]
+    for index, memory_id in enumerate(mem_ids, start=1):
+        mock_state.memory_graph.memories[memory_id] = {
+            "id": memory_id,
+            "content": f"Memory {index}",
+        }
+
+    response = client.post(
+        "/associate",
+        json={
+            "associations": [
+                {
+                    "memory1_id": mem_ids[0],
+                    "memory2_id": mem_ids[1],
+                    "type": "RELATES_TO",
+                    "strength": 0.8,
+                },
+                {
+                    "memory1_id": mem_ids[1],
+                    "memory2_id": mem_ids[2],
+                    "type": "PREFERS_OVER",
+                    "strength": 0.9,
+                    "reason": "Clearer",
+                    "context": "Test",
+                },
+            ]
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data["status"] == "success"
+    assert data["created_count"] == 2
+    assert data["failed_count"] == 0
+    assert data["summary"] == "2/2 associations created successfully"
+    assert [item["index"] for item in data["succeeded"]] == [0, 1]
+    assert data["failed"] == []
+    assert len(mock_state.memory_graph.relationships) == 2
+    prefers = [
+        rel for rel in mock_state.memory_graph.relationships if rel["type"] == "PREFERS_OVER"
+    ]
+    assert prefers[0]["reason"] == "Clearer"
+    assert prefers[0]["context"] == "Test"
+
+
+def test_create_association_batch_partial_success(client, mock_state, auth_headers):
+    """Batch association should report per-item failures without rolling back successes."""
+    mem_a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    mem_b = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    missing = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+    for memory_id in (mem_a, mem_b):
+        mock_state.memory_graph.memories[memory_id] = {
+            "id": memory_id,
+            "content": f"Memory {memory_id}",
+        }
+
+    response = client.post(
+        "/associate",
+        json={
+            "associations": [
+                {
+                    "memory1_id": mem_a,
+                    "memory2_id": mem_b,
+                    "type": "RELATES_TO",
+                    "strength": 0.8,
+                },
+                {
+                    "memory1_id": "not-a-uuid",
+                    "memory2_id": mem_b,
+                    "type": "RELATES_TO",
+                    "strength": 0.8,
+                },
+                {
+                    "memory1_id": mem_a,
+                    "memory2_id": mem_a,
+                    "type": "RELATES_TO",
+                    "strength": 0.8,
+                },
+                {
+                    "memory1_id": mem_a,
+                    "memory2_id": mem_b,
+                    "type": "SIMILAR_TO",
+                    "strength": 0.8,
+                },
+                {
+                    "memory1_id": mem_a,
+                    "memory2_id": missing,
+                    "type": "RELATES_TO",
+                    "strength": 0.8,
+                },
+            ]
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 207
+    data = response.get_json()
+    assert data["status"] == "partial_success"
+    assert data["created_count"] == 1
+    assert data["failed_count"] == 4
+    assert data["summary"] == "1/5 associations created successfully"
+    assert [item["index"] for item in data["succeeded"]] == [0]
+    failures = {item["index"]: item["reason"] for item in data["failed"]}
+    assert "'memory1_id' must be a valid UUID" in failures[1]
+    assert "Cannot associate a memory with itself" in failures[2]
+    assert "Relation type must be one of" in failures[3]
+    assert "One or both memories do not exist" in failures[4]
+    assert len(mock_state.memory_graph.relationships) == 1
+
+
+def test_create_association_batch_all_item_failures(client, mock_state, auth_headers):
+    """A valid batch request with no valid items should still return per-item failures."""
+    response = client.post(
+        "/associate",
+        json={
+            "associations": [
+                {
+                    "memory1_id": "not-a-uuid",
+                    "memory2_id": "also-not-a-uuid",
+                    "type": "RELATES_TO",
+                    "strength": 0.8,
+                }
+            ]
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 207
+    data = response.get_json()
+    assert data["status"] == "partial_success"
+    assert data["created_count"] == 0
+    assert data["failed_count"] == 1
+    assert data["summary"] == "0/1 associations created successfully"
+
+
+def test_create_association_batch_rejects_empty_array(client, mock_state, auth_headers):
+    """Malformed batch envelopes should remain hard 400 errors."""
+    response = client.post("/associate", json={"associations": []}, headers=auth_headers)
+
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "'associations' must be a non-empty array" in data["message"]
+
+
 # ==================== Test Startup Recall ====================
 
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -3212,7 +3212,7 @@ def test_create_association_batch_all_success(client, mock_state, auth_headers):
                     "memory1_id": mem_ids[0],
                     "memory2_id": mem_ids[1],
                     "type": "RELATES_TO",
-                    "strength": 0.8,
+                    "strength": 0.0,
                 },
                 {
                     "memory1_id": mem_ids[1],
@@ -3236,6 +3236,7 @@ def test_create_association_batch_all_success(client, mock_state, auth_headers):
     assert [item["index"] for item in data["succeeded"]] == [0, 1]
     assert data["failed"] == []
     assert len(mock_state.memory_graph.relationships) == 2
+    assert mock_state.memory_graph.relationships[0]["strength"] == 0.0
     prefers = [
         rel for rel in mock_state.memory_graph.relationships if rel["type"] == "PREFERS_OVER"
     ]
@@ -3331,6 +3332,56 @@ def test_create_association_batch_all_item_failures(client, mock_state, auth_hea
     assert data["created_count"] == 0
     assert data["failed_count"] == 1
     assert data["summary"] == "0/1 associations created successfully"
+
+
+def test_create_association_batch_query_error_reports_partial_success(
+    client, mock_state, auth_headers
+):
+    """Later grouped write failures should not hide earlier successful writes."""
+    mem_ids = [
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+        "33333333-3333-3333-3333-333333333333",
+    ]
+    for index, memory_id in enumerate(mem_ids, start=1):
+        mock_state.memory_graph.memories[memory_id] = {
+            "id": memory_id,
+            "content": f"Memory {index}",
+        }
+    mock_state.memory_graph.association_error_types = {"PREFERS_OVER"}
+
+    response = client.post(
+        "/associate",
+        json={
+            "associations": [
+                {
+                    "memory1_id": mem_ids[0],
+                    "memory2_id": mem_ids[1],
+                    "type": "RELATES_TO",
+                    "strength": 0.8,
+                },
+                {
+                    "memory1_id": mem_ids[1],
+                    "memory2_id": mem_ids[2],
+                    "type": "PREFERS_OVER",
+                    "strength": 0.9,
+                    "reason": "Clearer",
+                },
+            ]
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 207
+    data = response.get_json()
+    assert data["status"] == "partial_success"
+    assert data["created_count"] == 1
+    assert data["failed_count"] == 1
+    assert data["summary"] == "1/2 associations created successfully"
+    assert [item["index"] for item in data["succeeded"]] == [0]
+    failures = {item["index"]: item["reason"] for item in data["failed"]}
+    assert failures == {1: "Failed to create association batch for relation type PREFERS_OVER"}
+    assert len(mock_state.memory_graph.relationships) == 1
 
 
 def test_create_association_batch_rejects_empty_array(client, mock_state, auth_headers):

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -3342,6 +3342,39 @@ def test_create_association_batch_rejects_empty_array(client, mock_state, auth_h
     assert "'associations' must be a non-empty array" in data["message"]
 
 
+def test_create_association_single_ignores_non_list_associations_key(
+    client, mock_state, auth_headers
+):
+    """Legacy single-association payloads should tolerate an unrelated associations key."""
+    mem1_id = "44444444-4444-4444-4444-444444444444"
+    mem2_id = "55555555-5555-5555-5555-555555555555"
+    mock_state.memory_graph.memories[mem1_id] = {
+        "id": mem1_id,
+        "content": "Memory 1",
+    }
+    mock_state.memory_graph.memories[mem2_id] = {
+        "id": mem2_id,
+        "content": "Memory 2",
+    }
+
+    response = client.post(
+        "/associate",
+        json={
+            "memory1_id": mem1_id,
+            "memory2_id": mem2_id,
+            "type": "RELATES_TO",
+            "strength": 0.8,
+            "associations": None,
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data["status"] == "success"
+    assert len(mock_state.memory_graph.relationships) == 1
+
+
 # ==================== Test Startup Recall ====================
 
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -3236,7 +3236,13 @@ def test_create_association_batch_all_success(client, mock_state, auth_headers):
     assert [item["index"] for item in data["succeeded"]] == [0, 1]
     assert data["failed"] == []
     assert len(mock_state.memory_graph.relationships) == 2
-    assert mock_state.memory_graph.relationships[0]["strength"] == 0.0
+    assert any(
+        rel["type"] == "RELATES_TO"
+        and rel["id1"] == mem_ids[0]
+        and rel["id2"] == mem_ids[1]
+        and rel["strength"] == 0.0
+        for rel in mock_state.memory_graph.relationships
+    )
     prefers = [
         rel for rel in mock_state.memory_graph.relationships if rel["type"] == "PREFERS_OVER"
     ]


### PR DESCRIPTION
## Summary
- Add backwards-compatible batch support to POST /associate via an associations array capped at 500 items
- Batch-write valid associations with FalkorDB UNWIND grouped by relationship type and return per-index partial-success results
- Update the MCP bridge, tests, and docs for bulk associate_memories behavior

Closes #196.

## Tests
- make test
- make lint
- source .venv/bin/activate && black --check automem/api/memory.py tests/support/fake_graph.py tests/test_api_endpoints.py
- npm test --prefix mcp-sse-server

## API / Config
- Existing single-association request/response shape remains supported
- Batch responses return 201 when all items succeed and 207 when any item fails
- No config changes