### PR TITLE
fix(enrichment): circuit-break exhausted quota calls

### DIFF
--- a/app.py
+++ b/app.py
@@ -318,6 +318,7 @@ memory_classifier = MemoryClassifier(
     classification_model=CLASSIFICATION_MODEL,
     logger=logger,
     stats=state.classification_stats,
+    circuit=state.enrichment_circuit,
 )
 
 

--- a/automem/api/enrichment.py
+++ b/automem/api/enrichment.py
@@ -30,6 +30,7 @@ def create_enrichment_blueprint(
             "max_attempts": max_attempts,
             "stats": state.enrichment_stats.to_dict(),
             "classification": state.classification_stats.to_dict(),
+            "circuit": state.enrichment_circuit.to_dict(),
         }
         return jsonify(response)
 

--- a/automem/api/memory.py
+++ b/automem/api/memory.py
@@ -514,6 +514,7 @@ def create_memory_blueprint_full(
                     openai_client,
                     CLASSIFICATION_MODEL,
                     MEMORY_SUMMARY_TARGET_LENGTH,
+                    state.enrichment_circuit,
                 )
                 if summary:
                     original_content = content
@@ -1248,6 +1249,7 @@ def create_memory_blueprint_full(
                         openai_client,
                         CLASSIFICATION_MODEL,
                         MEMORY_SUMMARY_TARGET_LENGTH,
+                        state.enrichment_circuit,
                     )
                     if summary:
                         logger.info(

--- a/automem/classification/memory_classifier.py
+++ b/automem/classification/memory_classifier.py
@@ -97,6 +97,7 @@ Return JSON with: {"type": "<type>", "confidence": <0.0-1.0>}"""
         classification_model: str,
         logger: Any,
         stats: Any = None,
+        circuit: Any = None,
     ) -> None:
         self._normalize_memory_type = normalize_memory_type
         self._ensure_openai_client = ensure_openai_client
@@ -104,6 +105,7 @@ Return JSON with: {"type": "<type>", "confidence": <0.0-1.0>}"""
         self._classification_model = classification_model
         self._logger = logger
         self._stats = stats
+        self._circuit = circuit
 
     def classify(self, content: str, *, use_llm: bool = True) -> tuple[str, float]:
         """Classify memory type and return confidence score."""
@@ -134,12 +136,17 @@ Return JSON with: {"type": "<type>", "confidence": <0.0-1.0>}"""
             except Exception as exc:
                 self._logger.exception("LLM classification failed, using fallback")
                 llm_error = str(exc)
+                if self._circuit is not None:
+                    self._circuit.record_failure(llm_error)
             if self._stats is not None:
                 self._stats.record_fallback(llm_error)
 
         return "Memory", 0.3
 
     def _classify_with_llm(self, content: str) -> Optional[tuple[str, float]]:
+        if self._circuit is not None and not self._circuit.allow_request():
+            self._logger.info("Skipping LLM classification while enrichment circuit is open")
+            return None
         client = self._get_openai_client()
         if client is None:
             self._ensure_openai_client()
@@ -166,6 +173,8 @@ Return JSON with: {"type": "<type>", "confidence": <0.0-1.0>}"""
             response_format={"type": "json_object"},
             **extra_params,
         )
+        if self._circuit is not None:
+            self._circuit.record_success()
 
         raw_content = response.choices[0].message.content
         if not raw_content:

--- a/automem/classification/memory_classifier.py
+++ b/automem/classification/memory_classifier.py
@@ -136,22 +136,25 @@ Return JSON with: {"type": "<type>", "confidence": <0.0-1.0>}"""
             except Exception as exc:
                 self._logger.exception("LLM classification failed, using fallback")
                 llm_error = str(exc)
-                if self._circuit is not None:
-                    self._circuit.record_failure(llm_error)
             if self._stats is not None:
                 self._stats.record_fallback(llm_error)
 
         return "Memory", 0.3
 
     def _classify_with_llm(self, content: str) -> Optional[tuple[str, float]]:
-        if self._circuit is not None and not self._circuit.allow_request():
-            self._logger.info("Skipping LLM classification while enrichment circuit is open")
-            return None
+        was_probe = False
+        if self._circuit is not None:
+            allowed, was_probe = self._circuit.begin_request()
+            if not allowed:
+                self._logger.info("Skipping LLM classification while enrichment circuit is open")
+                return None
         client = self._get_openai_client()
         if client is None:
             self._ensure_openai_client()
             client = self._get_openai_client()
         if client is None:
+            if self._circuit is not None:
+                self._circuit.record_failure("OpenAI client unavailable", was_probe)
             return None
 
         extra_params: dict[str, Any] = {}
@@ -164,17 +167,22 @@ Return JSON with: {"type": "<type>", "confidence": <0.0-1.0>}"""
             extra_params["max_tokens"] = 50
             extra_params["temperature"] = 0.3
 
