### PR TITLE
ci(release): pin release-please target-branch to main

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,10 @@
 #    - Updates CHANGELOG.md
 #    - Creates a GitHub Release with tag (v0.9.3, etc.)
 #
+# target-branch is pinned to main on purpose: the GitHub default branch is
+# develop, and release-please-action otherwise opens the Release PR against
+# develop. Merging that PR never tags, because this workflow only runs on main.
+#
 # Docs dispatch is handled separately by docs-dispatch.yml on main pushes.
 #
 # Commit message format:
@@ -41,4 +45,5 @@ jobs:
         id: release
         with:
           release-type: python
+          target-branch: main
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ The benchmark system uses **snapshot-based evaluation**: ingest once, eval many 
 
 ## Commit & Pull Requests
 
-- Feature PRs target `develop` (repo default). Promote `develop` to `main` with a validated release merge; release-please and GHCR `:stable` then run on `main`. Do not open feature work onto `main`.
+- Feature PRs target `develop` (repo default). Promote `develop` to `main` with a validated release merge; release-please and GHCR `:stable` then run on `main`. Do not open feature work onto `main`. Release Please must set `target-branch: main` — the action otherwise follows the GitHub default branch (`develop`) and never tags.
 - PR titles must use Conventional Commit format because squash merges use the PR title as the release commit title. Do not prefix titles with `[codex]`, `[claude]`, `[copilot]`, `[wip]`, or similar labels; put agent/status context in the PR body.
 - Use Conventional Commit types: `feat`, `fix`, `docs`, `refactor`, `test`, `ci`, `build`, `chore`, `perf`, `revert` (e.g., `feat(api): add /analyze endpoint`).
 - For public API changes, use `feat(api): ...` unless the change is strictly a bug fix with no new public surface. For docs-only changes, use `docs: ...`; for release automation, use `ci(release): ...` or `chore(release): ...`.


### PR DESCRIPTION
## Summary
- Pin `release-please-action` to `target-branch: main` so it stops following the GitHub default branch (`develop`).
- The 0.16.2 attempt opened [#234](https://github.com/verygoodplugins/automem/pull/234) against develop and closed the real main release PR [#220](https://github.com/verygoodplugins/automem/pull/220). Because this workflow only runs on `main`, merging #234 never created the `v0.16.2` tag or GHCR `:stable` images.

## Test plan
- [ ] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-please.yml'))"`)
- [ ] After merge + promote to `main`, the next Release Please run opens a PR against `main` (not `develop`)
- [ ] Completing that (or a manual `gh release create v0.16.2`) publishes the GitHub release and triggers Docker Build for `:stable`