### PR TITLE
feat(embedding): support Voyage store and recall models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ QDRANT_COLLECTION=memories
 EMBEDDING_PROVIDER=auto
 VOYAGE_API_KEY=
 VOYAGE_MODEL=voyage-4
+# Optional Voyage 4 mixed-model routing; VOYAGE_MODEL remains the fallback.
+# VOYAGE_STORE_MODEL=voyage-4-lite
+# VOYAGE_RECALL_MODEL=voyage-4-large
 VECTOR_SIZE=1024  # voyage-4 and Ollama bge-m3; must match your selected provider
 PORT=8001
 # OpenAI is the automatic API fallback when VOYAGE_API_KEY is unset.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,30 @@
 # Repository Guidelines
 
+## Astra 协作约定
+
+- 以用户当前目标和本轮明确约束为准。任务要求实施时，完成实际修改与必要验证，不停在计划、建议或“是否继续”。普通实现选择自行决定；只有缺失信息会实质改变结果或操作超出授权时才询问，并先完成不依赖答案的工作。
+- 用户指令优先于本地 skills 的工作流建议。只读取与当前任务直接相关的文件和技能；不因关键词命中就串联整套技能、生成流程工件或增加审批。
+- 保留既有业务规则、数据所有权、用户改动和明确的工具限制。只改当前目标需要的内容，不顺手重构、升级依赖、搬目录或扩展产品范围。
+
+## 拒绝过度防御性编程
+
+- 直接使用已有输入、文件、依赖和运行环境，不重复做环境、权限、目录或文件存在性预检查。
+- 不为假想故障添加重复参数验证、大量极端输入分支、宽泛 `try/catch`、默认值兜底、静默失败或伪造成功。契约不满足时暴露具体错误。
+- 不主动新增重试、退避、熔断、降级、备用实现、兼容层、自动备份、回滚、迁移或恢复机制。
+- 不主动添加 SHA、MD5、签名、文件哈希、完整性校验、CI/CD、发布门禁、安全扫描、许可证审计、复杂日志、监控、遥测或诊断框架。
+- 不为未来需求预建插件系统、通用框架或抽象层，不为小改动铺设大量单元测试、回归测试、故障注入或性能基准。
+- 只在缺少检查会立即阻止核心功能、造成明显数据损坏或掩盖真实错误时保留最小必要检查。现有鉴权、真实业务校验和数据保护功能继续遵守其契约；本规则不授权删除这些功能。
+- 例外必须来自用户明确要求，或与本次改动直接相关的既有产品契约。旧文档中泛化的“每次全量检查”“必须先审批”“自动完善”不构成额外任务。
+
+## 验证与交付
+
+- 选择能证明本次行为的最小验证：文档或提示词改动检查内容和 diff；代码改动运行相关构建、现有定向测试或核心流程冒烟。低影响、可逆改动不新增仅复述实现的测试。
+- 必要检查通过即交付；只有新改动、失败或具体未解决疑点才扩大或重复验证。不要为了收尾重跑无关全量测试、打包、实机流程或基准。
+- 错误如实报告。区分实际运行通过、静态检查、未运行与真实环境验证；历史测试数量不能当作本次证据。
+- 仅在任务需要时使用子代理；不强制委派、切换模型或修改推理档位，遵守当前会话设置与工具权限。
+- 按当前授权和项目约定执行 Git 操作，只提交本任务文件；不要为清空工作区而夹带其他改动，不强推或丢弃用户内容。没有远端时报告，不擅自创建远端。
+- 用简明中文交代实际修改、验证结果和已知问题。只有需求、接口或已验证事实改变时同步相关文档，不追加与交付无关的报告。
+
 ## Project Structure & Modules
 
 - `automem/`: Core package. Notable dirs: `api/` (Flask blueprints), `utils/`, `stores/`, `config.py`.
@@ -26,7 +51,7 @@
 
 - Python with type hints. Indent 4 spaces; line length 100 (Black).
 - Tools: Black, Isort (profile=black), Flake8; pre-commit hooks available.
-- Run `pre-commit install` and `make fmt && make lint` before committing.
+- Reuse existing formatting/lint tools for affected Python changes; do not install hooks as part of unrelated work.
 - Naming: modules/functions `snake_case`, classes `PascalCase`, constants `UPPER_SNAKE_CASE`.
 
 ## Testing Guidelines
@@ -34,50 +59,13 @@
 - Framework: Pytest. Place tests in `tests/` named `test_*.py`.
 - Unit tests: `make test`.
 - Integration: `make test-integration` (requires Docker). See `docs/TESTING.md` for env flags and live testing options.
