### PR TITLE
docs(readme): lead benchmark section with neutral AMB numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
   <a href="LICENSE"><img src="https://img.shields.io/github/license/verygoodplugins/automem" alt="License" /></a>
   <a href="https://automem.ai/discord"><img src="https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
   <a href="https://x.com/automem_ai"><img src="https://img.shields.io/badge/X-@automem__ai-000000?logo=x&logoColor=white" alt="X" /></a>
-  <a href="benchmarks/EXPERIMENT_LOG.md"><img src="https://img.shields.io/badge/LongMemEval-87.00%25-success" alt="LongMemEval benchmark" /></a>
-  <a href="https://automem.ai/benchmarks"><img src="https://img.shields.io/badge/BEAM%2010M-57.4%25-success" alt="BEAM 10M on the Agent Memory Benchmark" /></a>
+  <a href="https://automem.ai/benchmarks"><img src="https://img.shields.io/badge/LoCoMo%20(AMB)-85.1%25-success" alt="LoCoMo on the neutral Agent Memory Benchmark" /></a>
+  <a href="https://automem.ai/benchmarks"><img src="https://img.shields.io/badge/BEAM%2010M%20(AMB)-57.4%25-success" alt="BEAM 10M on the neutral Agent Memory Benchmark" /></a>
   <a href="https://railway.com/deploy/automem-ai-memory-service?referralCode=VuFE6g&utm_medium=integration&utm_source=github&utm_campaign=generic"><img src="https://img.shields.io/badge/Deploy%20on-Railway-0B0D0E?logo=railway&logoColor=white" alt="Deploy on Railway" /></a>
 </p>
 
@@ -28,7 +28,7 @@ Your AI forgets between sessions. RAG dumps documents that look similar. Vector 
 
 AutoMem stores typed relationships *and* embeddings. When you ask "why did we choose PostgreSQL?", recall returns not just the matching memory — but the alternatives you considered, the principle behind the choice, and the related decisions that came after.
 
-Current canonical benchmark results are **87.00%** on LongMemEval full with **97.00% recall@5**, and **84.74%** on LoCoMo full. See [`benchmarks/EXPERIMENT_LOG.md`](benchmarks/EXPERIMENT_LOG.md) for methodology, judge policy, category breakdowns, and historical runs.
+On its *own* internal harness, AutoMem scores **87.00%** on LongMemEval full (**97.00%** recall@5) and **84.74%** on LoCoMo full — but those are engineering baselines scored by a self-hosted judge (`gpt-5.4-mini`), and the same answers can swing ~12 points on judge model alone. For comparison against other systems, the numbers that matter come from the **neutral** third-party board below. See [`benchmarks/EXPERIMENT_LOG.md`](benchmarks/EXPERIMENT_LOG.md) for methodology, judge policy, category breakdowns, and historical runs.
 
 ### On the neutral Agent Memory Benchmark
 


### PR DESCRIPTION
## What & why

The README benchmark section led with AutoMem's **internal** harness numbers — LongMemEval **87.00%**, LoCoMo **84.74%** — described as "current canonical benchmark results," and placed them **above** the neutral Agent Memory Benchmark (AMB) section.

Those internal numbers are scored by a self-hosted judge (`gpt-5.4-mini`). The same answers can swing ~12 points on judge choice alone, and the neutral board reports the comparable LongMemEval family at 74.4% (vs 85.1% LoCoMo). Leading with the self-graded figure as "canonical" invites an obvious "your own two numbers disagree" read and undercuts the honest neutral results that follow.

This re-leads the section with the neutral board and demotes the internal numbers to clearly-stamped engineering baselines.

## Changes (3 lines, docs only)

- **Badges:** replace the internal `LongMemEval 87.00%` badge with two neutral-board badges — `LoCoMo (AMB) 85.1%` and `BEAM 10M (AMB) 57.4%` — both linking to automem.ai/benchmarks.
- **Intro line:** keep the internal 87.00% / 84.74% numbers but stamp them as self-judged engineering baselines, note the ~12-point judge swing, and defer to the neutral board for cross-system comparison.

## Notes for reviewer

- No numbers were invented or changed — internal figures are unchanged (just reframed); neutral figures match `benchmarks/EXPERIMENT_LOG.md` (AMB section) and automem.ai/benchmarks.
- Consistent with the existing "submitted, PR #24 under review" posture; nothing here claims official/leaderboard status.
- Context: this is the pre-flight reconciliation for an upcoming dev.to article on reading agent-memory benchmarks — the article points readers at this README, so it can't lead with a contradictory self-graded number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
