### PR TITLE
fix(backup): page FalkorDB export by node id instead of deep SKIP

### DIFF
--- a/automem/backup.py
+++ b/automem/backup.py
@@ -14,6 +14,47 @@ from typing import Any, Callable, Iterable, Iterator, Optional
 VALID_BACKUP_INCLUDES = ("falkordb", "qdrant")
 STREAM_QUEUE_MAX_CHUNKS = 8
 
+# FalkorDB caps every result set at RESULTSET_SIZE and returns the short set
+# with no error, so a batch that reaches the cap may have lost rows silently.
+DEFAULT_RESULTSET_CAP = 10000
+INITIAL_RELATIONSHIP_ID_CHUNK = 256
+MAX_RELATIONSHIP_ID_CHUNK = 4096
+# A bulk export should not inherit an interactive query's TIMEOUT budget.
+BACKUP_QUERY_TIMEOUT_MS = 300000
+# Concurrent writes shift the totals mid-export; a wider gap means lost rows.
+BACKUP_COUNT_TOLERANCE = 0.01
+
+NODE_EXPORT_QUERY = """
+                MATCH (n)
+                WHERE id(n) >= {lo} AND id(n) < {hi}
+                RETURN
+                    id(n) as id,
+                    labels(n) as labels,
+                    properties(n) as props
+                """
+
+RELATIONSHIP_EXPORT_QUERY = """
+                MATCH (a)-[r]->(b)
+                WHERE id(a) >= {lo} AND id(a) < {hi}
+                RETURN
+                    id(a) as source_id,
+                    type(r) as rel_type,
+                    id(b) as target_id,
+                    properties(r) as props
+                """
+
+SINGLE_NODE_RELATIONSHIP_EXPORT_QUERY = """
+                MATCH (a)-[r]->(b)
+                WHERE id(a) = {node_id}
+                RETURN
+                    id(a) as source_id,
+                    type(r) as rel_type,
+                    id(b) as target_id,
+                    properties(r) as props
+                ORDER BY id(r)
+                SKIP {offset} LIMIT {limit}
+                """
+
 
 class BackupError(RuntimeError):
     """Raised when backup creation fails."""
@@ -70,6 +111,160 @@ def _query_rows(result: Any) -> list[Any]:
     return list(getattr(result, "result_set", []) or [])
 
 