-- Add/adjust tests for new endpoints, stores, or utils; prefer fixtures over globals.
+- Run the directly affected tests. Add one only when needed to prove a new behavior or reproduce the defect; prefer fixtures over globals.
 
 ## Benchmarking
 
-The benchmark system uses **snapshot-based evaluation**: ingest once, eval many times from the same snapshot. This keeps runs deterministic and fast.
+Run benchmarks only for requested retrieval/scoring/performance work. Prefer the existing snapshot-based `make bench-eval BENCH=locomo-mini` for a bounded before/after comparison; use a full benchmark only when required to answer the task. Do not attach paid judge runs or full benchmark tiers to ordinary commits.
 
-**Source of truth**: `benchmarks/EXPERIMENT_LOG.md` — contains current baselines, all experiment results, and the tiered benchmark table.
-
-`automem` is the canonical home for official benchmark harnesses and published benchmark numbers. Use the separate `automem-evals` repo for exploratory ruleset work, seeded corpora, scenario authoring, cross-agent or cross-backend comparisons, and bulky timestamped result artifacts. External eval repos should treat AutoMem as a black-box service and follow `docs/EVALS_CONTRACT.md`.
-
-### Tiered System
-
-| Tier | Benchmark | Command | Runtime | Cost | When to use |
-|------|-----------|---------|---------|------|-------------|
-| 0 | Unit tests | `make test` | 30s | free | Every change |
-| 1 | LoCoMo-mini (2 convos, 304 Qs) | `make bench-eval BENCH=locomo-mini` | 2-3 min | free / ~$0.20 with judge | Rapid iteration |
-| 2 | LoCoMo-full (10 convos, 1986 Qs) | `make bench-eval BENCH=locomo` | 5-10 min | free / ~$1-3 with judge | Before merge |
-| 3 | LongMemEval-mini (20 Qs) | `make bench-mini-longmemeval` | 15 min | ~$1 | Scoring/entity changes |
-| 4 | LongMemEval-full (500 Qs) | `make test-longmemeval` | 1-2 hr | ~$10 | Milestones only |
-
-### Key Commands
-
-- `make bench-eval BENCH=locomo-mini CONFIG=baseline` — eval from snapshot (~2 min).
-- `make bench-compare BENCH=locomo CONFIG=<name> BASELINE=baseline` — A/B compare two configs.
-- `make bench-compare-branch BRANCH=<branch>` — compare a branch against baseline.
-- `make bench-ingest BENCH=locomo` — ingest + snapshot (run once per embedding change).
-- `make bench-health` — recall health check (score distribution, entity quality, latency).
-
-### Workflow for Recall/Retrieval Changes
-
-1. Run `make bench-eval BENCH=locomo-mini` on `main` to confirm the current baseline.
-2. Create a feature branch and implement changes.
-3. Run the same eval on the branch.
-4. Record both results as a new row in `benchmarks/EXPERIMENT_LOG.md`.
-5. Promote to `make bench-eval BENCH=locomo` (full) before merge.
-
-### Directory Layout
-
-- `benchmarks/EXPERIMENT_LOG.md` — results table and experiment metadata (committed).
-- `benchmarks/baselines/` — baseline result JSONs (small files committed, large ones gitignored).
-- `benchmarks/snapshots/` — Qdrant/FalkorDB snapshot data (gitignored, regenerate with `make bench-ingest`).
-- `benchmarks/results/` — per-run result JSONs (gitignored).
-- `scripts/bench/` — shell and Python scripts driving ingest, eval, compare, and health checks; see [scripts/README.md](scripts/README.md).
-- `tests/benchmarks/` — legacy benchmark harnesses (LoCoMo, LongMemEval) and historical result markdown files.
+`benchmarks/EXPERIMENT_LOG.md` stores official results. `automem-evals` holds exploratory corpora and bulky results; external evaluations follow `docs/EVALS_CONTRACT.md`. Keep snapshots and generated results in existing ignored paths. Record only measurements actually run.
 
 ## Commit & Pull Requests
 
@@ -86,7 +74,7 @@ The benchmark system uses **snapshot-based evaluation**: ingest once, eval many 
 - Use Conventional Commit types: `feat`, `fix`, `docs`, `refactor`, `test`, `ci`, `build`, `chore`, `perf`, `revert` (e.g., `feat(api): add /analyze endpoint`).
 - For public API changes, use `feat(api): ...` unless the change is strictly a bug fix with no new public surface. For docs-only changes, use `docs: ...`; for release automation, use `ci(release): ...` or `chore(release): ...`.
 - PRs must include: clear description and scope, linked issues, test plan/output, and notes on API or config changes. Update relevant docs under `docs/`.