-        response = client.chat.completions.create(
-            model=self._classification_model,
-            messages=[
-                {"role": "system", "content": self.SYSTEM_PROMPT},
-                {"role": "user", "content": content[:1000]},
-            ],
-            response_format={"type": "json_object"},
-            **extra_params,
-        )
+        try:
+            response = client.chat.completions.create(
+                model=self._classification_model,
+                messages=[
+                    {"role": "system", "content": self.SYSTEM_PROMPT},
+                    {"role": "user", "content": content[:1000]},
+                ],
+                response_format={"type": "json_object"},
+                **extra_params,
+            )
+        except Exception as exc:
+            if self._circuit is not None:
+                self._circuit.record_failure(str(exc), was_probe)
+            raise
         if self._circuit is not None:
-            self._circuit.record_success()
+            self._circuit.record_success(was_probe)
 
         raw_content = response.choices[0].message.content
         if not raw_content:

--- a/automem/config.py
+++ b/automem/config.py
@@ -178,6 +178,8 @@ MEMORY_AUTO_SUMMARIZE = os.getenv("MEMORY_AUTO_SUMMARIZE", "true").lower() not i
 }
 # Target length for summarized content
 MEMORY_SUMMARY_TARGET_LENGTH = int(os.getenv("MEMORY_SUMMARY_TARGET_LENGTH", "300"))
+# Cooldown after a definitive LLM quota exhaustion response.
+ENRICHMENT_CIRCUIT_COOLDOWN_SECONDS = float(os.getenv("ENRICHMENT_CIRCUIT_COOLDOWN_SECONDS", "300"))
 
 # Memory types for classification
 MEMORY_TYPES = {"Decision", "Pattern", "Preference", "Style", "Habit", "Insight", "Context"}

--- a/automem/service_state.py
+++ b/automem/service_state.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass, field
 from queue import Queue
 from threading import Event, Lock, Thread
 from typing import Any, Dict, Optional, Set
-import time
 
 from falkordb import FalkorDB
 from qdrant_client import QdrantClient
@@ -26,23 +26,25 @@ class EnrichmentCircuit:
         self.circuit_open_skips = 0
         self.recoveries = 0
 
-    def allow_request(self) -> bool:
+    def begin_request(self) -> tuple[bool, bool]:
+        """Reserve an LLM request and report whether it is the recovery probe."""
         with self._lock:
             now = self._clock()
             if now < self._opened_until:
                 self.circuit_open_skips += 1
-                return False
+                return False, False
             if self._opened_until:
                 if self._probe_pending:
                     self.circuit_open_skips += 1
-                    return False
+                    return False, False
                 self._probe_pending = True
-            return True
+                return True, True
+            return True, False
 
-    def record_failure(self, error: str) -> bool:
+    def record_failure(self, error: str, was_probe: bool = False) -> bool:
         if "insufficient_quota" not in error.lower() and "quota" not in error.lower():
             with self._lock:
-                if self._probe_pending:
+                if was_probe and self._probe_pending:
                     self._opened_until = 0.0
                     self._probe_pending = False
             return False
@@ -51,12 +53,12 @@ class EnrichmentCircuit:
             self._probe_pending = False
             return True
 
-    def record_success(self) -> None:
+    def record_success(self, was_probe: bool = False) -> None:
         with self._lock:
-            if self._opened_until:
+            if was_probe and self._probe_pending:
                 self.recoveries += 1
-            self._opened_until = 0.0
-            self._probe_pending = False
+                self._opened_until = 0.0
+                self._probe_pending = False
 
     def to_dict(self) -> Dict[str, Any]:
         with self._lock:

