### PR TITLE
fix(recall): preserve vector fetch limit floor

### DIFF
--- a/automem/api/recall.py
+++ b/automem/api/recall.py
@@ -1955,8 +1955,9 @@ def handle_recall(
             # pure-vector match would otherwise be cut before its signal can
             # lift it. Results are trimmed to `limit` downstream, so the
             # response size is unchanged. OVERFETCH=1 restores legacy behavior.
-            vector_fetch_limit = min(
-                per_query_limit * RECALL_VECTOR_OVERFETCH, RECALL_VECTOR_FETCH_CAP
+            vector_fetch_limit = max(
+                per_query_limit,
+                min(per_query_limit * RECALL_VECTOR_OVERFETCH, RECALL_VECTOR_FETCH_CAP),
             )
             if tag_filters and (query_str or embedding_param):
                 vector_fetch_limit = max(vector_fetch_limit, recall_max_limit)

--- a/tests/test_recall_overfetch.py
+++ b/tests/test_recall_overfetch.py
@@ -117,3 +117,9 @@ def test_vector_overfetch_off_switch_uses_1x(overfetch_env, monkeypatch):
     assert last_limit == 5
     # without over-fetch the target never enters the candidate pool
     assert "lennard-bafoeg" not in ids
+
+
+def test_vector_fetch_cap_never_reduces_below_requested_limit(overfetch_env, monkeypatch):
+    monkeypatch.setattr(recall_module, "RECALL_VECTOR_FETCH_CAP", 3)
+    _ids, last_limit = _recall(overfetch_env)
+    assert last_limit == 5


### PR DESCRIPTION
## Summary

- Preserve the caller's requested vector fetch limit even when `RECALL_VECTOR_FETCH_CAP` is configured below `limit`.
- Add a regression test for the cap-under-limit edge case.
- Keeps the cap as an over-fetch ceiling without allowing it to make recall narrower than legacy behavior.

## Context

Follow-up to PR #205. The original over-fetch implementation used `min(per_query_limit * RECALL_VECTOR_OVERFETCH, RECALL_VECTOR_FETCH_CAP)`, which can ask Qdrant for fewer candidates than the requested response limit when the cap is set low.

## Tests

- `venv/bin/pytest tests/test_recall_overfetch.py tests/test_recall_artifact_exclusion.py`
- `make test`
- A/B already run locally while evaluating PR #205:
  - `locomo-mini`: main `82.98% (195/235)` -> PR `84.26% (198/235)`
  - `locomo`: main `81.58% (1258/1542)` -> PR `81.84% (1262/1542)`

## Risk Notes

- This is a narrow guardrail around the new config; it should only affect deployments that lower `RECALL_VECTOR_FETCH_CAP` below requested `limit`.
- No merge performed.
