### PR TITLE
fix(memory): require confirmed graph writes

### DIFF
--- a/automem/api/memory.py
+++ b/automem/api/memory.py
@@ -364,6 +364,48 @@ def _delete_graph_memories(
         abort_fn(500, description="Failed to delete memories by tag")
 
 
+def _result_rows(result: Any) -> List[Any]:
+    return list(getattr(result, "result_set", []) or [])
+
+
+def _returned_memory_id(row: Any) -> Optional[str]:
+    if not row:
+        return None
+
+    returned = row[0]
+    if isinstance(returned, str):
+        return returned
+
+    properties = getattr(returned, "properties", None)
+    if isinstance(properties, dict):
+        value = properties.get("id")
+        return str(value) if value is not None else None
+
+    if isinstance(returned, dict):
+        value = returned.get("id")
+        return str(value) if value is not None else None
+
+    return None
+
+
+def _memory_write_confirmed(result: Any, expected_id: str) -> bool:
+    rows = _result_rows(result)
+    if not rows:
+        return False
+
+    returned_id = _returned_memory_id(rows[0])
+    return returned_id == expected_id
+
+
+def _batch_memory_write_confirmed(result: Any, expected_ids: List[str]) -> bool:
+    rows = _result_rows(result)
+    if len(rows) != len(expected_ids):
+        return False
+
+    returned_ids = {_returned_memory_id(row) for row in rows}
+    return returned_ids == set(expected_ids)
+
+
 def create_memory_blueprint(
     store_memory: Callable[[], Any],
     update_memory: Callable[[str], Any],
@@ -568,7 +610,7 @@ def create_memory_blueprint_full(
             last_accessed = updated_at
 
         try:
-            graph.query(
+            graph_result = graph.query(
                 """
                 MERGE (m:Memory {id: $id})
                 ON CREATE SET
@@ -618,6 +660,10 @@ def create_memory_blueprint_full(
             )
         except Exception:
             logger.exception("Failed to persist memory in FalkorDB")
+            abort(500, description="Failed to store memory in FalkorDB")
+
+        if not _memory_write_confirmed(graph_result, memory_id):
+            logger.error("FalkorDB store returned no memory row for %s", memory_id)
             abort(500, description="Failed to store memory in FalkorDB")
 
         # Queue enrichment
@@ -1220,7 +1266,7 @@ def create_memory_blueprint_full(
             abort(503, description="FalkorDB is unavailable")
 
         try:
-            graph.query(
+            graph_result = graph.query(
                 """
                 UNWIND $memories AS m
                 MERGE (node:Memory {id: m.id})
@@ -1244,6 +1290,15 @@ def create_memory_blueprint_full(
             )
         except Exception:
             logger.exception("Batch graph write failed")
+            abort(500, description="Failed to store memories in FalkorDB")
+
+        expected_ids = [memory["id"] for memory in validated]
+        if not _batch_memory_write_confirmed(graph_result, expected_ids):
+            logger.error(
+                "Batch graph write returned %d/%d memory ids",
+                len(_result_rows(graph_result)),
+                len(expected_ids),
+            )
             abort(500, description="Failed to store memories in FalkorDB")
 
         # 4. Batch Qdrant upsert

--- a/tests/support/fake_graph.py
+++ b/tests/support/fake_graph.py
@@ -232,6 +232,37 @@ class FakeGraph:
             skip, limit = _skip_limit(query)
             return FakeResult(rows[skip : None if limit is None else skip + limit])
 
+        # Batch memory create/upsert
+        if "UNWIND $memories AS m" in query and "MERGE (node:Memory {id: m.id})" in query:
+            rows = []
+            for memory in params.get("memories") or []:
+                memory_id = str(memory.get("id") or "")
+                if not memory_id:
+                    continue
+                self.nodes.add(memory_id)
+                existing = self.memories.get(memory_id, {})
+                self.memories[memory_id] = {
+                    "id": memory_id,
+                    "content": memory.get("content", existing.get("content", "")),
+                    "tags": memory.get("tags", existing.get("tags", [])),
+                    "tag_prefixes": memory.get("tag_prefixes", existing.get("tag_prefixes", [])),
+                    "importance": memory.get("importance", existing.get("importance", 0.5)),
+                    "type": memory.get("type", existing.get("type", "Memory")),
+                    "timestamp": memory.get("timestamp", existing.get("timestamp", _utc_now())),
+                    "metadata": memory.get("metadata", existing.get("metadata", "{}")),
+                    "updated_at": memory.get("updated_at", existing.get("updated_at")),
+                    "last_accessed": memory.get("last_accessed", existing.get("last_accessed")),
+                    "t_valid": memory.get("t_valid", existing.get("t_valid")),
+                    "t_invalid": memory.get("t_invalid", existing.get("t_invalid")),
+                    "confidence": memory.get("confidence", existing.get("confidence", 1.0)),
+                    "summary": memory.get("summary", existing.get("summary")),
+                    "processed": memory.get("processed", existing.get("processed", False)),
+                    "enriched": memory.get("enriched", existing.get("enriched", False)),
+                    "enriched_at": memory.get("enriched_at", existing.get("enriched_at")),
+                }
+                rows.append([memory_id])
+            return FakeResult(rows)
+
         # Memory create/upsert
         if "MERGE (m:Memory {id:" in query or "CREATE (m:Memory {id:" in query:
             memory_id = str(params["id"])

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -21,7 +21,7 @@ from automem.utils import scoring
 from automem.utils.scoring import _compute_metadata_score, _compute_recency_score
 from automem.utils.text import _extract_keywords
 from automem.utils.time import query_has_temporal_intent
-from tests.support.fake_graph import FakeGraph
+from tests.support.fake_graph import FakeGraph, FakeResult
 
 
 class MockQdrantClient:
@@ -3836,6 +3836,93 @@ def test_falkordb_unavailable(client, mock_state, auth_headers):
     assert response.status_code == 503
     data = response.get_json()
     assert "FalkorDB is unavailable" in data["message"]
+
+
+class EmptyStoreResultGraph(FakeGraph):
+    """Simulate FalkorDB accepting a write query but returning no persisted rows."""
+
+    def query(self, query: str, params: dict[str, Any] | None = None, **kwargs: Any) -> FakeResult:
+        self.queries.append((query, params or {}))
+        if "MERGE (m:Memory {id:" in query and "RETURN m" in query:
+            return FakeResult([])
+        if "UNWIND $memories AS m" in query and "RETURN node.id" in query:
+            return FakeResult([])
+        return super().query(query, params, **kwargs)
+
+
+def test_store_memory_requires_confirmed_graph_write(client, mock_state, auth_headers):
+    """POST /memory must not return success unless FalkorDB returns the stored node."""
+    mock_state.memory_graph = EmptyStoreResultGraph()
+
+    response = client.post(
+        "/memory",
+        json={
+            "content": "Silent store failure probe",
+            "type": "Context",
+            "embedding": [0.2] * config.VECTOR_SIZE,
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 500
+    data = response.get_json()
+    assert "Failed to store memory in FalkorDB" in data["message"]
+    assert mock_state.memory_graph.memories == {}
+    assert mock_state.qdrant.upsert_calls == []
+    assert mock_state.qdrant.points == {}
+
+
+def test_batch_store_requires_confirmed_graph_write(client, mock_state, auth_headers):
+    """POST /memory/batch must not claim stored rows FalkorDB did not return."""
+    mock_state.memory_graph = EmptyStoreResultGraph()
+    mock_state.embedding_provider = FakeEmbeddingProvider([[0.3] * config.VECTOR_SIZE])
+
+    response = client.post(
+        "/memory/batch",
+        json={
+            "memories": [
+                {
+                    "content": "Silent batch failure probe",
+                    "type": "Context",
+                    "tags": ["issue-202"],
+                }
+            ]
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 500
+    data = response.get_json()
+    assert "Failed to store memories in FalkorDB" in data["message"]
+    assert mock_state.memory_graph.memories == {}
+    assert mock_state.qdrant.upsert_calls == []
+    assert mock_state.qdrant.points == {}
+
+
+def test_batch_store_success_confirms_graph_ids(client, mock_state, auth_headers):
+    """Successful POST /memory/batch writes graph rows before vector upsert."""
+    mock_state.embedding_provider = FakeEmbeddingProvider([[0.4] * config.VECTOR_SIZE])
+
+    response = client.post(
+        "/memory/batch",
+        json={
+            "memories": [
+                {
+                    "content": "Confirmed batch write probe",
+                    "type": "Context",
+                    "tags": ["issue-202"],
+                }
+            ]
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data["status"] == "success"
+    [memory_id] = data["memory_ids"]
+    assert memory_id in mock_state.memory_graph.memories
+    assert memory_id in mock_state.qdrant.points
 
 
 def test_invalid_json_payload(client, mock_state, auth_headers):

--- a/tests/test_embedding_providers.py
+++ b/tests/test_embedding_providers.py
@@ -940,7 +940,11 @@ def test_end_to_end_memory_storage_with_provider(monkeypatch):
 
     # Mock graph
     mock_graph = Mock()
-    mock_graph.query.return_value = Mock(result_set=[[Mock(properties={"id": "test-id"})]])
+
+    def query_result_with_written_id(_query, params=None, **_kwargs):
+        return Mock(result_set=[[Mock(properties={"id": params["id"]})]])
+
+    mock_graph.query.side_effect = query_result_with_written_id
     app.state.memory_graph = mock_graph
 
     # Initialize provider


### PR DESCRIPTION
## Summary
- require single-memory FalkorDB writes to return the stored memory id before `/memory` reports success
- require batch FalkorDB writes to return every generated memory id before `/memory/batch` reports success
- avoid enrichment/vector side effects when the graph write is not confirmed
- teach the shared fake graph to model successful batch writes

Closes #202.

## Public/API Notes
- No response shape changes for successful requests.
- If FalkorDB accepts a write query but returns no stored row/id, `/memory` now returns `500` instead of `201 success`; `/memory/batch` does the same when any expected id is missing.

## Breaking Changes
- None intended. This only changes false-success failure behavior.

## Validation
- RED confirmed before implementation: `tests/test_api_endpoints.py -q -k 'confirmed_graph_write'` returned two failures because both endpoints still returned `201`.
- RED confirmed for fake batch coverage: `tests/test_api_endpoints.py -q -k 'batch_store_success_confirms_graph_ids'` failed until the fake graph returned batch ids.
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest tests/test_api_endpoints.py -q` -> 195 passed, 1 skipped
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest tests/test_embedding_providers.py -q -k 'end_to_end_memory_storage_with_provider'` -> 1 passed, 45 deselected
- `make test` -> 634 passed, 1 skipped, 65 deselected
- `make lint` -> passed
- `git diff --check` -> passed