--- a/automem/service_state.py
+++ b/automem/service_state.py
@@ -41,6 +41,10 @@ class EnrichmentCircuit:
 
     def record_failure(self, error: str) -> bool:
         if "insufficient_quota" not in error.lower() and "quota" not in error.lower():
+            with self._lock:
+                if self._probe_pending:
+                    self._opened_until = 0.0
+                    self._probe_pending = False
             return False
         with self._lock:
             self._opened_until = self._clock() + self._cooldown_seconds

--- a/automem/service_state.py
+++ b/automem/service_state.py
@@ -4,13 +4,63 @@ from dataclasses import dataclass, field
 from queue import Queue
 from threading import Event, Lock, Thread
 from typing import Any, Dict, Optional, Set
+import time
 
 from falkordb import FalkorDB
 from qdrant_client import QdrantClient
 
-from automem.config import VECTOR_SIZE
+from automem.config import ENRICHMENT_CIRCUIT_COOLDOWN_SECONDS, VECTOR_SIZE
 from automem.embedding.provider import EmbeddingProvider
 from automem.utils.time import utc_now
+
+
+class EnrichmentCircuit:
+    """Fail-soft cooldown for definitive LLM quota failures."""
+
+    def __init__(self, cooldown_seconds: float = 300, clock: Any = time.monotonic) -> None:
+        self._cooldown_seconds = cooldown_seconds
+        self._clock = clock
+        self._opened_until = 0.0
+        self._probe_pending = False
+        self._lock = Lock()
+        self.circuit_open_skips = 0
+        self.recoveries = 0
+
+    def allow_request(self) -> bool:
+        with self._lock:
+            now = self._clock()
+            if now < self._opened_until:
+                self.circuit_open_skips += 1
+                return False
+            if self._opened_until:
+                if self._probe_pending:
+                    self.circuit_open_skips += 1
+                    return False
+                self._probe_pending = True
+            return True
+
+    def record_failure(self, error: str) -> bool:
+        if "insufficient_quota" not in error.lower() and "quota" not in error.lower():
+            return False
+        with self._lock:
+            self._opened_until = self._clock() + self._cooldown_seconds
+            self._probe_pending = False
+            return True
+
+    def record_success(self) -> None:
+        with self._lock:
+            if self._opened_until:
+                self.recoveries += 1
+            self._opened_until = 0.0
+            self._probe_pending = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "circuit_open_skips": self.circuit_open_skips,
+                "recoveries": self.recoveries,
+                "open": self._clock() < self._opened_until,
+            }
 
 
 @dataclass
@@ -106,6 +156,9 @@ class ServiceState:
     enrichment_thread: Optional[Thread] = None
     enrichment_stats: EnrichmentStats = field(default_factory=EnrichmentStats)
     classification_stats: ClassificationStats = field(default_factory=ClassificationStats)
+    enrichment_circuit: EnrichmentCircuit = field(
+        default_factory=lambda: EnrichmentCircuit(ENRICHMENT_CIRCUIT_COOLDOWN_SECONDS)
+    )
     enrichment_inflight: Set[str] = field(default_factory=set)
     enrichment_pending: Set[str] = field(default_factory=set)
     enrichment_lock: Lock = field(default_factory=Lock)