+def _backup_rows(graph: Any, query: str) -> list[Any]:
+    return _query_rows(graph.query(query, timeout=BACKUP_QUERY_TIMEOUT_MS))
+
+
+def _backup_scalar(graph: Any, query: str) -> Any:
+    rows = _backup_rows(graph, query)
+    if not rows or not rows[0]:
+        return None
+    return rows[0][0]
+
+
+def _resultset_cap(graph: Any, batch_size: int, logger: Any = None) -> int:
+    """Largest batch that FalkorDB will return in full."""
+    configured = DEFAULT_RESULTSET_CAP
+    try:
+        raw = graph.execute_command("GRAPH.CONFIG", "GET", "RESULTSET_SIZE")
+        reported = int(raw[1])
+        # 0 or negative means unlimited.
+        if reported > 0:
+            configured = reported
+    except Exception as exc:  # noqa: BLE001 - config read is best-effort
+        if logger:
+            logger.debug("Could not read RESULTSET_SIZE (%s); assuming %d", exc, configured)
+
+    return max(1, min(batch_size, configured))
+
+
+def _export_falkordb_nodes(
+    graph: Any, max_node_id: int, cap: int, logger: Any = None
+) -> list[dict[str, Any]]:
+    nodes: list[dict[str, Any]] = []
+    # One row per node, so half the cap can never reach it.
+    chunk = max(1, cap // 2)
+    lo = 0
+
+    while lo <= max_node_id:
+        hi = min(lo + chunk, max_node_id + 1)
+        rows = _backup_rows(graph, NODE_EXPORT_QUERY.format(lo=lo, hi=hi))
+        nodes.extend({"id": row[0], "labels": row[1], "properties": row[2]} for row in rows)
+
+        if logger and rows:
+            logger.info(
+                "Exported FalkorDB node batch: %d nodes (total: %d)",
+                len(rows),
+                len(nodes),
+            )
+        lo = hi
+
+    return nodes
+
+
+def _export_node_relationships(graph: Any, node_id: int, cap: int) -> list[dict[str, Any]]:
+    """Page one node's out-edges, for a node whose degree alone reaches the cap."""
+    relationships: list[dict[str, Any]] = []
+    offset = 0
+
+    while True:
+        rows = _backup_rows(
+            graph,
+            SINGLE_NODE_RELATIONSHIP_EXPORT_QUERY.format(node_id=node_id, offset=offset, limit=cap),
+        )
+        relationships.extend(
+            {
+                "source_id": row[0],
+                "type": row[1],
+                "target_id": row[2],
+                "properties": row[3],
+            }
+            for row in rows
+        )
+        if len(rows) < cap:
+            return relationships
+        offset += cap
+
+
+def _export_falkordb_relationships(
+    graph: Any, max_node_id: int, cap: int, logger: Any = None
+) -> list[dict[str, Any]]:
+    relationships: list[dict[str, Any]] = []
+    chunk = INITIAL_RELATIONSHIP_ID_CHUNK
+    lo = 0
+
+    while lo <= max_node_id:
+        hi = min(lo + chunk, max_node_id + 1)
+        rows = _backup_rows(graph, RELATIONSHIP_EXPORT_QUERY.format(lo=lo, hi=hi))
+
+        # At the cap the result set may have been truncated server-side, and a
+        # truncated batch is indistinguishable from a complete one. Narrow the
+        # range and retry rather than trust it.
+        reached_cap = len(rows) >= cap
+        if reached_cap and hi - lo > 1:
+            chunk = max(1, (hi - lo) // 4)
+            continue
+        if reached_cap:
+            relationships.extend(_export_node_relationships(graph, lo, cap))
+            if logger:
+                logger.info(
+                    "Exported FalkorDB relationships for high-degree node %d (total: %d)",
+                    lo,
+                    len(relationships),
+                )
+            lo += 1
+            chunk = INITIAL_RELATIONSHIP_ID_CHUNK
+            continue
+
+        relationships.extend(
+            {
+                "source_id": row[0],
+                "type": row[1],
+                "target_id": row[2],
+                "properties": row[3],
+            }
+            for row in rows
+        )
+        if logger and rows:
+            logger.info(
+                "Exported FalkorDB relationship batch: %d relationships (total: %d)",
+                len(rows),
+                len(relationships),
+            )
+
+        lo = hi
+        room_to_grow = len(rows) * 3 < cap and chunk < MAX_RELATIONSHIP_ID_CHUNK
+        if room_to_grow:
+            chunk = min(chunk * 2, MAX_RELATIONSHIP_ID_CHUNK)
+
+    return relationships
+
+
+def _verify_export_count(
+    *, kind: str, exported: int, before: int, after: int, logger: Any = None
+) -> None:
+    """Fail a truncated export instead of writing a backup that looks complete."""
+    expected = min(before, after)
+    if exported >= expected:
+        return
+
+    shortfall = expected - exported
+    if exported < expected * (1 - BACKUP_COUNT_TOLERANCE):
+        raise BackupError(
+            f"FalkorDB {kind} export is short by {shortfall} "
+            f"(exported {exported}, graph held {expected}) - refusing to write a partial backup"
+        )
+    if logger:
+        logger.warning(
+            "FalkorDB %s export is short by %d (exported %d, graph held %d); "
+            "within tolerance for concurrent writes",
+            kind,
+            shortfall,
+            exported,
+            expected,
+        )
+
+
 def export_falkordb_artifact(
     *,
     graph: Any,
@@ -78,81 +273,42 @@ def export_falkordb_artifact(
     batch_size: int = 10000,
     logger: Any = None,
 ) -> BackupArtifact:
-    """Export FalkorDB graph data as a compressed JSON backup artifact."""
+    """Export FalkorDB graph data as a compressed JSON backup artifact.
+
+    Pages on internal node id ranges, which FalkorDB plans as ``NodeByIdSeek``.
+    ``SKIP <offset>`` re-scans every skipped row, so its cost grows with depth
+    until batches exceed the server's ``TIMEOUT`` and the export dies partway
+    through a large graph.
+    """
     if graph is None:
         raise BackupError("FalkorDB is unavailable")
 
-    nodes: list[dict[str, Any]] = []
-    offset = 0
+    cap = _resultset_cap(graph, batch_size, logger)
+    max_node_id = _backup_scalar(graph, "MATCH (n) RETURN max(id(n))")
+    node_count_before = _backup_scalar(graph, "MATCH (n) RETURN count(n)") or 0
+    relationship_count_before = _backup_scalar(graph, "MATCH ()-[r]->() RETURN count(r)") or 0
 
-    while True:
-        rows = _query_rows(
-            graph.query(
-                f"""
-                MATCH (n)
-                RETURN
-                    id(n) as id,
-                    labels(n) as labels,
-                    properties(n) as props
-                SKIP {offset} LIMIT {batch_size}
-                """
-            )
-        )
-        if not rows:
-            break
+    if max_node_id is None:
+        nodes: list[dict[str, Any]] = []
+        relationships: list[dict[str, Any]] = []
+    else:
+        nodes = _export_falkordb_nodes(graph, int(max_node_id), cap, logger)
+        relationships = _export_falkordb_relationships(graph, int(max_node_id), cap, logger)
 
-        for row in rows:
-            nodes.append({"id": row[0], "labels": row[1], "properties": row[2]})
-
-        if logger:
-            logger.info(
-                "Exported FalkorDB node batch: %d nodes (total: %d)",
-                len(rows),
-                len(nodes),
-            )
-        if len(rows) < batch_size:
-            break
-        offset += batch_size
-
-    relationships: list[dict[str, Any]] = []
-    offset = 0
-
-    while True:
-        rows = _query_rows(
-            graph.query(
-                f"""
-                MATCH (a)-[r]->(b)
-                RETURN
-                    id(a) as source_id,
-                    type(r) as rel_type,
-                    id(b) as target_id,
-                    properties(r) as props
-                SKIP {offset} LIMIT {batch_size}
-                """
-            )
-        )
-        if not rows:
-            break
-
-        for row in rows:
-            relationships.append(
-                {
-                    "source_id": row[0],
-                    "type": row[1],
-                    "target_id": row[2],
-                    "properties": row[3],
-                }
-            )
-
-        if logger:
-            logger.info(
-                "Exported FalkorDB relationship batch: %d relationships (total: %d)",
-                len(rows),
-                len(relationships),
-            )
-        if len(rows) < batch_size:
-            break
-        offset += batch_size
+    _verify_export_count(
+        kind="node",
+        exported=len(nodes),
+        before=node_count_before,
+        after=_backup_scalar(graph, "MATCH (n) RETURN count(n)") or 0,
+        logger=logger,
+    )
+    _verify_export_count(
+        kind="relationship",
+        exported=len(relationships),
+        before=relationship_count_before,
+        after=_backup_scalar(graph, "MATCH ()-[r]->() RETURN count(r)") or 0,
+        logger=logger,
+    )
 
     stats = {
         "node_count": len(nodes),

--- a/tests/support/fake_graph.py
+++ b/tests/support/fake_graph.py
@@ -32,6 +32,21 @@ def _skip_limit(query: str) -> tuple[int, int | None]:
     return int(match.group(1)), int(match.group(2))
 
 
+def _id_range(query: str, alias: str) -> tuple[int, int] | None:
+    """Parse the `id(x) >= lo AND id(x) < hi` window the backup exporter pages with."""
+    match = re.search(
+        rf"id\({alias}\)\s*>=\s*(\d+)\s+AND\s+id\({alias}\)\s*<\s*(\d+)", " ".join(query.split())
+    )
+    if not match:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+def _single_id(query: str, alias: str) -> int | None:
+    match = re.search(rf"id\({alias}\)\s*=\s*(\d+)", " ".join(query.split()))
+    return int(match.group(1)) if match else None
+
+
 def _memory_type_allowed(memory: Dict[str, Any], excluded_types: List[str]) -> bool:
     if not excluded_types:
         return True
@@ -48,6 +63,10 @@ class FakeGraph:
 
     def __init__(self, *, seed_enrichment_fixture: bool = False) -> None:
         self.queries: List[tuple[str, Dict[str, Any]]] = []
+        self.query_kwargs: List[Dict[str, Any]] = []
+
+        # Set to mimic FalkorDB's RESULTSET_SIZE cap (silent truncation).
+        self.resultset_cap: int | None = None
 
         # Generic memory storage + associations
         self.memories: Dict[str, Dict[str, Any]] = {}
@@ -94,8 +113,46 @@ class FakeGraph:
                 ["mem-c", "Automation habit noted"],
             ]
 
+    def _backup_node_rows(self) -> List[List[Any]]:
+        return [
+            [index, ["Memory"], dict(memory)]
+            for index, (_memory_id, memory) in enumerate(sorted(self.memories.items()))
+        ]
+
+    def _backup_relationship_rows(self) -> List[List[Any]]:
+        backup_ids = {memory_id: index for index, memory_id in enumerate(sorted(self.memories))}
+        rows: List[List[Any]] = []
+        for rel in self.relationships:
+            source_id = str(rel.get("id1") or "")
+            target_id = str(rel.get("id2") or "")
+            if source_id not in backup_ids or target_id not in backup_ids:
+                continue
+            props = {key: value for key, value in rel.items() if key not in {"id1", "id2", "type"}}
+            rows.append(
+                [
+                    backup_ids[source_id],
+                    str(rel.get("type") or "RELATES_TO"),
+                    backup_ids[target_id],
+                    props,
+                ]
+            )
+        return sorted(rows, key=lambda row: row[0])
+
+    def _apply_result_limits(self, rows: List[List[Any]], query: str) -> List[List[Any]]:
+        """Apply SKIP/LIMIT, then RESULTSET_SIZE truncation the way the server does: silently."""
+        skip, limit = _skip_limit(query)
+        rows = rows[skip : None if limit is None else skip + limit]
+        if self.resultset_cap is not None:
+            rows = rows[: self.resultset_cap]
+        return rows
+
+    def execute_command(self, *args: Any) -> Any:
+        if args[:3] == ("GRAPH.CONFIG", "GET", "RESULTSET_SIZE"):
+            return ["RESULTSET_SIZE", self.resultset_cap or 0]
+        raise NotImplementedError(f"FakeGraph.execute_command{args}")
+
     def query(self, query: str, params: Dict[str, Any] | None = None, **kwargs: Any) -> FakeResult:
-        del kwargs
+        self.query_kwargs.append(dict(kwargs))
         params = params or {}
         self.queries.append((query, params))
 
@@ -196,41 +253,36 @@ class FakeGraph:
             return FakeResult([])
 
         # Full graph backup export
+        if "RETURN max(id(n))" in query:
+            node_rows = self._backup_node_rows()
+            return FakeResult([[node_rows[-1][0] if node_rows else None]])
+
+        if "RETURN count(n)" in query:
+            return FakeResult([[len(self._backup_node_rows())]])
+
+        if "RETURN count(r)" in query:
+            return FakeResult([[len(self._backup_relationship_rows())]])
+
         if "MATCH (n)" in query and "id(n) as id" in query and "properties(n) as props" in query:
-            memory_items = sorted(self.memories.items(), key=lambda item: item[0])
-            rows = [
-                [index, ["Memory"], dict(memory)]
-                for index, (_memory_id, memory) in enumerate(memory_items)
-            ]
-            skip, limit = _skip_limit(query)
-            return FakeResult(rows[skip : None if limit is None else skip + limit])
+            rows = self._backup_node_rows()
+            id_range = _id_range(query, "n")
+            if id_range:
+                rows = [row for row in rows if id_range[0] <= row[0] < id_range[1]]
+            return FakeResult(self._apply_result_limits(rows, query))
 
         if (
             "MATCH (a)-[r]->(b)" in query
             and "id(a) as source_id" in query
             and "properties(r) as props" in query
         ):
-            memory_ids = [memory_id for memory_id, _memory in sorted(self.memories.items())]
-            backup_ids = {memory_id: index for index, memory_id in enumerate(memory_ids)}
-            rows = []
-            for rel in self.relationships:
-                source_id = str(rel.get("id1") or "")
-                target_id = str(rel.get("id2") or "")
-                if source_id not in backup_ids or target_id not in backup_ids:
-                    continue
-                props = {
-                    key: value for key, value in rel.items() if key not in {"id1", "id2", "type"}
-                }
-                rows.append(
-                    [
-                        backup_ids[source_id],
-                        str(rel.get("type") or "RELATES_TO"),
-                        backup_ids[target_id],
-                        props,
-                    ]
-                )
-            skip, limit = _skip_limit(query)
-            return FakeResult(rows[skip : None if limit is None else skip + limit])
+            rows = self._backup_relationship_rows()
+            id_range = _id_range(query, "a")
+            single_id = _single_id(query, "a")
+            if id_range:
+                rows = [row for row in rows if id_range[0] <= row[0] < id_range[1]]
+            elif single_id is not None:
+                rows = [row for row in rows if row[0] == single_id]
+            return FakeResult(self._apply_result_limits(rows, query))
 
         # Batch memory create/upsert
         if "UNWIND $memories AS m" in query and "MERGE (node:Memory {id: m.id})" in query:

--- a/tests/test_falkordb_backup_export.py
+++ b/tests/test_falkordb_backup_export.py
@@ -1,0 +1,157 @@
+"""Regression tests for the FalkorDB backup export pagination.
+
+Covers the two ways the previous ``SKIP <offset> LIMIT <batch_size>`` paging
+lost data: batches that grew slower with depth until they exceeded the server's
+``TIMEOUT``, and FalkorDB's ``RESULTSET_SIZE`` cap silently truncating a result
+set that the loop then read as "the last page".
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+import json
+import re
+from typing import Any
+
+import pytest
+
+from automem.backup import BackupError, export_falkordb_artifact
+from tests.support.fake_graph import FakeGraph
+
+
+def build_graph(memory_count: int, degrees: dict[int, int] | None = None) -> FakeGraph:
+    """Seed a graph with `memory_count` memories and per-node out-degrees."""
+    graph = FakeGraph()
+    for index in range(memory_count):
+        memory_id = f"mem-{index:05d}"
+        graph.memories[memory_id] = {"id": memory_id, "content": f"memory {index}"}
+        graph.nodes.add(memory_id)
+
+    for source, degree in (degrees or {}).items():
+        for step in range(degree):
+            graph.relationships.append(
+                {
+                    "id1": f"mem-{source:05d}",
+                    "id2": f"mem-{(source + step + 1) % memory_count:05d}",
+                    "type": "RELATES_TO",
+                    "strength": 0.5,
+                }
+            )
+    return graph
+
+
+def export(graph: FakeGraph, **kwargs: Any) -> dict[str, Any]:
+    artifact = export_falkordb_artifact(
+        graph=graph, graph_name="memories", timestamp="20260101_000000", **kwargs
+    )
+    with gzip.open(io.BytesIO(artifact.data), "rt", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def assert_exported_everything(graph: FakeGraph, payload: dict[str, Any]) -> None:
+    assert payload["stats"]["node_count"] == len(graph.memories)
+    assert payload["stats"]["relationship_count"] == len(graph.relationships)
+    assert len(payload["nodes"]) == len(graph.memories)
+
+    exported_ids = [node["id"] for node in payload["nodes"]]
+    assert len(set(exported_ids)) == len(exported_ids), "a node was exported twice"
+
+    exported_edges = sorted(
+        (rel["source_id"], rel["type"], rel["target_id"]) for rel in payload["relationships"]
+    )
+    assert len(exported_edges) == len(graph.relationships)
+    node_ids = set(exported_ids)
+    assert all(edge[0] in node_ids and edge[2] in node_ids for edge in exported_edges)
+
+
+def test_export_round_trips_a_small_graph() -> None:
+    graph = build_graph(50, {index: 2 for index in range(50)})
+    assert_exported_everything(graph, export(graph))
+
+
+def test_export_is_complete_when_resultset_cap_is_below_batch_size() -> None:
+    """RESULTSET_SIZE under batch_size used to end the export after one batch."""
+    graph = build_graph(2500, {index: 3 for index in range(2500)})
+    graph.resultset_cap = 1000
+
+    payload = export(graph)
+
+    assert_exported_everything(graph, payload)
+    assert payload["stats"] == {"node_count": 2500, "relationship_count": 7500}
+
+
+def test_export_subdivides_a_dense_relationship_range() -> None:
+    """A node id window holding more relationships than the cap must be split."""
+    degrees = {index: 1 for index in range(300)}
+    degrees.update({index: 60 for index in range(40, 45)})
+    graph = build_graph(300, degrees)
+    graph.resultset_cap = 100
+
+    assert_exported_everything(graph, export(graph))
+
+
+def test_export_pages_a_single_high_degree_node() -> None:
+    """One node with more out-edges than the cap falls back to bounded SKIP."""
+    degrees = {index: 2 for index in range(200)}
+    degrees[7] = 250
+    graph = build_graph(200, degrees)
+    graph.resultset_cap = 100
+
+    payload = export(graph)
+
+    assert_exported_everything(graph, payload)
+    hub_edges = [rel for rel in payload["relationships"] if rel["source_id"] == 7]
+    assert len(hub_edges) == 250
+
+
+def test_export_handles_out_degree_exactly_at_the_cap() -> None:
+    """Rows == cap is ambiguous between complete and truncated; treat it as truncated."""
+    degrees = {index: 1 for index in range(50)}
+    degrees[3] = 100
+    graph = build_graph(50, degrees)
+    graph.resultset_cap = 100
+
+    assert_exported_everything(graph, export(graph))
+
+
+def test_export_rejects_a_silently_truncated_result() -> None:
+    """A backup that lost rows must fail rather than look complete."""
+
+    class LossyGraph(FakeGraph):
+        def _apply_result_limits(self, rows: list[Any], query: str) -> list[Any]:
+            kept = super()._apply_result_limits(rows, query)
+            return [row for index, row in enumerate(kept) if index % 5]
+
+    graph = LossyGraph()
+    for index in range(300):
+        memory_id = f"mem-{index:05d}"
+        graph.memories[memory_id] = {"id": memory_id}
+
+    with pytest.raises(BackupError, match="short by"):
+        export(graph)
+
+
+def test_export_handles_an_empty_graph() -> None:
+    payload = export(FakeGraph())
+
+    assert payload["nodes"] == []
+    assert payload["relationships"] == []
+    assert payload["stats"] == {"node_count": 0, "relationship_count": 0}
+
+
+def test_export_avoids_deep_skip_and_always_sets_a_timeout() -> None:
+    """Deep SKIP is what exceeded the server TIMEOUT on a large graph."""
+    graph = build_graph(400, {index: 3 for index in range(400)})
+
+    export(graph)
+
+    assert graph.query_kwargs, "no queries were issued"
+    assert all(kwargs.get("timeout") for kwargs in graph.query_kwargs)
+
+    offsets = [
+        int(match.group(1))
+        for query, _params in graph.queries
+        if (match := re.search(r"\bSKIP\s+(\d+)", query))
+    ]
+    assert all(offset == 0 for offset in offsets), f"deep SKIP still in use: {offsets}"


### PR DESCRIPTION
`export_falkordb_artifact` pages the graph with `SKIP <offset> LIMIT <batch_size>`. That loses data two ways on a graph of any size.

## 1. Deep SKIP exceeds the server timeout

FalkorDB re-scans and discards every skipped row, so each batch costs more than the last. On my instance (20,682 nodes / 238,238 relationships) the tail batches reached 1120 ms of server execution and tripped the instance's `TIMEOUT` config (1000), killing the backup partway through:

```
INFO  | Exported FalkorDB relationship batch: 10000 relationships (total: 210000)
INFO  | Exported FalkorDB relationship batch: 10000 relationships (total: 220000)
ERROR | ❌ FalkorDB backup failed: Query timed out
ERROR | ❌ Backup failed: Query timed out
```

Measured against that graph, same rows returned:

| Pagination | Server execution |
|---|---|
| `SKIP 220000 LIMIT 10000` | 1120 ms (`Filter` over `All Node Scan`) |
| `WHERE id(a) >= lo AND id(a) < hi` | 37–42 ms (`NodeByIdSeek`) |

This has been failing roughly every other scheduled run for me since the graph crossed ~220k relationships.

## 2. `RESULTSET_SIZE` truncates silently

FalkorDB caps a result set at `RESULTSET_SIZE` and returns the short set **with no error**. A query covering 65,900 relationships came back with exactly 10,000 rows and no warning.

The loop breaks when a batch returns fewer rows than `batch_size`, so any `RESULTSET_SIZE` below `batch_size` ends the export after the first batch. Running the current exporter unmodified against a 5,000-node / 15,000-relationship graph with `RESULTSET_SIZE=1000`:

```
UPSTREAM  exported: {'node_count': 1000, 'relationship_count': 1000}
          lost: 4000 nodes, 14000 relationships (no error raised)
PATCHED   exported: {'node_count': 5000, 'relationship_count': 15000}
```

80% of nodes and 93% of relationships silently missing, and the backup reports success. At the 10000 default the batch size and the cap coincide, so nothing is lost today — but the failure mode is invisible when it does fire, and it fires on the *first* batch.

## The change

Pages on internal node id ranges, which FalkorDB plans as `NodeByIdSeek`. Every relationship has exactly one source node, so ranges over `id(a)` partition the edge set with no overlap or gaps.

- Batches stay under the result-set cap, read from `GRAPH.CONFIG GET RESULTSET_SIZE` and bounded by `batch_size`.
- A batch that *reaches* the cap is ambiguous between complete and truncated, so its range is subdivided and retried rather than trusted.
- A single node whose out-degree alone reaches the cap falls back to `SKIP` bounded by that one node's edges.
- Queries carry an explicit timeout — a bulk export shouldn't inherit an interactive query's `TIMEOUT` budget.
- Exported totals are verified against `count()` before the artifact is written, with a 1% tolerance for concurrent writes. A larger shortfall raises `BackupError` instead of writing a backup that looks complete.

Relationship windows self-tune (256 node ids, doubling while batches stay clear of the cap), so batch count adapts to graph density rather than being fixed.

**The backup file format is unchanged**, so existing restore tooling reads these backups as-is.

## Verification

Against a live FalkorDB instance:

- The current exporter reproduces the timeout at 220,000 relationships.
- This one exports 20,715 nodes and 238,668 relationships, matching live `count()` exactly, zero duplicate ids, in 24 s.

Test suite: 642 passed, 1 skipped (`pytest -m "not integration and not live"`), including the 24 existing `test_backup_endpoint.py` tests. `black`, `isort`, and `flake8` clean.

`tests/support/fake_graph.py` gains id-range and `count()`/`max()` handling plus an optional `resultset_cap` that truncates silently the way the server does. **Six of the eight new tests fail against the current exporter**; the two that pass are the small-graph and empty-graph cases it already handled.

## One thing I did not change

The export is not atomic — nodes are read, then relationships. A relationship created mid-export can point at a node newer than the node phase, so it lands in the backup with a target that isn't there. I saw 16 such edges in a run where the graph grew by 24 nodes during the export. `_restore_relationship_batches` already skips these with a warning, and the race predates this change (the old exporter had a wider window, being slower), so I left it alone. Happy to follow up if you'd like it addressed.
