### PR TITLE
fix(mcp-sse): emit the stored date in compact recall output

### DIFF
--- a/mcp-sse-server/server.js
+++ b/mcp-sse-server/server.js
@@ -378,15 +378,23 @@ export function formatRecallAsItems(results, { detailed = false } = {}) {
     const tags = Array.isArray(mem.tags) ? mem.tags.filter(t => typeof t === 'string' && t.trim()) : [];
     const score = it?.final_score !== undefined ? Number(it.final_score) : undefined;
     const dedupCount = Array.isArray(it?.deduped_from) ? it.deduped_from.length : 0;
+    // When the memory was stored. Without it a caller replaying recall text has no
+    // way to tell a note written today from one written six weeks ago, and relative
+    // language inside the content ("we leave tomorrow") reads as if it were current.
+    // `timestamp` is what /recall returns; `created_at` covers id-fetch shapes.
+    const storedAt = mem.timestamp || mem.created_at || '';
 
     if (!detailed) {
       const tagSuffix = tags.length ? ` [${tags.join(', ')}]` : '';
       const scoreSuffix = score !== undefined ? ` score=${score.toFixed(3)}` : '';
       const dedupNote = dedupCount ? ` (deduped x${dedupCount})` : '';
       const scopeNote = it?.outside_tag_scope ? ' [outside tag scope]' : '';
+      // Own line, matching the stdio package (src/recall-memory.ts) so both
+      // transports render the same shape and downstream parsers see one format.
+      const createdLine = storedAt ? `\nCreated: ${String(storedAt)}` : '';
       return {
         type: 'text',
-        text: `${i + 1}. ${String(content)}${tagSuffix}${scoreSuffix}${dedupNote}${scopeNote}\nID: ${id}`,
+        text: `${i + 1}. ${String(content)}${tagSuffix}${scoreSuffix}${dedupNote}${scopeNote}\nID: ${id}${createdLine}`,
       };
     }
 
@@ -394,7 +402,9 @@ export function formatRecallAsItems(results, { detailed = false } = {}) {
     lines.push(`${i + 1}. ${String(content)}`);
     if (id) lines.push(`ID: ${id}`);
     if (mem.type) lines.push(`Type: ${String(mem.type)}`);
-    if (mem.timestamp) lines.push(`Timestamp: ${String(mem.timestamp)}`);
+    // Label kept as-is for compatibility; source broadened so id-fetch shapes
+    // (which carry created_at rather than timestamp) also render a date.
+    if (storedAt) lines.push(`Timestamp: ${String(storedAt)}`);
     if (mem.updated_at) lines.push(`Updated: ${String(mem.updated_at)}`);
     if (mem.last_accessed) lines.push(`Last accessed: ${String(mem.last_accessed)}`);
     if (mem.importance !== undefined) {
@@ -693,7 +703,9 @@ export function buildMcpServer(client) {
           }
 
           // Back-compat: preserve the old single-block text format as default.
-          const itemsText = formatRecallAsItems(results).map(x => x.text.replace('\nID: ', '\n   ID: ')).join('\n\n');
+          const itemsText = formatRecallAsItems(results)
+            .map(x => x.text.replace('\nID: ', '\n   ID: ').replace('\nCreated: ', '\n   Created: '))
+            .join('\n\n');
           return {
             content: [{
               type: 'text',

--- a/mcp-sse-server/test/server.test.js
+++ b/mcp-sse-server/test/server.test.js
@@ -125,6 +125,48 @@ test("formatRecallAsItems supports detailed output including relations", () => {
   assert.ok(!compact.includes("Metadata:"));
 });
 
+// Regression: the compact (default) block used to drop the stored date entirely, so a
+// caller replaying recall text could not tell a note written today from one written six
+// weeks ago — relative language inside the content read as if it were current.
+test("formatRecallAsItems compact output carries the stored date on its own line", () => {
+  const results = [
+    {
+      final_score: 0.817,
+      memory: {
+        id: "mem-trip",
+        content: "Ground: drive up Aug 1 in Kyle's car. Kyoshk Island Aug 2-9.",
+        tags: ["travel", "canada-trip"],
+        timestamp: "2026-07-28T09:15:00Z",
+      },
+    },
+  ];
+
+  const compact = formatRecallAsItems(results)[0].text;
+  const lines = compact.split("\n");
+
+  // Own line, matching the stdio package's shape (src/recall-memory.ts).
+  assert.ok(
+    lines.some(line => line === "Created: 2026-07-28T09:15:00Z"),
+    `expected a standalone Created line, got:\n${compact}`
+  );
+  // The pre-existing trailing metadata must stay on the content line, because
+  // downstream parsers peel score/tags off the last *content* line.
+  assert.ok(lines[0].endsWith("score=0.817"));
+  assert.ok(lines.includes("ID: mem-trip"));
+});
+
+test("formatRecallAsItems accepts created_at as well as timestamp, and omits the line when absent", () => {
+  // id-fetch shapes carry created_at rather than timestamp.
+  const [fromCreatedAt, undated] = formatRecallAsItems([
+    { memory: { id: "mem-a", content: "A", created_at: "2026-01-02T03:04:05Z" } },
+    { memory: { id: "mem-b", content: "B" } },
+  ]).map(x => x.text);
+
+  assert.ok(fromCreatedAt.includes("Created: 2026-01-02T03:04:05Z"));
+  assert.ok(!undated.includes("Created:"), "no date must render no Created line");
+  assert.ok(undated.endsWith("ID: mem-b"), "undated output must not gain a trailing newline");
+});
+
 test("formatRecallAsItems detailed output renders full metadata and omits empty metadata", () => {
   const bigMetadata = { notes: "x".repeat(400) };
   const results = [


### PR DESCRIPTION
## Problem

The default (non-detailed) recall block in `formatRecallAsItems` rendered content, tags, score and ID — but dropped the memory's stored timestamp entirely:

```
1. Jack's Aug 2026 Canada cottage trip. Ground: drive up Aug 1 in Kyle's car. Kyoshk Island Aug 2-9. [travel, canada-trip] score=0.817
   ID: a7585fbd-6124-4e31-9523-0795bc90ef4f
```

A caller replaying that text has no way to tell a note written today from one written six weeks ago. Absolute dates inside the content then read as if they were current.

**Observed in production.** On 2026-08-11 an agent asked to recall a trip itinerary — written before departure, for a trip that ran Aug 1–9 — answered:

> "Here's the itinerary: drive up to Hamilton **today (Aug 1)**, crash at Georgia's tonight. **Tomorrow Aug 2** you hit Parry Sound…"

The current date *was* in that agent's system prompt. The memory content was correct and used absolute dates. What was missing was any signal that the memory was two weeks old, so the model had no reason to read those dates as historical.

This is also an inconsistency inside this project: the sibling stdio package already emits `Created:` in its own text block (`src/recall-memory.ts:267-269`), and this server's own `detailed` branch emits `Timestamp:`. Only the compact path — the default, and the highest-traffic one — omitted it.

## Change

- Compact block gains `Created: <timestamp>` **on its own line**, matching the stdio package's shape so both transports render identically.
- The `detailed` branch keeps its existing `Timestamp:` label (no output change for existing consumers) but reads the same broadened source, so id-fetch shapes — which carry `created_at` rather than `timestamp` — now render a date too.
- The single-block back-compat path indents `Created:` to match `ID:`.

Purely additive. Content, tags and score keep their existing positions, so parsers that peel trailing metadata off the *content* line are unaffected.

## Verification

**Tier 1 — `node --test test/server.test.js` → 22/22 pass** (20 pre-existing + 2 new).

Red→green on the two new tests, same command, fix reverted vs applied:

```
########## RED (fix reverted) ##########
✖ formatRecallAsItems compact output carries the stored date on its own line
✖ formatRecallAsItems accepts created_at as well as timestamp, and omits the line when absent
ℹ pass 0
ℹ fail 2
  AssertionError: expected a standalone Created line, got:

########## GREEN (with fix) ##########
✔ formatRecallAsItems compact output carries the stored date on its own line
✔ formatRecallAsItems accepts created_at as well as timestamp, and omits the line when absent
ℹ pass 2
ℹ fail 0
```

**Downstream check — AutoHub's existing parser, unmodified.** AutoHub already looks for a `Created:` line (`src/memory/memory-client.js:103-108`); it was simply never present. Feeding this branch's output through that parser with zero AutoHub changes:

```
1. Jack's Aug 2026 Canada cottage trip. Ground: drive up Aug 1 in Kyle's car. Kyoshk Island Aug 2-9. [travel, canada-trip, family] score=0.817
   ID: a7585fbd-6124-4e31-9523-0795bc90ef4f
   Created: 2026-07-28T09:15:00Z

--- AutoHub parseMemoryList() (unmodified) ---
[ { "id": "a7585fbd-…", "createdAt": "2026-07-28T09:15:00Z", "score": 0.817,
    "tags": ["travel","canada-trip","family"] } ]
```

`createdAt` now populates, and `score`/`tags` still parse — confirming the addition does not disturb the existing trailing-metadata parse.

**Claim:** every consumer of the remote recall endpoint can now tell how old a recalled memory is, without changing how they call it.

## Follow-up (not in this PR)

`Created:` (compact, stdio) vs `Timestamp:` (detailed) is the same field under two labels. Worth unifying, but it changes existing output, so it belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