-- CI must pass; formatting/lint clean.
+- Observe existing checks when a PR is requested; do not add CI or make unrelated workflows a gate for a local documentation change.
 
 ## Security & Configuration
 
@@ -95,4 +83,4 @@ The benchmark system uses **snapshot-based evaluation**: ingest once, eval many 
 
 ## Agent Memory Protocol
 
-Follow rules in `.cursor/rules/automem.mdc` for memory operations.
+Consult `.cursor/rules/automem.mdc` only when the user requests AutoMem memory operations. Ordinary repository work does not authorize writing agent memories.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -466,6 +466,8 @@ Admin operations additionally require `X-Admin-Token: <admin_token>` header.
 | `EMBEDDING_MODEL`   | OpenAI embedding model                | `text-embedding-3-small` |
 | `VOYAGE_API_KEY`    | Voyage API key (Voyage provider)      | _unset_    |
 | `VOYAGE_MODEL`      | Voyage model (Voyage provider)        | `voyage-4` |
+| `VOYAGE_STORE_MODEL`| Optional Voyage model for stored memories | `VOYAGE_MODEL` |
+| `VOYAGE_RECALL_MODEL`| Optional Voyage model for recall queries | `VOYAGE_MODEL` |
 | `OPENAI_API_KEY`    | API key (OpenAI or compatible provider) | _unset_  |
 | `OPENAI_BASE_URL`   | Custom endpoint for OpenAI-compatible providers | _unset_ |
 | `OLLAMA_BASE_URL`   | Ollama endpoint for intentional local/self-hosted use | `http://localhost:11434` |
@@ -473,7 +475,7 @@ Admin operations additionally require `X-Admin-Token: <admin_token>` header.
 
 👉 **New to Qdrant?** See the [Qdrant Setup Guide](docs/QDRANT_SETUP.md) for setup options (self-hosted on Railway or Qdrant Cloud).
 
-> **Upgrade safety:** `VECTOR_SIZE_AUTODETECT=true` (default) adopts an existing collection dimension to avoid a startup mismatch. It does not migrate vectors: changing embedding provider or model requires recreating the collection and re-embedding, even when both models are 1024d.
+> **Upgrade safety:** `VECTOR_SIZE_AUTODETECT=true` (default) adopts an existing collection dimension to avoid a startup mismatch. It does not migrate vectors: changing embedding provider or model requires recreating the collection and re-embedding, even when both models are 1024d. The intentional exception is mixed-model routing within the Voyage 4 family via `VOYAGE_STORE_MODEL` and `VOYAGE_RECALL_MODEL`, whose vectors share an embedding space.
 >
 > The recommended setup is Voyage (`voyage-4`) at 1024d. If Voyage is unavailable, an OpenAI-compatible provider is the API fallback. Use FastEmbed only for intentional local/self-hosted deployments; its 1024d cloud fallback can add roughly 4 GB RSS and materially increase hosting cost.
 

--- a/app.py
+++ b/app.py
@@ -520,6 +520,7 @@ _coerce_importance = _app_helpers.coerce_importance
 _coerce_embedding = _app_helpers.coerce_embedding
 _generate_placeholder_embedding = _app_helpers.generate_placeholder_embedding
 _generate_real_embedding = _app_helpers.generate_real_embedding
+_generate_real_recall_embedding = _app_helpers.generate_real_recall_embedding
 _generate_real_embeddings_batch = _app_helpers.generate_real_embeddings_batch
 _fetch_relations = _app_helpers.fetch_relations
 

--- a/automem/app_helper_bindings.py
+++ b/automem/app_helper_bindings.py
@@ -11,6 +11,7 @@ class AppHelperBindings:
     coerce_embedding: Callable[[Any], Optional[List[float]]]
     generate_placeholder_embedding: Callable[[str], List[float]]
     generate_real_embedding: Callable[[str], List[float]]
+    generate_real_recall_embedding: Callable[[str], List[float]]
     generate_real_embeddings_batch: Callable[..., List[List[float]]]
     fetch_relations: Callable[[Any, str], List[Dict[str, Any]]]
 
@@ -62,6 +63,16 @@ def create_app_helper_runtime(
             placeholder_embedding=get_generate_placeholder_embedding_fn(),
         )
 
