### PR TITLE
fix(qdrant): index the `type` payload field so recall filters stop 400ing

### DIFF
--- a/automem/stores/runtime_clients.py
+++ b/automem/stores/runtime_clients.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 import os
 from typing import Any, Callable
 
+# Qdrant rejects an entire search with 400 when a filter references an unindexed payload
+# field, so every field recall filters on must be indexed. `type` backs RECALL_EXCLUDED_TYPES,
+# which applies to all vector searches since that setting defaults to a non-empty value.
+QDRANT_FILTERED_PAYLOAD_FIELDS = ("tags", "tag_prefixes", "type")
+
 
 def init_falkordb(
     *,
@@ -157,27 +162,12 @@ def ensure_qdrant_collection(
             return
 
         logger.info("Ensuring Qdrant payload indexes for collection '%s'", collection_name)
-        if payload_schema_type_enum:
+        keyword_schema = payload_schema_type_enum.KEYWORD if payload_schema_type_enum else "keyword"
+        for field_name in QDRANT_FILTERED_PAYLOAD_FIELDS:
             state.qdrant.create_payload_index(
                 collection_name=collection_name,
-                field_name="tags",
-                field_schema=payload_schema_type_enum.KEYWORD,
-            )
-            state.qdrant.create_payload_index(
-                collection_name=collection_name,
-                field_name="tag_prefixes",
-                field_schema=payload_schema_type_enum.KEYWORD,
-            )
-        else:
-            state.qdrant.create_payload_index(
-                collection_name=collection_name,
-                field_name="tags",
-                field_schema="keyword",
-            )
-            state.qdrant.create_payload_index(
-                collection_name=collection_name,
-                field_name="tag_prefixes",
-                field_schema="keyword",
+                field_name=field_name,
+                field_schema=keyword_schema,
             )
     except ValueError:
         raise

--- a/tests/test_vector_size_safety.py
+++ b/tests/test_vector_size_safety.py
@@ -276,17 +276,13 @@ class TestEnsureQdrantCollectionPayloadIndexes:
         """`type` backs RECALL_EXCLUDED_TYPES; without an index Qdrant 400s every search."""
         qdrant = self._run_ensure(SimpleNamespace(KEYWORD="keyword"))
 
-        indexed = {
-            call.kwargs["field_name"] for call in qdrant.create_payload_index.call_args_list
-        }
+        indexed = {call.kwargs["field_name"] for call in qdrant.create_payload_index.call_args_list}
         assert indexed == {"tags", "tag_prefixes", "type"}
 
     def test_indexes_every_field_without_payload_schema_enum(self):
         qdrant = self._run_ensure(None)
 
-        indexed = {
-            call.kwargs["field_name"] for call in qdrant.create_payload_index.call_args_list
-        }
+        indexed = {call.kwargs["field_name"] for call in qdrant.create_payload_index.call_args_list}
         assert indexed == {"tags", "tag_prefixes", "type"}
         assert all(
             call.kwargs["field_schema"] == "keyword"

--- a/tests/test_vector_size_safety.py
+++ b/tests/test_vector_size_safety.py
@@ -251,6 +251,48 @@ class TestInitQdrantPropagation:
 
 
 class TestEnsureQdrantCollectionPayloadIndexes:
+    def _run_ensure(self, payload_schema_type_enum):
+        from automem.stores.runtime_clients import ensure_qdrant_collection
+
+        qdrant = MagicMock()
+        qdrant.get_collections.return_value = SimpleNamespace(
+            collections=[SimpleNamespace(name="memories")]
+        )
+        state = SimpleNamespace(qdrant=qdrant, effective_vector_size=None)
+
+        ensure_qdrant_collection(
+            state=state,
+            logger=MagicMock(),
+            collection_name="memories",
+            vector_size_config=1024,
+            get_effective_vector_size_fn=lambda _client: (1024, "collection"),
+            vector_params_cls=MagicMock(),
+            distance_enum=SimpleNamespace(COSINE="Cosine"),
+            payload_schema_type_enum=payload_schema_type_enum,
+        )
+        return qdrant
+
+    def test_indexes_every_field_recall_filters_on(self):
+        """`type` backs RECALL_EXCLUDED_TYPES; without an index Qdrant 400s every search."""
+        qdrant = self._run_ensure(SimpleNamespace(KEYWORD="keyword"))
+
+        indexed = {
+            call.kwargs["field_name"] for call in qdrant.create_payload_index.call_args_list
+        }
+        assert indexed == {"tags", "tag_prefixes", "type"}
+
+    def test_indexes_every_field_without_payload_schema_enum(self):
+        qdrant = self._run_ensure(None)
+
+        indexed = {
+            call.kwargs["field_name"] for call in qdrant.create_payload_index.call_args_list
+        }
+        assert indexed == {"tags", "tag_prefixes", "type"}
+        assert all(
+            call.kwargs["field_schema"] == "keyword"
+            for call in qdrant.create_payload_index.call_args_list
+        )
+
     @patch.dict("os.environ", {"QDRANT_ENSURE_PAYLOAD_INDEXES": "false"}, clear=False)
     def test_can_skip_payload_indexes_for_restore_tuned_lab_collection(self):
         from automem.stores.runtime_clients import ensure_qdrant_collection


### PR DESCRIPTION
Every vector search sends Qdrant a filter condition on the `type` payload field, but that field is never indexed — so Qdrant rejects the search and recall silently falls back to keyword-only.

## The bug

`_vector_search` builds its filter with `excluded_types=RECALL_EXCLUDED_TYPES` on every call:

```python
query_filter = build_qdrant_tag_filter(
    tag_filters, tag_mode, tag_match,
    excluded_types=RECALL_EXCLUDED_TYPES,
)
```

`RECALL_EXCLUDED_TYPES` defaults to a **non-empty** value:

```python
RECALL_EXCLUDED_TYPES = frozenset(
    t.strip() for t in os.getenv("RECALL_EXCLUDED_TYPES", "MetaPattern").split(",") if t.strip()
)
```

So the `type` condition is present by default. But `ensure_qdrant_collection` only indexes `tags` and `tag_prefixes`, and Qdrant refuses to run a filter over an unindexed payload field:

```
Bad request: Index required but not found for "type" of one of the
following types: [keyword]. Help: Create an index for this key or use
a different filter.
```

## Why it is easy to miss

`_vector_search` catches broadly and returns `[]`:

```python
except Exception:
    logger.exception("Qdrant search failed")
    return []
```

Recall keeps returning results, so nothing looks broken — the vector half is just gone. On a live instance the symptoms are:

- `vector_search.matched: false` on every recall, every hit `match_type: "keyword"`
- `vector_count: null` and `vector_dimensions.collection: null` in `/health`
- semantically-phrased queries returning unrelated keyword collisions

None of which names the actual cause. The 400 only appears in server logs.

## The fix

Add `type` to the ensured payload indexes, and collapse the duplicated enum/string branches into one loop over a named tuple so the set of filtered fields is stated once:

```python
QDRANT_FILTERED_PAYLOAD_FIELDS = ("tags", "tag_prefixes", "type")
```

## Verification

Reproduced and fixed on a live instance (~25k points, 768d collection, upgraded from a pre-0.16.0 build). Creating the `type` payload index by hand restored `vector_search.matched: true` and `match_type: "vector"` results immediately, with no other change — and `/health` went from `vector_count: null` back to `vector_count: 24937`.

Two regression tests cover both the enum and string-schema branches. Both fail when `type` is removed from the tuple and pass with it (tamper-checked, not just observed green).

Note: `tests/test_vector_size_safety.py` has 12 pre-existing failures in a minimal env (`AttributeError: module 'automem' has no attribute 'config'`); they fail identically on an unmodified checkout. This PR takes that file from 9 passing to 11.