### PR TITLE
fix(sync): ignore metapattern artifacts in drift checks

### DIFF
--- a/automem/api/admin.py
+++ b/automem/api/admin.py
@@ -5,6 +5,9 @@ from typing import Any, Callable, Dict, List, Optional, Set
 
 from flask import Blueprint, abort, jsonify, request
 
+from automem.config import RECALL_EXCLUDED_TYPES
+from automem.sync.accounting import fetch_falkor_memory_ids, fetch_qdrant_point_ids
+
 
 def _parse_metadata(raw: Any) -> Dict[str, Any]:
     """Parse metadata from FalkorDB which may be a string or dict."""
@@ -34,28 +37,13 @@ def _parse_tags(raw: Any) -> List[str]:
     return []
 
 
-def _get_all_qdrant_ids(qdrant_client: Any, collection_name: str) -> Set[str]:
+def _get_all_qdrant_ids(
+    qdrant_client: Any,
+    collection_name: str,
+    excluded_types: Optional[Set[str]] = None,
+) -> Set[str]:
     """Fetch all point IDs from Qdrant collection."""
-    all_ids: Set[str] = set()
-    offset = None
-
-    while True:
-        result = qdrant_client.scroll(
-            collection_name=collection_name,
-            limit=1000,
-            offset=offset,
-            with_payload=False,
-            with_vectors=False,
-        )
-        points, next_offset = result
-        for point in points:
-            all_ids.add(str(point.id))
-
-        if next_offset is None:
-            break
-        offset = next_offset
-
-    return all_ids
+    return fetch_qdrant_point_ids(qdrant_client, collection_name, excluded_types)
 
 
 def create_admin_blueprint_full(
@@ -253,16 +241,11 @@ def create_admin_blueprint_full(
             batch_size = 32
         dry_run = bool(payload.get("dry_run", False))
 
-        # Get all memory IDs from FalkorDB
-        falkor_query = "MATCH (m:Memory) RETURN m.id AS id"
-        falkor_result = graph.query(falkor_query)
-        falkor_ids: Set[str] = set()
-        for row in getattr(falkor_result, "result_set", []) or []:
-            if row[0]:
-                falkor_ids.add(str(row[0]))
+        # Get vector-sync-eligible memory IDs from FalkorDB.
+        falkor_ids = fetch_falkor_memory_ids(graph, RECALL_EXCLUDED_TYPES)
 
-        # Get all point IDs from Qdrant
-        qdrant_ids = _get_all_qdrant_ids(qdrant_client, collection_name)
+        # Get vector-sync-eligible point IDs from Qdrant.
+        qdrant_ids = _get_all_qdrant_ids(qdrant_client, collection_name, RECALL_EXCLUDED_TYPES)
 
         # Find missing (in FalkorDB but not in Qdrant)
         missing_ids = falkor_ids - qdrant_ids

--- a/automem/api/health.py
+++ b/automem/api/health.py
@@ -4,6 +4,8 @@ from typing import Any, Callable, Optional
 
 from flask import Blueprint, jsonify
 
+from automem.sync.accounting import count_falkor_memories, count_qdrant_points
+
 
 def create_health_blueprint(
     get_memory_graph: Callable[[], Any],
@@ -17,7 +19,7 @@ def create_health_blueprint(
 
     @bp.route("/health", methods=["GET"])
     def health() -> Any:
-        from automem.config import VECTOR_SIZE
+        from automem.config import RECALL_EXCLUDED_TYPES, VECTOR_SIZE
 
         graph_available = get_memory_graph() is not None
         qdrant_available = get_qdrant_client() is not None
@@ -35,9 +37,7 @@ def create_health_blueprint(
             try:
                 graph = get_memory_graph()
                 if graph:
-                    result = graph.query("MATCH (m:Memory) RETURN COUNT(m) as count")
-                    if getattr(result, "result_set", None):
-                        memory_count = result.result_set[0][0]
+                    memory_count = count_falkor_memories(graph, RECALL_EXCLUDED_TYPES)
             except Exception:
                 pass
 
@@ -49,7 +49,9 @@ def create_health_blueprint(
                 qdrant = get_qdrant_client()
                 if qdrant:
                     info = qdrant.get_collection(collection_name)
-                    vector_count = info.points_count
+                    vector_count = count_qdrant_points(
+                        qdrant, collection_name, RECALL_EXCLUDED_TYPES
+                    )
                     collection_vector_size = info.config.params.vectors.size
             except Exception:
                 pass

--- a/automem/config.py
+++ b/automem/config.py
@@ -159,7 +159,8 @@ RECALL_VECTOR_OVERFETCH = max(1, int(os.getenv("RECALL_VECTOR_OVERFETCH", "4")))
 RECALL_VECTOR_FETCH_CAP = max(1, int(os.getenv("RECALL_VECTOR_FETCH_CAP", "200")))
 
 # Internal artifact memory types that must never surface in user-facing /recall
-# results (e.g. consolidation cluster summaries). Comma-separated env override.
+# results or vector sync accounting (e.g. consolidation cluster summaries).
+# Comma-separated env override.
 RECALL_EXCLUDED_TYPES = frozenset(
     t.strip() for t in os.getenv("RECALL_EXCLUDED_TYPES", "MetaPattern").split(",") if t.strip()
 )

--- a/automem/sync/accounting.py
+++ b/automem/sync/accounting.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, List, Set
+
+from automem.stores.vector_store import _build_qdrant_tag_filter
+
+
+def _normalized_excluded_types(excluded_types: Iterable[str] | None) -> List[str]:
+    return [
+        str(memory_type).strip()
+        for memory_type in (excluded_types or [])
+        if str(memory_type).strip()
+    ]
+
+
+def _excluded_type_params(excluded_types: Iterable[str] | None) -> dict[str, Any]:
+    excluded = _normalized_excluded_types(excluded_types)
+    return {"excluded_types": excluded} if excluded else {}
+
+
+def _memory_type_where(excluded_types: Iterable[str] | None, alias: str = "m") -> str:
+    excluded = _normalized_excluded_types(excluded_types)
+    if not excluded:
+        return ""
+    return f"WHERE NOT coalesce({alias}.type, '') IN $excluded_types"
+
+
+def count_falkor_memories(graph: Any, excluded_types: Iterable[str] | None) -> int:
+    """Count vector-sync-eligible graph memories."""
+    result = graph.query(
+        f"""
+        MATCH (m:Memory)
+        {_memory_type_where(excluded_types)}
+        RETURN COUNT(m) as count
+        """,
+        _excluded_type_params(excluded_types),
+    )
+    rows = getattr(result, "result_set", []) or []
+    if not rows:
+        return 0
+    return int(rows[0][0] or 0)
+
+
+def fetch_falkor_memory_ids(graph: Any, excluded_types: Iterable[str] | None) -> Set[str]:
+    """Fetch vector-sync-eligible graph memory IDs."""
+    result = graph.query(
+        f"""
+        MATCH (m:Memory)
+        {_memory_type_where(excluded_types)}
+        RETURN m.id AS id
+        """,
+        _excluded_type_params(excluded_types),
+    )
+    ids: Set[str] = set()
+    for row in getattr(result, "result_set", []) or []:
+        if row[0]:
+            ids.add(str(row[0]))
+    return ids
+
+
+def _qdrant_exclusion_filter(excluded_types: Iterable[str] | None) -> Any:
+    return _build_qdrant_tag_filter(None, excluded_types=excluded_types)
+
+
+def count_qdrant_points(
+    qdrant_client: Any,
+    collection_name: str,
+    excluded_types: Iterable[str] | None,
+) -> int:
+    """Count vector-sync-eligible Qdrant points."""
+    count_filter = _qdrant_exclusion_filter(excluded_types)
+    count_fn = getattr(qdrant_client, "count", None)
+    if count_fn is not None:
+        result = count_fn(
+            collection_name=collection_name,
+            count_filter=count_filter,
+            exact=True,
+        )
+        return int(getattr(result, "count", result) or 0)
+
+    return len(fetch_qdrant_point_ids(qdrant_client, collection_name, excluded_types))
+
+
+def fetch_qdrant_point_ids(
+    qdrant_client: Any,
+    collection_name: str,
+    excluded_types: Iterable[str] | None,
+) -> Set[str]:
+    """Fetch vector-sync-eligible Qdrant point IDs."""
+    point_ids: Set[str] = set()
+    scroll_filter = _qdrant_exclusion_filter(excluded_types)
+    offset = None
+
+    while True:
+        result = qdrant_client.scroll(
+            collection_name=collection_name,
+            scroll_filter=scroll_filter,
+            limit=1000,
+            offset=offset,
+            with_payload=False,
+            with_vectors=False,
+        )
+        points, next_offset = result
+        for point in points:
+            point_ids.add(str(point.id))
+
+        if next_offset is None:
+            break
+        offset = next_offset
+
+    return point_ids

--- a/automem/sync/runtime_worker.py
+++ b/automem/sync/runtime_worker.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Set
+from typing import Any, Callable
+
+from automem.config import RECALL_EXCLUDED_TYPES
+from automem.sync.accounting import fetch_falkor_memory_ids, fetch_qdrant_point_ids
 
 
 def init_sync_worker(
@@ -66,28 +69,8 @@ def run_sync_check(
         return
 
     try:
-        falkor_result = graph.query("MATCH (m:Memory) RETURN m.id AS id")
-        falkor_ids: Set[str] = set()
-        for row in getattr(falkor_result, "result_set", []) or []:
-            if row[0]:
-                falkor_ids.add(str(row[0]))
-
-        qdrant_ids: Set[str] = set()
-        offset = None
-        while True:
-            result = qdrant.scroll(
-                collection_name=collection_name,
-                limit=1000,
-                offset=offset,
-                with_payload=False,
-                with_vectors=False,
-            )
-            points, next_offset = result
-            for point in points:
-                qdrant_ids.add(str(point.id))
-            if next_offset is None:
-                break
-            offset = next_offset
+        falkor_ids = fetch_falkor_memory_ids(graph, RECALL_EXCLUDED_TYPES)
+        qdrant_ids = fetch_qdrant_point_ids(qdrant, collection_name, RECALL_EXCLUDED_TYPES)
 
         missing_ids = falkor_ids - qdrant_ids
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -360,7 +360,7 @@ Background worker that checks FalkorDB ↔ Qdrant consistency.
 | `RECALL_METADATA_SEARCH_ENABLED` | Enable bounded metadata sidecar recall candidates | `true` |
 | `RECALL_VECTOR_OVERFETCH` | Multiplier for semantic vector candidate fetch size before final recall re-ranking | `4` |
 | `RECALL_VECTOR_FETCH_CAP` | Absolute cap for over-fetched vector candidates, separate from response `RECALL_MAX_LIMIT` | `200` |
-| `RECALL_EXCLUDED_TYPES` | Comma-separated memory types excluded from user-facing recall results | `MetaPattern` |
+| `RECALL_EXCLUDED_TYPES` | Comma-separated internal artifact memory types excluded from user-facing recall and vector sync accounting | `MetaPattern` |
 | `RECALL_MIN_SCORE` | Drop results scoring below this final score (per-request `min_score` overrides) | `0.0` (disabled) |
 | `RECALL_ADAPTIVE_FLOOR` | Drop weak tail results when there is a clear score gap between strong and weak candidates (per-request `adaptive_floor` overrides) | `true` |
 | `RECALL_RELEVANCE_GATE` | Within-pool relevance gate: when a query is present and a result's best topical evidence (max of vector/keyword/metadata/exact components) is below this threshold, its query-independent components (importance, confidence, recency, tag overlap) are scaled by `evidence / gate` — a linear ramp. Stops high-importance off-topic memories from dominating tag-scoped recall (issue #130). Negative values clamp to `0.0`, values above `1.0` clamp to `1.0`. | `0.0` (disabled) |

--- a/tests/support/fake_graph.py
+++ b/tests/support/fake_graph.py
@@ -32,6 +32,13 @@ def _skip_limit(query: str) -> tuple[int, int | None]:
     return int(match.group(1)), int(match.group(2))
 
 
+def _memory_type_allowed(memory: Dict[str, Any], excluded_types: List[str]) -> bool:
+    if not excluded_types:
+        return True
+    memory_type = str(memory.get("type") or "")
+    return memory_type not in {str(value) for value in excluded_types}
+
+
 class FakeGraph:
     """Shared fake FalkorDB graph used across unit tests.
 
@@ -129,6 +136,15 @@ class FakeGraph:
             if memory is not None:
                 memory["relevance_score"] = score
             return FakeResult([])
+
+        if "MATCH (m:Memory)" in query and "RETURN COUNT(m)" in query:
+            excluded_types = params.get("excluded_types") or []
+            count = sum(
+                1
+                for memory in self.memories.values()
+                if _memory_type_allowed(memory, excluded_types)
+            )
+            return FakeResult([[count]])
 
         # JIT canonical enrichment state check
         if "MATCH (m:Memory {id: $id}) RETURN m.enriched, m.processed" in query:
@@ -383,7 +399,12 @@ class FakeGraph:
             return FakeResult(rows)
 
         if "MATCH (m:Memory)" in query and "RETURN m.id AS id" in query:
-            rows = [[memory_id] for memory_id in self.memories]
+            excluded_types = params.get("excluded_types") or []
+            rows = [
+                [memory_id]
+                for memory_id, memory in self.memories.items()
+                if _memory_type_allowed(memory, excluded_types)
+            ]
             return FakeResult(rows)
 
         # Startup recall query patterns

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -136,6 +136,24 @@ class MockQdrantClient:
                 return False
         return True
 
+    def count(self, collection_name, count_filter=None, exact=True):
+        """Mock count operation."""
+        _ = collection_name, exact
+        matches = [
+            point
+            for point in self.points.values()
+            if self._filter_matches(point["payload"], count_filter)
+        ]
+        return SimpleNamespace(count=len(matches))
+
+    def get_collection(self, collection_name):
+        """Mock collection metadata for health checks."""
+        _ = collection_name
+        return SimpleNamespace(
+            points_count=len(self.points),
+            config=SimpleNamespace(params=SimpleNamespace(vectors=SimpleNamespace(size=768))),
+        )
+
 
 @pytest.fixture
 def mock_state(monkeypatch):
@@ -318,6 +336,39 @@ def test_health_endpoint_falkordb_down(client, mock_state):
     assert data["status"] == "degraded"
     assert data["falkordb"] == "disconnected"
     assert data["qdrant"] == "connected"
+
+
+def test_health_endpoint_ignores_metapattern_artifacts_in_sync_counts(client, mock_state):
+    """MetaPattern graph artifacts should not create health drift."""
+    memory_id = "11111111-1111-1111-1111-111111111111"
+    artifact_id = "22222222-2222-2222-2222-222222222222"
+    mock_state.memory_graph.memories[memory_id] = {
+        "id": memory_id,
+        "content": "Ordinary vector-backed memory",
+        "type": "Context",
+    }
+    mock_state.memory_graph.memories[artifact_id] = {
+        "id": artifact_id,
+        "content": "Meta-pattern cluster artifact",
+        "type": "MetaPattern",
+    }
+    mock_state.qdrant.points[memory_id] = {
+        "vector": [0.1] * 768,
+        "payload": {"type": "Context", "content": "Ordinary vector-backed memory"},
+    }
+    mock_state.qdrant.points[artifact_id] = {
+        "vector": [0.0] * 768,
+        "payload": {"type": "MetaPattern", "content": "Meta-pattern cluster artifact"},
+    }
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["memory_count"] == 1
+    assert data["vector_count"] == 1
+    assert data["sync_status"] == "synced"
+    assert data["status"] == "healthy"
 
 
 # ==================== Test Memory Recall ====================
@@ -3086,6 +3137,88 @@ def test_admin_sync_uses_embedding_provider_without_openai(client, mock_state, a
     assert data["failed"] == 0
     assert mock_state.qdrant.points[memory_id]["vector"] == [0.6] * 768
     assert mock_state.embedding_provider.batch_calls == [["Missing vector memory"]]
+
+
+def test_admin_sync_dry_run_ignores_metapattern_missing_vector(client, mock_state, admin_headers):
+    """MetaPattern graph artifacts should not be reported as sync drift."""
+    memory_id = "12121212-1212-1212-1212-121212121212"
+    artifact_id = "34343434-3434-3434-3434-343434343434"
+    mock_state.memory_graph.memories[memory_id] = {
+        "id": memory_id,
+        "content": "Already vector-backed memory",
+        "tags": ["sync"],
+        "type": "Context",
+    }
+    mock_state.memory_graph.memories[artifact_id] = {
+        "id": artifact_id,
+        "content": "Meta-pattern cluster artifact",
+        "tags": [],
+        "type": "MetaPattern",
+    }
+    mock_state.qdrant.points[memory_id] = {
+        "vector": [0.2] * 768,
+        "payload": {"type": "Context", "content": "Already vector-backed memory"},
+    }
+    mock_state.qdrant.points[artifact_id] = {
+        "vector": [0.0] * 768,
+        "payload": {"type": "MetaPattern", "content": "Meta-pattern cluster artifact"},
+    }
+
+    response = client.post("/admin/sync", json={"dry_run": True}, headers=admin_headers)
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "dry_run"
+    assert data["falkordb_count"] == 1
+    assert data["qdrant_count"] == 1
+    assert data["missing_count"] == 0
+    assert data["orphaned_count"] == 0
+    assert data["missing_sample"] == []
+
+
+def test_sync_worker_ignores_metapattern_missing_vector(mock_state):
+    """Background sync repair should not enqueue graph-only artifacts."""
+    from automem.sync.runtime_worker import run_sync_check
+
+    memory_id = "56565656-5656-5656-5656-565656565656"
+    artifact_id = "78787878-7878-7878-7878-787878787878"
+    mock_state.memory_graph.memories[memory_id] = {
+        "id": memory_id,
+        "content": "Already synced memory",
+        "type": "Context",
+    }
+    mock_state.memory_graph.memories[artifact_id] = {
+        "id": artifact_id,
+        "content": "Meta-pattern cluster artifact",
+        "type": "MetaPattern",
+    }
+    mock_state.qdrant.points[memory_id] = {
+        "vector": [0.3] * 768,
+        "payload": {"type": "Context", "content": "Already synced memory"},
+    }
+    queued = []
+
+    run_sync_check(
+        state=mock_state,
+        logger=SimpleNamespace(
+            debug=lambda *args, **kwargs: None,
+            info=lambda *args, **kwargs: None,
+            warning=lambda *args, **kwargs: None,
+            exception=lambda *args, **kwargs: None,
+        ),
+        get_memory_graph_fn=lambda: mock_state.memory_graph,
+        get_qdrant_client_fn=lambda: mock_state.qdrant,
+        collection_name="memories",
+        utc_now_fn=lambda: "2026-01-01T00:00:00+00:00",
+        enqueue_embedding_fn=lambda memory_id, content: queued.append((memory_id, content)),
+    )
+
+    assert queued == []
+    assert mock_state.sync_last_result == {
+        "falkordb_count": 1,
+        "qdrant_count": 1,
+        "missing_count": 0,
+    }
 
 
 def test_admin_sync_counts_provider_fallback_as_failed(client, mock_state, admin_headers):


### PR DESCRIPTION
## Summary

- Treat configured internal artifact memory types, defaulting to `MetaPattern`, as graph-only for vector sync accounting.
- Share sync-eligible FalkorDB/Qdrant count and ID helpers across `/health`, `/admin/sync`, and the background sync worker.
- Update docs for `RECALL_EXCLUDED_TYPES` to clarify it applies to recall and vector sync accounting.

## Tests

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest tests/test_api_endpoints.py -q -k 'health or admin_sync or sync_worker_ignores_metapattern'`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest tests/test_consolidation_engine.py tests/test_recall_artifact_exclusion.py -q`
- `make test`
- `make lint`

## Risk Notes

- `/health` and `/admin/sync` memory/vector counts now report sync-eligible counts, not raw all-node/all-point totals.
- Existing MetaPattern graph nodes remain unembedded by design; stale MetaPattern Qdrant vectors are ignored for sync drift.

Closes #209