+    def generate_real_recall_embedding(content: str) -> List[float]:
+        return generate_real_embedding_value_fn(
+            content,
+            init_embedding_provider=init_embedding_provider_fn,
+            state=get_state_fn(),
+            logger=logger,
+            placeholder_embedding=get_generate_placeholder_embedding_fn(),
+            for_recall=True,
+        )
+
     def generate_real_embeddings_batch(
         contents: List[str], *, allow_placeholder_fallback: bool = True
     ) -> List[List[float]]:
@@ -90,6 +101,7 @@ def create_app_helper_runtime(
         coerce_embedding=coerce_embedding,
         generate_placeholder_embedding=generate_placeholder_embedding,
         generate_real_embedding=generate_real_embedding,
+        generate_real_recall_embedding=generate_real_recall_embedding,
         generate_real_embeddings_batch=generate_real_embeddings_batch,
         fetch_relations=fetch_relations,
     )

--- a/automem/embedding/provider.py
+++ b/automem/embedding/provider.py
@@ -26,6 +26,14 @@ class EmbeddingProvider(ABC):
         """
         pass
 
+    def embed_for_store(self, text: str) -> List[float]:
+        """Generate a document embedding for storage."""
+        return self.generate_embedding(text)
+
+    def embed_for_recall(self, text: str) -> List[float]:
+        """Generate a query embedding for recall."""
+        return self.generate_embedding(text)
+
     @abstractmethod
     def generate_embeddings_batch(self, texts: List[str]) -> List[List[float]]:
         """Generate embeddings for multiple texts in a single batch.