--- a/automem/utils/text.py
+++ b/automem/utils/text.py
@@ -122,6 +122,7 @@ def summarize_content(
     openai_client: Any,
     model: str,
     target_length: int = 300,
+    circuit: Any = None,
 ) -> Optional[str]:
     """Summarize content using an LLM to fit within target length.
 
@@ -137,9 +138,11 @@ def summarize_content(
     if openai_client is None:
         logger.warning("Cannot summarize: OpenAI client not available")
         return None
-
     if not content or len(content) <= target_length:
         return content
+    if circuit is not None and not circuit.allow_request():
+        logger.info("Skipping summarization while enrichment circuit is open")
+        return None
 
     try:
         system_prompt = SUMMARIZE_SYSTEM_PROMPT.format(target_length=target_length)
@@ -163,6 +166,8 @@ def summarize_content(
             ],
             **extra_params,
         )
+        if circuit is not None:
+            circuit.record_success()
 
         summary = response.choices[0].message.content.strip()
 
@@ -183,8 +188,10 @@ def summarize_content(
         )
         return None
 
-    except Exception:
+    except Exception as exc:
         logger.exception("Memory summarization failed")
+        if circuit is not None:
+            circuit.record_failure(str(exc))
         return None
 
 

--- a/automem/utils/text.py
+++ b/automem/utils/text.py
@@ -140,9 +140,12 @@ def summarize_content(
         return None
     if not content or len(content) <= target_length:
         return content
-    if circuit is not None and not circuit.allow_request():
-        logger.info("Skipping summarization while enrichment circuit is open")
-        return None
+    was_probe = False
+    if circuit is not None:
+        allowed, was_probe = circuit.begin_request()
+        if not allowed:
+            logger.info("Skipping summarization while enrichment circuit is open")
+            return None
 
     try:
         system_prompt = SUMMARIZE_SYSTEM_PROMPT.format(target_length=target_length)
@@ -167,7 +170,7 @@ def summarize_content(
             **extra_params,
         )
         if circuit is not None:
-            circuit.record_success()
+            circuit.record_success(was_probe)
 
         summary = response.choices[0].message.content.strip()
 
@@ -191,7 +194,7 @@ def summarize_content(
     except Exception as exc:
         logger.exception("Memory summarization failed")
         if circuit is not None:
-            circuit.record_failure(str(exc))
+            circuit.record_failure(str(exc), was_probe)
         return None
 
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -131,7 +131,7 @@ GET /recall?query=project%20plan&state_mode=history
 Enrichment
 
 - GET `/enrichment/status`
-  - Response: queue size, inflight/pending, stats, plus a `classification` block with type-classification counters (`llm_attempts`, `llm_successes`, `fallbacks`, `pattern_classifications`, `last_error`, `last_error_at`) for monitoring LLM-classification fallback rate.
+  - Response: queue size, inflight/pending, stats, plus a `classification` block with type-classification counters (`llm_attempts`, `llm_successes`, `fallbacks`, `pattern_classifications`, `last_error`, `last_error_at`) for monitoring LLM-classification fallback rate, and a `circuit` block with `open`, `circuit_open_skips`, and `recoveries` for monitoring quota-circuit state.
 
 - POST `/enrichment/reprocess`
   - Body: `{ "ids": ["..."] }` or query `?ids=a,b,c`

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -299,6 +299,7 @@ Controls entity extraction and relationship linking.
 | `ENRICHMENT_IDLE_SLEEP_SECONDS` | Sleep when queue empty | `2` |
 | `ENRICHMENT_FAILURE_BACKOFF_SECONDS` | Backoff on failure | `5` |
 | `ENRICHMENT_ENABLE_SUMMARIES` | Enable summarization | `true` |
+| `ENRICHMENT_CIRCUIT_COOLDOWN_SECONDS` | Cooldown after LLM quota exhaustion before one recovery probe is allowed | `300` |
 | `ENRICHMENT_SPACY_MODEL` | spaCy model name | `en_core_web_sm` |
 | `JIT_ENRICHMENT_ENABLED` | Inline enrichment during recall | `true` |
 

--- a/tests/test_enrichment_circuit.py
+++ b/tests/test_enrichment_circuit.py
@@ -31,6 +31,8 @@ def test_successful_probe_closes_circuit_and_records_recovery():
     circuit.record_failure("insufficient_quota")
     now[0] += 60
     assert circuit.allow_request() is True
+    assert circuit.record_failure("connection reset") is False
+    assert circuit.allow_request() is True
     circuit.record_success()
 
     assert circuit.allow_request() is True
@@ -85,5 +87,3 @@ def test_summarizer_makes_no_second_request_while_circuit_is_open():
     summarize_content(content, client, "gpt-4o-mini", 300, circuit)
 
     assert len(calls) == 1
-    assert circuit.record_failure("connection reset") is False
-    assert circuit.allow_request() is True

--- a/tests/test_enrichment_circuit.py
+++ b/tests/test_enrichment_circuit.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-from datetime import timedelta
+from types import SimpleNamespace
+import logging
 
+from automem.classification.memory_classifier import MemoryClassifier
 from automem.service_state import EnrichmentCircuit
+from automem.utils.text import summarize_content
 
 
 def test_quota_failure_opens_circuit_and_skips_requests():
@@ -32,3 +35,55 @@ def test_successful_probe_closes_circuit_and_records_recovery():
 
     assert circuit.allow_request() is True
     assert circuit.to_dict()["recoveries"] == 1
+
+
+def test_failed_probe_does_not_permanently_block_future_requests():
+    now = [100.0]
+    circuit = EnrichmentCircuit(cooldown_seconds=60, clock=lambda: now[0])
+
+    circuit.record_failure("insufficient_quota")
+    now[0] += 60
+    assert circuit.allow_request() is True
+
+
+def test_classifier_makes_no_second_request_while_circuit_is_open():
+    calls = []
+
+    def create(*args, **kwargs):
+        calls.append(1)
+        raise RuntimeError("insufficient_quota")
+
+    client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    circuit = EnrichmentCircuit(cooldown_seconds=60, clock=lambda: 100.0)
+    classifier = MemoryClassifier(
+        normalize_memory_type=lambda raw: (raw, False),
+        ensure_openai_client=lambda: None,
+        get_openai_client=lambda: client,
+        classification_model="gpt-4o-mini",
+        logger=logging.getLogger(__name__),
+        circuit=circuit,
+    )
+
+    classifier.classify("qwxz flibber jabberwock snorkelblatt")
+    classifier.classify("qwxz flibber jabberwock snorkelblatt")
+
+    assert len(calls) == 1
+
+
+def test_summarizer_makes_no_second_request_while_circuit_is_open():
+    calls = []
+
+    def create(*args, **kwargs):
+        calls.append(1)
+        raise RuntimeError("insufficient_quota")
+
+    client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    circuit = EnrichmentCircuit(cooldown_seconds=60, clock=lambda: 100.0)
+    content = "x" * 600
+
+    summarize_content(content, client, "gpt-4o-mini", 300, circuit)
+    summarize_content(content, client, "gpt-4o-mini", 300, circuit)
+
+    assert len(calls) == 1
+    assert circuit.record_failure("connection reset") is False
+    assert circuit.allow_request() is True

--- a/tests/test_enrichment_circuit.py
+++ b/tests/test_enrichment_circuit.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
 import logging
+from types import SimpleNamespace
 
 from automem.classification.memory_classifier import MemoryClassifier
 from automem.service_state import EnrichmentCircuit
@@ -11,9 +11,11 @@ from automem.utils.text import summarize_content
 def test_quota_failure_opens_circuit_and_skips_requests():
     circuit = EnrichmentCircuit(cooldown_seconds=60, clock=lambda: 100.0)
 
-    assert circuit.allow_request() is True
+    allowed, _ = circuit.begin_request()
+    assert allowed is True
     assert circuit.record_failure("429 insufficient_quota") is True
-    assert circuit.allow_request() is False
+    allowed, _ = circuit.begin_request()
+    assert allowed is False
     assert circuit.to_dict()["circuit_open_skips"] == 1
 
 
@@ -21,7 +23,8 @@ def test_non_quota_failure_does_not_open_circuit():
     circuit = EnrichmentCircuit(cooldown_seconds=60, clock=lambda: 100.0)
 
     assert circuit.record_failure("connection reset") is False
-    assert circuit.allow_request() is True
+    allowed, _ = circuit.begin_request()
+    assert allowed is True
 
 
 def test_successful_probe_closes_circuit_and_records_recovery():
@@ -30,10 +33,13 @@ def test_successful_probe_closes_circuit_and_records_recovery():
 
     circuit.record_failure("insufficient_quota")
     now[0] += 60
-    assert circuit.allow_request() is True
-    circuit.record_success()
+    allowed, was_probe = circuit.begin_request()
+    assert allowed is True
+    assert was_probe is True
+    circuit.record_success(was_probe)
 
-    assert circuit.allow_request() is True
+    allowed, _ = circuit.begin_request()
+    assert allowed is True
     assert circuit.to_dict()["recoveries"] == 1
 
 
@@ -43,9 +49,28 @@ def test_failed_probe_does_not_permanently_block_future_requests():
 
     circuit.record_failure("insufficient_quota")
     now[0] += 60
-    assert circuit.allow_request() is True
-    assert circuit.record_failure("connection reset") is False
-    assert circuit.allow_request() is True
+    allowed, was_probe = circuit.begin_request()
+    assert allowed is True
+    assert was_probe is True
+    assert circuit.record_failure("connection reset", was_probe) is False
+    allowed, _ = circuit.begin_request()
+    assert allowed is True
+
+
+def test_inflight_success_does_not_close_quota_circuit():
+    now = [100.0]
+    circuit = EnrichmentCircuit(cooldown_seconds=60, clock=lambda: now[0])
+
+    first_allowed, _ = circuit.begin_request()
+    second_allowed, second_was_probe = circuit.begin_request()
+    assert first_allowed is True
+    assert second_allowed is True
+    assert circuit.record_failure("insufficient_quota") is True
+
+    circuit.record_success(second_was_probe)
+
+    allowed, _ = circuit.begin_request()
+    assert allowed is False
 
 
 def test_classifier_makes_no_second_request_while_circuit_is_open():

--- a/tests/test_enrichment_circuit.py
+++ b/tests/test_enrichment_circuit.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from automem.service_state import EnrichmentCircuit
+
+
+def test_quota_failure_opens_circuit_and_skips_requests():
+    circuit = EnrichmentCircuit(cooldown_seconds=60, clock=lambda: 100.0)
+
+    assert circuit.allow_request() is True
+    assert circuit.record_failure("429 insufficient_quota") is True
+    assert circuit.allow_request() is False
+    assert circuit.to_dict()["circuit_open_skips"] == 1
+
+
+def test_non_quota_failure_does_not_open_circuit():
+    circuit = EnrichmentCircuit(cooldown_seconds=60, clock=lambda: 100.0)
+
+    assert circuit.record_failure("connection reset") is False
+    assert circuit.allow_request() is True
+
+
+def test_successful_probe_closes_circuit_and_records_recovery():
+    now = [100.0]
+    circuit = EnrichmentCircuit(cooldown_seconds=60, clock=lambda: now[0])
+
+    circuit.record_failure("insufficient_quota")
+    now[0] += 60
+    assert circuit.allow_request() is True
+    circuit.record_success()
+
+    assert circuit.allow_request() is True
+    assert circuit.to_dict()["recoveries"] == 1

--- a/tests/test_enrichment_circuit.py
+++ b/tests/test_enrichment_circuit.py
@@ -31,8 +31,6 @@ def test_successful_probe_closes_circuit_and_records_recovery():
     circuit.record_failure("insufficient_quota")
     now[0] += 60
     assert circuit.allow_request() is True
-    assert circuit.record_failure("connection reset") is False
-    assert circuit.allow_request() is True
     circuit.record_success()
 
     assert circuit.allow_request() is True
@@ -45,6 +43,8 @@ def test_failed_probe_does_not_permanently_block_future_requests():
 
     circuit.record_failure("insufficient_quota")
     now[0] += 60
+    assert circuit.allow_request() is True
+    assert circuit.record_failure("connection reset") is False
     assert circuit.allow_request() is True
 
 


### PR DESCRIPTION
## Summary

Closes #222.

When the enrichment LLM returns a definitive quota exhaustion error, repeated stores previously retried summarization and classification independently. This adds a shared, fail-soft cooldown circuit across both enrichment paths.

## Changes

- Open the circuit on `insufficient_quota`/quota errors for a configurable `ENRICHMENT_CIRCUIT_COOLDOWN_SECONDS` period (default 300 seconds).
- Skip additional upstream LLM requests while the circuit is open, while preserving deterministic fallback behavior.
- Allow one probe after cooldown and close the circuit after a successful response.
- Expose circuit-open skips and recoveries through the enrichment status response.
- Add focused regression tests for open, skip, non-quota, and recovery behavior.

The default remains backward compatible for successful requests and non-quota transient failures. The change only suppresses further enrichment requests after a quota-related failure; stores remain fail-soft.

## Verification

- `python -m compileall -q automem app.py` — passed.
- Direct circuit regression assertions — passed.
- `python -m black --check app.py automem tests/test_enrichment_circuit.py` — passed.
- `python -m flake8 app.py automem --count --select=E9,F63,F7,F82 --show-source --statistics` — passed.
- `python -m pytest -q tests/test_enrichment_circuit.py` — not runnable in this environment: pytest collection resolves an unrelated installed `tests` package (`D:\project\tscodex\connectonion-pr\tests`) and cannot import this checkout's `tests.support`; no test assertion was executed.
- Full `make test` and Docker integration tests were not run because the focused pytest collection issue must be resolved before they can provide meaningful results.