--- a/automem/embedding/provider_init.py
+++ b/automem/embedding/provider_init.py
@@ -100,8 +100,14 @@ def init_embedding_provider(
             from automem.embedding.voyage import VoyageEmbeddingProvider
 
             voyage_model = os.getenv("VOYAGE_MODEL", "voyage-4")
+            voyage_store_model = os.getenv("VOYAGE_STORE_MODEL") or None
+            voyage_recall_model = os.getenv("VOYAGE_RECALL_MODEL") or None
             state.embedding_provider = VoyageEmbeddingProvider(
-                api_key=api_key, model=voyage_model, dimension=vector_size
+                api_key=api_key,
+                model=voyage_model,
+                store_model=voyage_store_model,
+                recall_model=voyage_recall_model,
+                dimension=vector_size,
             )
             logger.info("Embedding provider: %s", state.embedding_provider.provider_name())
             return
@@ -178,8 +184,14 @@ def init_embedding_provider(
                 from automem.embedding.voyage import VoyageEmbeddingProvider
 
                 voyage_model = os.getenv("VOYAGE_MODEL", "voyage-4")
+                voyage_store_model = os.getenv("VOYAGE_STORE_MODEL") or None
+                voyage_recall_model = os.getenv("VOYAGE_RECALL_MODEL") or None
                 state.embedding_provider = VoyageEmbeddingProvider(
-                    api_key=voyage_key, model=voyage_model, dimension=vector_size
+                    api_key=voyage_key,
+                    model=voyage_model,
+                    store_model=voyage_store_model,
+                    recall_model=voyage_recall_model,
+                    dimension=vector_size,
                 )
                 logger.info(
                     "Embedding provider (auto-selected): %s",

--- a/automem/embedding/runtime_helpers.py
+++ b/automem/embedding/runtime_helpers.py
@@ -62,6 +62,7 @@ def generate_real_embedding(
     state: Any,
     logger: Any,
     placeholder_embedding: Callable[[str], List[float]],
+    for_recall: bool = False,
 ) -> List[float]:
     """Generate an embedding using the configured provider."""
     init_embedding_provider()
@@ -72,7 +73,12 @@ def generate_real_embedding(
 
     expected_dim = state.effective_vector_size
     try:
-        embedding = state.embedding_provider.generate_embedding(content)
+        embed = (
+            state.embedding_provider.embed_for_recall
+            if for_recall
+            else state.embedding_provider.embed_for_store
+        )
+        embedding = embed(content)
         if not isinstance(embedding, list) or len(embedding) != expected_dim:
             logger.warning(
                 "Provider %s returned %s dims (expected %d); falling back to placeholder",

--- a/automem/embedding/voyage.py
+++ b/automem/embedding/voyage.py
@@ -32,6 +32,8 @@ class VoyageEmbeddingProvider(EmbeddingProvider):
         self,
         api_key: Optional[str] = None,
         model: str = "voyage-4",
+        store_model: Optional[str] = None,
+        recall_model: Optional[str] = None,
         dimension: int = 1024,
         timeout: float = 30.0,
         max_retries: int = 2,
@@ -42,6 +44,8 @@ class VoyageEmbeddingProvider(EmbeddingProvider):
         Args:
             api_key: Voyage API key (falls back to VOYAGE_API_KEY env var)
             model: Voyage embedding model to use (voyage-4, voyage-4-large, voyage-4-lite)
+            store_model: Optional model override for stored memory embeddings
+            recall_model: Optional model override for recall query embeddings
             dimension: Number of dimensions for embeddings (256, 512, 1024, 2048)
             timeout: Request timeout in seconds (default 30)
             max_retries: Maximum number of retries (default 2)
@@ -60,6 +64,8 @@ class VoyageEmbeddingProvider(EmbeddingProvider):
             )
 
         self.model = model
+        self._store_model = store_model or model
+        self._recall_model = recall_model or model
         self._dimension = dimension
         self.timeout = timeout
         self.max_retries = max_retries
@@ -74,21 +80,28 @@ class VoyageEmbeddingProvider(EmbeddingProvider):
         )
 
         logger.info(
-            "Voyage embedding provider initialized (model=%s, dimensions=%d, timeout=%.1fs, retries=%d)",
+            "Voyage embedding provider initialized "
+            "(model=%s, store_model=%s, recall_model=%s, dimensions=%d, timeout=%.1fs, retries=%d)",
             model,
+            self._store_model,
+            self._recall_model,
             dimension,
             timeout,
             max_retries,
         )
 
     def _make_request(
-        self, texts: List[str], input_type: Optional[str] = None
+        self,
+        texts: List[str],
+        input_type: Optional[str] = None,
+        model_override: Optional[str] = None,
     ) -> List[List[float]]:
         """Make embedding request to Voyage API.
 
         Args:
             texts: List of texts to embed
             input_type: Optional input type ("query" or "document")
+            model_override: Optional model to use for this request
 
         Returns:
             List of embedding vectors
@@ -96,9 +109,10 @@ class VoyageEmbeddingProvider(EmbeddingProvider):
         Raises:
             Exception: If API call fails after retries
         """
+        request_model = model_override or self._store_model
         payload = {
             "input": texts,
-            "model": self.model,
+            "model": request_model,
             "output_dimension": self._dimension,
         }
 
@@ -116,10 +130,13 @@ class VoyageEmbeddingProvider(EmbeddingProvider):
 
                 # Defensive validation of API response structure
                 if not isinstance(data, dict):
-                    raise ValueError(f"Voyage API response is not an object (model={self.model})")
+                    raise ValueError(
+                        f"Voyage API response is not an object (model={request_model})"
+                    )
                 if "error" in data:
                     raise ValueError(
-                        f"Voyage API returned error payload (model={self.model}, status={response.status_code}): "
+                        f"Voyage API returned error payload "
+                        f"(model={request_model}, status={response.status_code}): "
                         f"{data['error']}"
                     )
                 if "data" not in data:
@@ -154,7 +171,7 @@ class VoyageEmbeddingProvider(EmbeddingProvider):
                             f"Voyage embedding length {len(emb)} "
                             f"!= configured dimension "
                             f"{self._dimension} "
-                            f"at index {i} (model={self.model})"
+                            f"at index {i} (model={request_model})"
                         )
 
                 # Validate count matches input
@@ -210,9 +227,17 @@ class VoyageEmbeddingProvider(EmbeddingProvider):
         Raises:
             Exception: If API call fails
         """
-        embeddings = self._make_request([text])
+        embeddings = self._make_request([text], model_override=self._store_model)
         logger.debug("Generated Voyage embedding for text (length: %d)", len(text))
         return embeddings[0]
+
+    def embed_for_store(self, text: str) -> List[float]:
+        """Embed a memory document with the configured store model."""
+        return self._make_request([text], model_override=self._store_model)[0]
+
+    def embed_for_recall(self, text: str) -> List[float]:
+        """Embed a recall query with the configured recall model."""
+        return self._make_request([text], model_override=self._recall_model)[0]
 
     def generate_embeddings_batch(self, texts: List[str]) -> List[List[float]]:
         """Generate embeddings for multiple texts in one API call.
@@ -235,7 +260,7 @@ class VoyageEmbeddingProvider(EmbeddingProvider):
 
         for i in range(0, len(texts), batch_size):
             batch = texts[i : i + batch_size]
-            embeddings = self._make_request(batch)
+            embeddings = self._make_request(batch, model_override=self._store_model)
             all_embeddings.extend(embeddings)
 
         logger.info(

--- a/automem/runtime_wiring.py
+++ b/automem/runtime_wiring.py
@@ -20,7 +20,7 @@ def wire_recall_and_blueprints(
         fetch_relations=module._fetch_relations,
         extract_keywords=module._extract_keywords,
         coerce_embedding=module._coerce_embedding,
-        generate_real_embedding=module._generate_real_embedding,
+        generate_real_embedding=module._generate_real_recall_embedding,
         logger=module.logger,
         collection_name=module.COLLECTION_NAME,
     )

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -56,6 +56,8 @@ AutoMem supports five embedding backends with automatic fallback.
 | `EMBEDDING_PROVIDER` | Embedding backend selection | `auto` | `auto`, `voyage`, `openai`, `local`, `ollama`, `placeholder` |
 | `VOYAGE_API_KEY` | Voyage API key (for Voyage provider) | - | `pa-...` |
 | `VOYAGE_MODEL` | Voyage embedding model | `voyage-4` | `voyage-4`, `voyage-4-large`, `voyage-4-lite` |
+| `VOYAGE_STORE_MODEL` | Optional Voyage model for stored memory embeddings | `VOYAGE_MODEL` | `voyage-4`, `voyage-4-large`, `voyage-4-lite` |
+| `VOYAGE_RECALL_MODEL` | Optional Voyage model for recall query embeddings | `VOYAGE_MODEL` | `voyage-4`, `voyage-4-large`, `voyage-4-lite` |
 | `OPENAI_API_KEY` | API key (OpenAI or compatible provider) | - | `sk-proj-...` |
 | `OPENAI_BASE_URL` | Custom base URL for OpenAI-compatible APIs (embeddings and classification/enrichment LLM calls) | - | `https://openrouter.ai/api/v1` |
 | `OLLAMA_BASE_URL` | Ollama API base URL | `http://localhost:11434` | `http://localhost:11434` |
@@ -113,9 +115,23 @@ Set `OLLAMA_BASE_URL` when the Ollama server is not at `http://localhost:11434`.
 **Voyage Details:**
 - Requires `VOYAGE_API_KEY`
 - Optional model override via `VOYAGE_MODEL` (default `voyage-4`)
+- Optional mixed-model routing via `VOYAGE_STORE_MODEL` and `VOYAGE_RECALL_MODEL`; either setting falls back to `VOYAGE_MODEL` when unset
 - Voyage 4 family supports output dimensions `256`, `512`, `1024`, or `2048`
 - Set `VECTOR_SIZE` to one of the supported Voyage dimensions
 - Voyage's free tier covers typical AutoMem usage. See the maintained [Voyage pricing page](https://docs.voyageai.com/docs/pricing) for current limits and rates.
+
+To opt into cheaper writes and higher-quality query embeddings within Voyage 4's shared
+embedding space:
+
+```bash
+VOYAGE_MODEL=voyage-4
+VOYAGE_STORE_MODEL=voyage-4-lite
+VOYAGE_RECALL_MODEL=voyage-4-large
+VECTOR_SIZE=1024
+```
+
+The single-model configuration remains the default. Benchmark recall quality for your own
+dataset before adopting a mixed-model configuration in production.
 
 **OpenAI-Compatible Providers (OpenRouter, LiteLLM, Azure, vLLM, etc.):**
 

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -2,7 +2,7 @@
 
 This document provides step-by-step instructions for migrating between different AutoMem configurations.
 
-**Heads up for existing deployments:** New installs default to **1024d** with Voyage (`voyage-4`). If you are only updating AutoMem and keeping the same embedding provider and model, `VECTOR_SIZE_AUTODETECT=true` (the default) can adopt an existing collection dimension to avoid a startup mismatch. It does **not** migrate embeddings. Any provider or model change requires backing up, recreating the Qdrant collection, and fully re-embedding every memory—even when both models output 1024 dimensions. To explicitly pin a dimension, set `VECTOR_SIZE=<your-dimension>`; set `VECTOR_SIZE_AUTODETECT=false` to fail on mismatch.
+**Heads up for existing deployments:** New installs default to **1024d** with Voyage (`voyage-4`). If you are only updating AutoMem and keeping the same embedding provider and model, `VECTOR_SIZE_AUTODETECT=true` (the default) can adopt an existing collection dimension to avoid a startup mismatch. It does **not** migrate embeddings. Any provider or model change requires backing up, recreating the Qdrant collection, and fully re-embedding every memory—even when both models output 1024 dimensions. The intentional exception is mixed-model routing within the Voyage 4 family via `VOYAGE_STORE_MODEL` and `VOYAGE_RECALL_MODEL`, whose vectors share an embedding space. To explicitly pin a dimension, set `VECTOR_SIZE=<your-dimension>`; set `VECTOR_SIZE_AUTODETECT=false` to fail on mismatch.
 
 ## Table of Contents
 

--- a/tests/test_embedding_providers.py
+++ b/tests/test_embedding_providers.py
@@ -548,6 +548,8 @@ def test_provider_selection_explicit_voyage(monkeypatch):
         mock_voyage_class.assert_called_once_with(
             api_key="voyage-key",
             model="voyage-4",
+            store_model=None,
+            recall_model=None,
             dimension=1024,
         )
 
@@ -579,7 +581,13 @@ def test_provider_selection_auto_prefers_voyage(monkeypatch):
             app.init_embedding_provider()
 
             assert app.state.embedding_provider is mock_provider
-            mock_voyage_class.assert_called_once()
+            mock_voyage_class.assert_called_once_with(
+                api_key="voyage-key",
+                model="voyage-4",
+                store_model=None,
+                recall_model=None,
+                dimension=1024,
+            )
             mock_openai_class.assert_not_called()
 
 

--- a/tests/test_voyage_mixed_model.py
+++ b/tests/test_voyage_mixed_model.py
@@ -1,0 +1,179 @@
+"""Tests for Voyage 4 mixed-model store and recall embeddings."""
+
+import logging
+import os
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from automem.embedding.provider import EmbeddingProvider
+from automem.embedding.provider_init import init_embedding_provider
+from automem.embedding.runtime_helpers import generate_real_embedding
+from automem.embedding.voyage import VoyageEmbeddingProvider
+from automem.runtime_wiring import wire_recall_and_blueprints
+
+
+class _SingleModelProvider(EmbeddingProvider):
+    def __init__(self) -> None:
+        self.calls = []
+
+    def generate_embedding(self, text: str) -> list[float]:
+        self.calls.append(text)
+        return [1.0, 2.0]
+
+    def generate_embeddings_batch(self, texts: list[str]) -> list[list[float]]:
+        return [self.generate_embedding(text) for text in texts]
+
+    def dimension(self) -> int:
+        return 2
+
+    def provider_name(self) -> str:
+        return "single-model"
+
+
+def test_base_provider_uses_single_model_for_store_and_recall() -> None:
+    provider = _SingleModelProvider()
+
+    assert provider.embed_for_store("memory") == [1.0, 2.0]
+    assert provider.embed_for_recall("query") == [1.0, 2.0]
+    assert provider.calls == ["memory", "query"]
+
+
+@patch("automem.embedding.voyage.httpx.Client")
+def test_voyage_routes_store_recall_and_batch_to_configured_models(
+    mock_httpx_client_class: Mock,
+) -> None:
+    mock_client = Mock()
+    mock_httpx_client_class.return_value = mock_client
+    store_vector = [0.1] * 256
+    recall_vector = [0.2] * 256
+    legacy_vector = [0.3] * 256
+    batch_vectors = [[0.4] * 256, [0.5] * 256]
+
+    response = Mock(status_code=200)
+    response.raise_for_status.return_value = None
+    response.json.side_effect = [
+        {"data": [{"embedding": store_vector}]},
+        {"data": [{"embedding": recall_vector}]},
+        {"data": [{"embedding": legacy_vector}]},
+        {"data": [{"embedding": vector} for vector in batch_vectors]},
+    ]
+    mock_client.post.return_value = response
+
+    provider = VoyageEmbeddingProvider(
+        api_key="voyage-test-key",
+        model="voyage-4",
+        store_model="voyage-4-lite",
+        recall_model="voyage-4-large",
+        dimension=256,
+    )
+
+    assert provider.embed_for_store("memory") == store_vector
+    assert provider.embed_for_recall("query") == recall_vector
+    assert provider.generate_embedding("legacy store") == legacy_vector
+    assert provider.generate_embeddings_batch(["one", "two"]) == batch_vectors
+    assert [call.kwargs["json"]["model"] for call in mock_client.post.call_args_list] == [
+        "voyage-4-lite",
+        "voyage-4-large",
+        "voyage-4-lite",
+        "voyage-4-lite",
+    ]
+    assert provider.provider_name() == "voyage:voyage-4"
+
+
+@patch("automem.embedding.voyage.httpx.Client")
+def test_voyage_split_models_independently_fall_back_to_legacy_model(
+    mock_httpx_client_class: Mock,
+) -> None:
+    cases = [
+        (None, None, "voyage-4", "voyage-4"),
+        ("voyage-4-lite", None, "voyage-4-lite", "voyage-4"),
+        (None, "voyage-4-large", "voyage-4", "voyage-4-large"),
+    ]
+
+    for store_model, recall_model, expected_store, expected_recall in cases:
+        provider = VoyageEmbeddingProvider(
+            api_key="voyage-test-key",
+            model="voyage-4",
+            store_model=store_model,
+            recall_model=recall_model,
+            dimension=1024,
+        )
+
+        assert provider._store_model == expected_store
+        assert provider._recall_model == expected_recall
+
+
+@patch.dict(
+    os.environ,
+    {
+        "EMBEDDING_PROVIDER": "voyage",
+        "VOYAGE_API_KEY": "voyage-key",
+        "VOYAGE_MODEL": "voyage-4",
+        "VOYAGE_STORE_MODEL": "voyage-4-lite",
+        "VOYAGE_RECALL_MODEL": "voyage-4-large",
+    },
+    clear=True,
+)
+@patch("automem.embedding.voyage.VoyageEmbeddingProvider")
+def test_provider_init_passes_voyage_store_and_recall_models(mock_voyage_class: Mock) -> None:
+    state = SimpleNamespace(
+        embedding_provider=None,
+        qdrant=None,
+        effective_vector_size=1024,
+    )
+    mock_voyage_class.return_value.provider_name.return_value = "voyage:voyage-4"
+
+    init_embedding_provider(
+        state=state,
+        logger=Mock(),
+        vector_size_config=1024,
+        embedding_model="text-embedding-3-small",
+    )
+
+    mock_voyage_class.assert_called_once_with(
+        api_key="voyage-key",
+        model="voyage-4",
+        store_model="voyage-4-lite",
+        recall_model="voyage-4-large",
+        dimension=1024,
+    )
+
+
+def test_runtime_routes_store_and_recall_to_explicit_provider_methods() -> None:
+    class Provider:
+        def embed_for_store(self, text: str) -> list[float]:
+            assert text == "text"
+            return [1.0, 1.0]
+
+        def embed_for_recall(self, text: str) -> list[float]:
+            assert text == "text"
+            return [2.0, 2.0]
+
+        def provider_name(self) -> str:
+            return "split-model"
+
+    state = SimpleNamespace(embedding_provider=Provider(), effective_vector_size=2)
+    kwargs = {
+        "init_embedding_provider": lambda: None,
+        "state": state,
+        "logger": logging.getLogger("test_voyage_mixed_model"),
+        "placeholder_embedding": lambda _text: [0.0, 0.0],
+    }
+
+    assert generate_real_embedding("text", **kwargs) == [1.0, 1.0]
+    assert generate_real_embedding("text", for_recall=True, **kwargs) == [2.0, 2.0]
+
+
+def test_recall_wiring_requests_the_recall_embedding_path() -> None:
+    module = Mock()
+    module._generate_real_recall_embedding.return_value = [2.0, 2.0]
+    configured = {}
+
+    wire_recall_and_blueprints(
+        module=module,
+        configure_recall_helpers_fn=lambda **kwargs: configured.update(kwargs),
+        register_blueprints_fn=lambda **_kwargs: None,
+    )
+
+    assert configured["generate_real_embedding"]("query") == [2.0, 2.0]
+    module._generate_real_recall_embedding.assert_called_once_with("query")


### PR DESCRIPTION
## Summary

- add explicit store and recall embedding hooks while preserving single-model provider behavior
- let Voyage route writes and batch embeddings through `VOYAGE_STORE_MODEL` and recall queries through `VOYAGE_RECALL_MODEL`
- retain `VOYAGE_MODEL` as the fallback for either unset override, so existing deployments are unchanged
- document the opt-in mixed-model configuration and migration exception for Voyage 4's shared embedding space

## Scope

Implements the configuration and runtime-routing phases described in #93. This does not change AutoMem's default model configuration or claim benchmark validation; the LoCoMo matrix in the issue remains follow-up work before mixed-model routing becomes a default.

## Validation

- `python -m pytest -q tests/test_voyage_mixed_model.py tests/test_api_endpoints.py` — 201 passed, 1 skipped
- `python -m pytest -q tests/test_voyage_mixed_model.py tests/test_embedding_providers.py -k "not test_fastembed_model_caching"` — 51 passed, 1 deselected
- `black --check .` and `isort --check-only .`
- `flake8 .`
- `npm test` in `mcp-sse-server` — 22 passed, 3 live-stack parity tests skipped

A full Windows unit run reached 654 passed and 1 skipped; its remaining 15 failures are existing platform-only assumptions around GBK decoding of shell scripts, GNU make availability, and `signal.SIGALRM`. No live Voyage/LoCoMo benchmark was run because no Voyage credentials are available locally, so the feature remains opt-in.

Refs #93